### PR TITLE
Fix: Add VITALS entity type to ActivityLog and EntityFile schemas

### DIFF
--- a/app/models/activity_log.py
+++ b/app/models/activity_log.py
@@ -148,6 +148,7 @@ class EntityType:
     FAMILY_MEMBER = "family_member"
     INSURANCE = "insurance"
     FAMILY_CONDITION = "family_condition"
+    VITALS = "vitals"
 
     # System entities
     SYSTEM = "system"
@@ -175,6 +176,7 @@ class EntityType:
             cls.FAMILY_MEMBER,
             cls.INSURANCE,
             cls.FAMILY_CONDITION,
+            cls.VITALS,
             cls.SYSTEM,
             cls.BACKUP,
         ]

--- a/app/schemas/entity_file.py
+++ b/app/schemas/entity_file.py
@@ -11,6 +11,7 @@ class EntityType(str, Enum):
     VISIT = "visit"
     ENCOUNTER = "encounter"  # Alternative name for visit
     PROCEDURE = "procedure"
+    VITALS = "vitals"
 
 
 class EntityFileBase(BaseModel):


### PR DESCRIPTION
This pull request adds support for a new entity type, `vitals`, to both the models and schemas in the codebase. The changes ensure that `vitals` is now recognized as a valid entity type throughout the system.

Entity type additions:

* Added `VITALS = "vitals"` to the `EntityType` class in `app/models/activity_log.py`, making it an official entity type.
* Included `VITALS` in the list returned by the `get_all_types` method in `app/models/activity_log.py`, so it will be part of all entity type enumerations.
* Added `VITALS = "vitals"` to the `EntityType` enum in `app/schemas/entity_file.py`, ensuring schema validation supports this new type.