### PR TITLE
Bug: Enhance Paperless file handling and filename correction

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,7 +16,7 @@ DB_NAME = os.getenv("DB_NAME", "")
 
 class Settings:  # App Info
     APP_NAME: str = "Medical Records Management System"
-    VERSION: str = "0.21.2"
+    VERSION: str = "0.21.3"
 
     DEBUG: bool = (
         os.getenv("DEBUG", "True").lower() == "true"

--- a/app/services/generic_entity_file_service.py
+++ b/app/services/generic_entity_file_service.py
@@ -564,6 +564,7 @@ class GenericEntityFileService:
                 )
 
             # Route to appropriate storage backend for download
+            logger.info(f"DEBUG: File {file_id} storage backend: {file_record.storage_backend}, paperless_doc_id: {file_record.paperless_document_id}")
             if file_record.storage_backend == "paperless":
                 return await self._get_paperless_download_info(db, file_record, current_user_id)
             else:


### PR DESCRIPTION
This pull request improves the handling of file downloads, especially for files processed by Paperless-NGX, by ensuring that file extensions and content types are accurate and consistent between the backend and frontend. The changes address issues where files (such as images converted to PDFs) may have mismatched extensions, which could cause problems for users downloading or viewing these files. The frontend is also updated to use the filename provided by the server in the response headers.

**Backend improvements for Paperless file handling:**

* Added a new function `fix_filename_for_paperless_content` in `entity_file.py` to correct file extensions (e.g., changing `.jpg` to `.pdf` if the content is actually a PDF), ensuring the filename matches the file's actual content.
* Updated both the `download_file` and `view_file` endpoints in `entity_file.py` to use the corrected filename, set the appropriate `Content-Type` (with special handling for PDFs), and include accurate headers such as `Content-Disposition` and `Content-Length`. [[1]](diffhunk://#diff-582256a735bcd16ce7ac517dd898b88d921d4be898d7c5c82f488632ef680f31L361-R421) [[2]](diffhunk://#diff-582256a735bcd16ce7ac517dd898b88d921d4be898d7c5c82f488632ef680f31L431-R518)
* Improved logging for debugging Paperless file downloads and backend routing in both `entity_file.py` and `generic_entity_file_service.py`. [[1]](diffhunk://#diff-582256a735bcd16ce7ac517dd898b88d921d4be898d7c5c82f488632ef680f31L361-R421) [[2]](diffhunk://#diff-582256a735bcd16ce7ac517dd898b88d921d4be898d7c5c82f488632ef680f31L431-R518) [[3]](diffhunk://#diff-d40b9a0a30342af2aef44629f6cb02f76eff82e889cba61811346841b2279073R567)

**Frontend download handling:**

* Refactored the file download logic in `frontend/src/services/api/index.js` to use the filename from the server's `Content-Disposition` header, ensuring users receive files with the correct extension and name.

**Other:**

* Bumped the application version to `0.21.3` in `config.py`.