### PR TITLE
Add "Manage Users" link to AdminSidebar for user management navigation

### DIFF
--- a/frontend/src/components/admin/AdminSidebar.js
+++ b/frontend/src/components/admin/AdminSidebar.js
@@ -92,6 +92,14 @@ const AdminSidebar = ({ isOpen, onToggle, currentPath }) => {
             <span className="nav-icon">🗄️</span>
             <span className="nav-text">Data Models</span>
           </Link>
+          <Link
+            to="/admin/models/user"
+            className={`nav-item ${currentPath.includes('/admin/models/user') ? 'active' : ''}`}
+            onClick={() => handleLinkClick('/admin/models/user')}
+          >
+            <span className="nav-icon">👥</span>
+            <span className="nav-text">Manage Users</span>
+          </Link>
         </div>
 
         <div className="nav-section">


### PR DESCRIPTION
This pull request adds a new navigation link to the admin sidebar for managing users. The new "Manage Users" link appears alongside existing admin navigation options.

Admin sidebar navigation:

* Added a "Manage Users" navigation link to the `AdminSidebar` component, directing users to `/admin/models/user` and visually highlighting it when active.