### PR TITLE
fix: off-by-1 date error

### DIFF
--- a/frontend/src/components/adapters/DateInput.js
+++ b/frontend/src/components/adapters/DateInput.js
@@ -33,7 +33,14 @@ export const DateInput = ({
 
   // Handle the change event to match form expectations
   const handleChange = date => {
-    const formattedDate = date ? date.toISOString().split('T')[0] : '';
+    let formattedDate = '';
+    if (date) {
+      // Use local date formatting to avoid timezone issues with toISOString()
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      formattedDate = `${year}-${month}-${day}`;
+    }
     const syntheticEvent = {
       target: {
         name: name,
@@ -44,7 +51,8 @@ export const DateInput = ({
   };
 
   // Convert string value to Date object for Mantine
-  const dateValue = value ? new Date(value) : null;
+  // For date-only strings like "1990-01-15", create Date in local timezone to avoid off-by-1 errors
+  const dateValue = value ? new Date(value + 'T00:00:00') : null;
 
   return (
     <MantineDateInput

--- a/frontend/src/components/medical/BaseMedicalForm.js
+++ b/frontend/src/components/medical/BaseMedicalForm.js
@@ -234,7 +234,10 @@ const BaseMedicalForm = ({
         return (
           <DateInput
             {...baseProps}
-            value={formData[name] ? new Date(formData[name]) : null}
+            value={formData[name] ? (() => {
+              const [year, month, day] = formData[name].split('-').map(Number);
+              return new Date(year, month - 1, day); // month is 0-indexed
+            })() : null}
             onChange={handleDateChange(name)}
             firstDayOfWeek={0}
             clearable

--- a/frontend/src/components/medical/MantinePatientForm.js
+++ b/frontend/src/components/medical/MantinePatientForm.js
@@ -70,7 +70,10 @@ const MantinePatientForm = ({
           <DateInput
             label="Birth Date"
             placeholder="Select birth date"
-            value={formData.birth_date ? new Date(formData.birth_date) : null}
+            value={formData.birth_date ? (() => {
+              const [year, month, day] = formData.birth_date.split('-').map(Number);
+              return new Date(year, month - 1, day); // month is 0-indexed
+            })() : null}
             onChange={handleDateChange('birth_date')}
             firstDayOfWeek={0}
             required

--- a/frontend/src/hooks/useFormHandlers.js
+++ b/frontend/src/hooks/useFormHandlers.js
@@ -43,11 +43,24 @@ export function useFormHandlers(onInputChange) {
       
       if (date) {
         // Check if it's already a Date object, if not try to create one
-        const dateObj = date instanceof Date ? date : new Date(date);
+        let dateObj;
+        if (date instanceof Date) {
+          dateObj = date;
+        } else if (typeof date === 'string') {
+          // Handle string dates by parsing manually to avoid timezone issues
+          const [year, month, day] = date.split('-').map(Number);
+          dateObj = new Date(year, month - 1, day); // month is 0-indexed
+        } else {
+          dateObj = new Date(date);
+        }
         
         // Verify we have a valid date before formatting
         if (!isNaN(dateObj.getTime())) {
-          formattedDate = dateObj.toISOString().split('T')[0];
+          // Use local date formatting to avoid timezone issues with toISOString()
+          const year = dateObj.getFullYear();
+          const month = String(dateObj.getMonth() + 1).padStart(2, '0');
+          const day = String(dateObj.getDate()).padStart(2, '0');
+          formattedDate = `${year}-${month}-${day}`;
         }
       }
       

--- a/frontend/src/hooks/useTimezone.js
+++ b/frontend/src/hooks/useTimezone.js
@@ -16,8 +16,23 @@ export const useTimezone = () => {
     isReady,
     formatDateTime: (utcString, options) =>
       timezoneService.formatDateTime(utcString, options),
-    formatDate: utcString =>
-      timezoneService.formatDateTime(utcString, { dateOnly: true }),
+    formatDate: utcString => {
+      if (!utcString) return 'N/A';
+      
+      // For date-only strings (like birth dates), parse them as local dates to avoid timezone issues
+      if (typeof utcString === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(utcString.trim())) {
+        const [year, month, day] = utcString.trim().split('-').map(Number);
+        const localDate = new Date(year, month - 1, day); // month is 0-indexed
+        return localDate.toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'short',
+          day: '2-digit',
+        });
+      }
+      
+      // For datetime strings, use the timezone service
+      return timezoneService.formatDateTime(utcString, { dateOnly: true });
+    },
     getCurrentTime: () => timezoneService.getCurrentFacilityTime(),
     facilityTimezone: timezoneService.getFacilityTimezone(),
   };

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -13,6 +13,20 @@ import { timezoneService } from '../services/timezoneService';
  * @returns {string} - Formatted date
  */
 export const formatDate = (utcDate, format = DATE_FORMATS.DISPLAY) => {
+  if (!utcDate) return 'N/A';
+  
+  // For date-only strings (like birth dates), parse them as local dates to avoid timezone issues
+  if (typeof utcDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(utcDate.trim())) {
+    const [year, month, day] = utcDate.trim().split('-').map(Number);
+    const localDate = new Date(year, month - 1, day); // month is 0-indexed
+    return localDate.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+    });
+  }
+  
+  // For datetime strings, use the timezone service
   return timezoneService.formatDateTime(utcDate, { dateOnly: true });
 };
 


### PR DESCRIPTION
- Updated DateInput to format dates using local date formatting instead of toISOString().
- Refactored date parsing in BaseMedicalForm and MantinePatientForm to create Date objects correctly from string inputs.
- Improved date handling in useFormHandlers and useTimezone hooks to ensure consistent local date parsing.
- Enhanced formatDate utility to handle date-only strings, ensuring accurate display without timezone discrepancies.