### PR TITLE
Bug: Implement data consistency fixes for family members in CRUD operations

### DIFF
--- a/frontend/src/components/medical/MantineFamilyMemberForm.js
+++ b/frontend/src/components/medical/MantineFamilyMemberForm.js
@@ -16,6 +16,15 @@ const MantineFamilyMemberForm = ({
     // Add any dynamic options for family members if needed
   };
 
+  // Handle is_deceased change to clear death_year when unchecked
+  const handleInputChange = (name, value) => {
+    if (name === 'is_deceased' && value === false && formData?.death_year) {
+      // Clear death_year when is_deceased is unchecked
+      onInputChange('death_year', null);
+    }
+    onInputChange(name, value);
+  };
+
   // Filter fields based on form state - only show death_year if is_deceased is true
   const filteredFields = familyMemberFormFields.filter(field => {
     if (field.name === 'death_year') {
@@ -50,7 +59,7 @@ const MantineFamilyMemberForm = ({
       onClose={onClose}
       title={title}
       formData={formData}
-      onInputChange={onInputChange}
+      onInputChange={handleInputChange}
       onSubmit={onSubmit}
       editingItem={editingMember}
       fields={filteredFields}


### PR DESCRIPTION
This pull request addresses data consistency issues regarding the `is_deceased` and `death_year` fields for family members, both on the backend and frontend. The main improvements ensure that these fields remain logically consistent, preventing conflicting states in the database and user interface.

**Backend consistency fixes:**

* Added logic in `CRUDFamilyMember.get_by_patient` and `get_by_patient_with_conditions` to automatically set `is_deceased` to `True` if a `death_year` is present but `is_deceased` is `False`, and to persist these corrections to the database. [[1]](diffhunk://#diff-ceeb3e19a4696b7482d59645082120744b95ff39a3d75ca2e6c67c693ff14aa7R17-R45) [[2]](diffhunk://#diff-ceeb3e19a4696b7482d59645082120744b95ff39a3d75ca2e6c67c693ff14aa7L30-R80)

**Frontend consistency fixes:**

* Updated `MantineFamilyMemberForm` so that unchecking the `is_deceased` field will automatically clear the `death_year` value, preventing users from submitting logically inconsistent data. [[1]](diffhunk://#diff-a51b87835a8eeee2cb9905e9324fbf21c1dc33e1f9196b7bb32a48a7b0d2943eR19-R27) [[2]](diffhunk://#diff-a51b87835a8eeee2cb9905e9324fbf21c1dc33e1f9196b7bb32a48a7b0d2943eL53-R62)