### PR TITLE
fix: Pin Python base image to slim-bookworm

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/frontend/.cache \
     npm prune --production
 
 # Stage 2: Python backend with built React app
-FROM python:3.12-slim AS backend
+FROM python:3.12-slim-bookworm AS backend
 
 # Set Python environment variables for optimization
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
This pull request makes a minor update to the Docker build configuration by changing the backend base image to use the `python:3.12-slim-bookworm` tag. This ensures the backend uses the Bookworm release of Debian for improved compatibility and security.

* Updated backend Docker base image from `python:3.12-slim` to `python:3.12-slim-bookworm` in `docker/Dockerfile`.…lity