### PR TITLE
fix: add owner_user_id to patient creation for constraint compliance

### DIFF
--- a/app/crud/patient.py
+++ b/app/crud/patient.py
@@ -148,6 +148,7 @@ class CRUDPatient(CRUDBase[Patient, PatientCreate, PatientUpdate]):
         # Create patient with the specified user_id
         patient_dict = patient_data.dict()
         patient_dict["user_id"] = user_id
+        patient_dict["owner_user_id"] = user_id  # Set owner_user_id for constraint compliance
 
         db_patient = Patient(**patient_dict)
         db.add(db_patient)


### PR DESCRIPTION
This pull request includes a small change to the `create_for_user` method in `app/crud/patient.py`. The change ensures that the `owner_user_id` field is set to the same value as `user_id` when creating a new patient, to comply with database constraints.