### PR TITLE
Bug: Fixed error logic for document viewing

### DIFF
--- a/frontend/src/constants/errorMessages.js
+++ b/frontend/src/constants/errorMessages.js
@@ -51,6 +51,7 @@ export const ERROR_MESSAGES = {
   // File management errors
   FILE_DELETE_FAILED: 'Failed to delete file. Please try again.',
   FILE_DOWNLOAD_FAILED: 'Failed to download file. Please try again.',
+  FILE_VIEW_FAILED: 'Failed to open file for viewing. Please try again.',
   FILE_NOT_FOUND: 'File not found.',
   
   // Batch upload errors
@@ -105,6 +106,7 @@ export const ERROR_TYPE_MAPPING = {
   [ERROR_MESSAGES.DUPLICATE_FILE]: ERROR_CATEGORIES.FILE,
   [ERROR_MESSAGES.FILE_DELETE_FAILED]: ERROR_CATEGORIES.FILE,
   [ERROR_MESSAGES.FILE_DOWNLOAD_FAILED]: ERROR_CATEGORIES.FILE,
+  [ERROR_MESSAGES.FILE_VIEW_FAILED]: ERROR_CATEGORIES.FILE,
   [ERROR_MESSAGES.FILE_NOT_FOUND]: ERROR_CATEGORIES.FILE,
   
   [ERROR_MESSAGES.PAPERLESS_UNAVAILABLE]: ERROR_CATEGORIES.PAPERLESS,
@@ -286,6 +288,8 @@ export const getUserFriendlyError = (error, operation = 'operation') => {
       return ERROR_MESSAGES.FILE_DELETE_FAILED;
     case 'download':
       return ERROR_MESSAGES.FILE_DOWNLOAD_FAILED;
+    case 'view':
+      return ERROR_MESSAGES.FILE_VIEW_FAILED;
     case 'submit':
     case 'save':
       return ERROR_MESSAGES.FORM_SUBMISSION_FAILED;


### PR DESCRIPTION
This pull request introduces enhancements to error handling and logging for file-related operations, particularly for viewing files, and improves the robustness of JWT token validation. Key changes include adding a new error message for file viewing, improving JWT payload parsing, and refining logging for better debugging.

### Enhancements to error handling and logging:

* Added a new error message `FILE_VIEW_FAILED` to support file viewing errors in `frontend/src/constants/errorMessages.js`. Updated the error type mapping and `getUserFriendlyError` function to include this new error. [[1]](diffhunk://#diff-83aa08c3aa916ef948bf3e042a8051cc42e60f953f83734f56313450ea315d87R54) [[2]](diffhunk://#diff-83aa08c3aa916ef948bf3e042a8051cc42e60f953f83734f56313450ea315d87R109) [[3]](diffhunk://#diff-83aa08c3aa916ef948bf3e042a8051cc42e60f953f83734f56313450ea315d87R291-R292)
* Improved logging in `ApiService` for better debugging:
  - Added detailed logs for JWT payload parsing errors, including warnings when parsing fails but the operation continues.
  - Enhanced logging for `window.open` failures, logging warnings instead of throwing errors when pop-ups are blocked or `window.open` returns `null`.
  - Included additional error details (`errorStack` and `errorType`) in the error logging payload.

### Improvements to JWT token validation:

* Made JWT payload parsing more robust by handling base64 padding issues and logging warnings instead of failing outright when parsing fails. This ensures the operation can continue with server-side validation.
* Adjusted token validation logic to differentiate between critical authentication issues (e.g., session expiration) and non-critical issues during file viewing, allowing the latter to proceed with warnings.