### PR TITLE
Fix: timezone correction in family sharing invitations

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -16,8 +16,7 @@ DB_NAME = os.getenv("DB_NAME", "")
 
 class Settings:  # App Info
     APP_NAME: str = "Medical Records Management System"
-    VERSION: str = "0.18.0"
-
+    VERSION: str = "0.18.1"
 
     DEBUG: bool = (
         os.getenv("DEBUG", "True").lower() == "true"

--- a/app/services/family_history_sharing.py
+++ b/app/services/family_history_sharing.py
@@ -215,7 +215,11 @@ class FamilyHistoryService:
             # Check if expired
             if invitation.expires_at:
                 now = get_utc_now()
-                if invitation.expires_at < now:
+                # Ensure both datetimes are timezone-aware for comparison
+                expires_at = invitation.expires_at
+                if expires_at.tzinfo is None:
+                    expires_at = expires_at.replace(tzinfo=timezone.utc)
+                if expires_at < now:
                     raise ValueError("Invitation has expired")
             
             # 2. Extract context data with error handling


### PR DESCRIPTION
This pull request includes minor updates to the `Settings` class and a bug fix in the family history sharing service. The changes improve version tracking, ensure timezone-aware datetime comparisons, and clean up imports.

### Configuration updates:
* [`app/core/config.py`](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bL19-R19): Updated the `VERSION` attribute in the `Settings` class from `0.18.0` to `0.18.1`. This reflects a minor version increment for the application.

### Bug fixes:
* [`app/services/family_history_sharing.py`](diffhunk://#diff-c9932dc5bc8be919ba1a778c7f780d9c7f6e652b99ad47cca8df82a913acfda2L218-R222): Fixed a bug in `accept_family_history_share_invitation` by ensuring that the `expires_at` datetime is always timezone-aware before comparing it with the current UTC time. This prevents potential errors when comparing naive and aware datetime objects.

### Code cleanup:
* [`app/core/config.py`](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bL1-R2): Reorganized imports by moving the `os` import to follow alphabetical order for consistency.