### PR TITLE
Fix: Await token retrieval in error logging and logout methods

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,7 +17,7 @@ DB_NAME = os.getenv("DB_NAME", "")
 
 class Settings:  # App Info
     APP_NAME: str = "Medical Records Management System"
-    VERSION: str = "0.25.0"
+    VERSION: str = "0.25.1"
 
     DEBUG: bool = (
         os.getenv("DEBUG", "True").lower() == "true"

--- a/frontend/src/services/auth/simpleAuthService.js
+++ b/frontend/src/services/auth/simpleAuthService.js
@@ -310,8 +310,8 @@ class SimpleAuthService {
       logger.error('Error retrieving current user from storage', {
         error: error.message,
         errorType: error.constructor.name,
-        hasToken: !!this.getToken(),
-        isTokenValid: this.isTokenValid(),
+        hasToken: !!(await this.getToken()),
+        isTokenValid: await this.isTokenValid(),
         category: 'auth_user_fetch_error'
       });
       return null;
@@ -330,12 +330,12 @@ class SimpleAuthService {
   async logout() {
     try {
       logger.info('Logging out user', {
-        hadToken: !!this.getToken(),
+        hadToken: !!(await this.getToken()),
         category: 'auth_logout'
       });
       
       // Call backend logout endpoint to invalidate token
-      const token = this.getToken();
+      const token = await this.getToken();
       if (token) {
         try {
           await this.makeRequest('/auth/logout', {


### PR DESCRIPTION
This pull request updates the `SimpleAuthService` class to ensure that token-related logging and operations correctly handle the asynchronous nature of token retrieval. The main change is converting calls to `this.getToken()` and `this.isTokenValid()` to use `await`, ensuring that the values are properly resolved before use in logging and logic.

**Improvements to asynchronous handling in authentication service:**

* Changed logging in error handling and logout to await the results of `getToken()` and `isTokenValid()`, ensuring accurate and up-to-date information is logged. [[1]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdL313-R314) [[2]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdL333-R338)
* Updated the logout process to await `getToken()` before making the logout request, preventing potential issues with unresolved promises.