### PR TITLE
Fix: directory permission checks

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -96,12 +96,12 @@ fix_directory_permissions() {
     return 0
 }
 
-# Check essential directories
-fix_directory_permissions "/app/uploads" "uploads"
-fix_directory_permissions "/app/uploads/lab_result_files" "lab result files"
-fix_directory_permissions "/app/logs" "logs"
-fix_directory_permissions "/app/backups" "backups"
-fix_directory_permissions "/app/uploads/trash" "trash"
+# Check essential directories (don't exit on permission failures for Docker volumes)
+fix_directory_permissions "/app/uploads" "uploads" || true
+fix_directory_permissions "/app/uploads/lab_result_files" "lab result files" || true
+fix_directory_permissions "/app/logs" "logs" || true
+fix_directory_permissions "/app/backups" "backups" || true
+fix_directory_permissions "/app/uploads/trash" "trash" || true
 
 echo "Directory permission check completed."
 


### PR DESCRIPTION
This pull request modifies the `fix_directory_permissions` calls in the `docker/entrypoint.sh` script to ensure that permission failures for Docker volumes do not cause the script to exit. This change improves the robustness of the entrypoint script when handling directories with permission issues.

### Key Change:

* **Improved error handling for directory permission checks:**
  - Updated calls to `fix_directory_permissions` to append `|| true`, ensuring that permission failures do not terminate the script. This change applies to the following directories: `/app/uploads`, `/app/uploads/lab_result_files`, `/app/logs`, `/app/backups`, and `/app/uploads/trash`.…ocker volumes