### PR TITLE
Bug: Support API token authentication for paperless uploads and connection persistence

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,7 +16,7 @@ DB_NAME = os.getenv("DB_NAME", "")
 
 class Settings:  # App Info
     APP_NAME: str = "Medical Records Management System"
-    VERSION: str = "0.21.0"
+    VERSION: str = "0.21.1"
 
     DEBUG: bool = (
         os.getenv("DEBUG", "True").lower() == "true"

--- a/app/services/generic_entity_file_service.py
+++ b/app/services/generic_entity_file_service.py
@@ -173,14 +173,14 @@ class GenericEntityFileService:
                         detail="Paperless integration is not enabled. Please enable it in settings before uploading to Paperless.",
                     )
 
-                if (
-                    not user_prefs.paperless_url
-                    or not user_prefs.paperless_username_encrypted
-                    or not user_prefs.paperless_password_encrypted
-                ):
+                # Check if we have either token OR username/password credentials
+                has_token = bool(user_prefs.paperless_api_token_encrypted)
+                has_credentials = bool(user_prefs.paperless_username_encrypted and user_prefs.paperless_password_encrypted)
+                
+                if not user_prefs.paperless_url or (not has_token and not has_credentials):
                     raise HTTPException(
                         status_code=400,
-                        detail="Paperless configuration is incomplete. Please configure URL and credentials in settings.",
+                        detail="Paperless configuration is incomplete. Please configure URL and authentication credentials (token or username/password) in settings.",
                     )
 
             # Read file content once for both backends
@@ -875,11 +875,11 @@ class GenericEntityFileService:
                 detail="Paperless integration is not enabled for this user",
             )
 
-        if (
-            not user_prefs.paperless_url
-            or not user_prefs.paperless_username_encrypted
-            or not user_prefs.paperless_password_encrypted
-        ):
+        # Check if we have either token OR username/password credentials
+        has_token = bool(user_prefs.paperless_api_token_encrypted)
+        has_credentials = bool(user_prefs.paperless_username_encrypted and user_prefs.paperless_password_encrypted)
+        
+        if not user_prefs.paperless_url or (not has_token and not has_credentials):
             raise HTTPException(
                 status_code=400, detail="Paperless configuration is incomplete"
             )

--- a/frontend/src/components/settings/PaperlessSettings.js
+++ b/frontend/src/components/settings/PaperlessSettings.js
@@ -24,20 +24,22 @@ const PaperlessSettings = ({
   
   // Track previous URL and token to detect actual changes
   const prevUrlRef = useRef();
-  const prevApiTokenRef = useRef();
+  const prevHasTokenRef = useRef();
 
   // Initialize connection status for saved settings
   useEffect(() => {
     const currentUrl = preferences?.paperless_url;
     
-    const currentApiToken = preferences?.paperless_api_token;
+    // Check for token existence using the backend's has_token field or form token
+    const currentHasToken = preferences?.paperless_has_token || 
+                           (preferences?.paperless_api_token && preferences.paperless_api_token.trim() !== '');
     
-    // Check if URL or API token actually changed (not just component re-render)
+    // Check if URL or token existence actually changed (not just component re-render)
     const urlChanged = prevUrlRef.current !== undefined && prevUrlRef.current !== currentUrl;
-    const apiTokenChanged = prevApiTokenRef.current !== undefined && prevApiTokenRef.current !== currentApiToken;
+    const tokenChanged = prevHasTokenRef.current !== undefined && prevHasTokenRef.current !== currentHasToken;
     
-    if (urlChanged || apiTokenChanged) {
-      // URL or API token changed - reset connection status
+    if (urlChanged || tokenChanged) {
+      // URL or token availability changed - reset connection status
       setConnectionStatus('disconnected');
       setServerInfo(null);
       
@@ -45,7 +47,7 @@ const PaperlessSettings = ({
         component: 'PaperlessSettings',
         oldUrl: prevUrlRef.current,
         newUrl: currentUrl,
-        tokenChanged: apiTokenChanged
+        tokenChanged: tokenChanged
       });
     } else if (currentUrl && connectionStatus === 'disconnected' && prevUrlRef.current === undefined) {
       // First load with saved URL - assume it was previously working
@@ -63,14 +65,14 @@ const PaperlessSettings = ({
     
     // Update refs for next comparison
     prevUrlRef.current = currentUrl;
-    prevApiTokenRef.current = currentApiToken;
+    prevHasTokenRef.current = currentHasToken;
     
     // Only set to disconnected if we truly have no URL
     if (!currentUrl) {
       setConnectionStatus('disconnected');
       setServerInfo(null);
     }
-  }, [preferences?.paperless_url, preferences?.paperless_api_token, connectionStatus]);
+  }, [preferences?.paperless_url, preferences?.paperless_api_token, preferences?.paperless_has_token, connectionStatus]);
 
   /**
    * Handle connection test


### PR DESCRIPTION
This pull request improves the handling of Paperless authentication throughout the backend and frontend, ensuring consistent support for both API token and username/password authentication. It also updates the version number and enhances frontend settings detection logic.

**Backend authentication consistency and validation:**

* Updated both `upload_file` and `_upload_to_paperless` in `generic_entity_file_service.py` to validate Paperless configuration by checking for either an API token or username/password credentials, improving flexibility and error messaging. [[1]](diffhunk://#diff-d40b9a0a30342af2aef44629f6cb02f76eff82e889cba61811346841b2279073L176-R183) [[2]](diffhunk://#diff-d40b9a0a30342af2aef44629f6cb02f76eff82e889cba61811346841b2279073L878-R882)
* Refactored `get_paperless_task_status` in `paperless.py` to use a unified authentication factory (`create_paperless_service`) that supports both token and username/password, ensuring consistent behavior with file uploads.

**Frontend settings logic improvements:**

* Enhanced `PaperlessSettings.js` to track and detect changes in token availability (using `has_token`), resetting connection status only when the URL or token presence changes, for more accurate UI feedback. [[1]](diffhunk://#diff-51be90a0f592b524c501fecae69c95426cbdd482727643ec5f5d79dfe918fe1fL27-R50) [[2]](diffhunk://#diff-51be90a0f592b524c501fecae69c95426cbdd482727643ec5f5d79dfe918fe1fL66-R75)

**Version update:**

* Bumped the app version to `0.21.1` in `config.py` to reflect these improvements.