### PR TITLE
fix: Remove unnecessary style properties from Medication component

### DIFF
--- a/frontend/src/pages/medical/Medication.js
+++ b/frontend/src/pages/medical/Medication.js
@@ -328,7 +328,7 @@ const Medication = () => {
 
   if (loading) {
     return (
-      <Container size="xl" py="md" style={{ maxWidth: '100%', overflow: 'hidden' }}>
+      <Container size="xl" py="md">
         <Center h={200}>
           <Stack align="center">
             <Loader size="lg" />
@@ -340,7 +340,7 @@ const Medication = () => {
   }
 
   return (
-    <Container size="xl" py="md" style={{ maxWidth: '100%', overflow: 'hidden' }}>
+    <Container size="xl" py="md">
       <PageHeader title="Medications" icon="💊" />
 
       <Stack gap="lg">


### PR DESCRIPTION
This pull request makes a minor change to the `Medication` page component by removing the inline `style` prop from the `Container` component. This simplifies the code and relies on default styling. Keeps the medication page in line with the other pages.