### PR TITLE
feat: Enhance patient management during user registration and login

### DIFF
--- a/app/services/custom_report_service.py
+++ b/app/services/custom_report_service.py
@@ -74,8 +74,53 @@ class CustomReportService:
         
         # Get the active patient ID
         if not user.active_patient_id:
-            logger.warning(f"No active patient for user {user_id}")
-            return DataSummaryResponse(categories={}, total_records=0)
+            # Check if user has a self-record that can be set as active
+            self_record = self.db.query(Patient).filter(
+                Patient.owner_user_id == user_id,
+                Patient.is_self_record == True
+            ).first()
+
+            if self_record:
+                user.active_patient_id = self_record.id
+                self.db.commit()
+                self.db.refresh(user)
+
+                logger.info(
+                    "Auto-setting self-record as active patient",
+                    extra={
+                        "user_id": user_id,
+                        "patient_id": self_record.id,
+                        "context": "custom_report_access"
+                    }
+                )
+            else:
+                # Check if user has any owned patients at all
+                any_patient = self.db.query(Patient).filter(
+                    Patient.owner_user_id == user_id
+                ).first()
+
+                if any_patient:
+                    user.active_patient_id = any_patient.id
+                    self.db.commit()
+                    self.db.refresh(user)
+
+                    logger.info(
+                        "Auto-setting first available patient as active",
+                        extra={
+                            "user_id": user_id,
+                            "patient_id": any_patient.id,
+                            "context": "custom_report_access"
+                        }
+                    )
+                else:
+                    logger.warning(
+                        "No patients available for user",
+                        extra={
+                            "user_id": user_id,
+                            "context": "custom_report_access"
+                        }
+                    )
+                    return DataSummaryResponse(categories={}, total_records=0)
         
         # Include patient ID in cache key so different patients have different caches
         cache_key = f"summary_{user_id}_{user.active_patient_id}"


### PR DESCRIPTION
This pull request introduces improvements to how the application sets and manages a user's active patient record during registration, login, and custom report access. The main goal is to ensure users always have an active patient set when possible, improving user experience and data consistency. The changes include transactional handling during registration, automatic selection of an active patient during login, and fallback logic for custom reports.

**Active Patient Management Enhancements**

* During user registration, the system now creates a self-record patient and sets it as the user's active patient in a single transaction. If this fails, it rolls back the changes and logs the error, allowing the user to set the active patient later.
* On login, if the user does not have an active patient, the system automatically selects one—prioritizing self-records—sets it as active, and logs the event.
* When accessing custom reports, if the user lacks an active patient, the service tries to set a self-record as active, or falls back to the first available patient. If no patient exists, it logs a warning and returns an empty summary.

**Codebase and Import Updates**

* Updated imports in `app/api/v1/endpoints/auth.py` to include the `Patient` model for use in new queries and logic.

**Error Handling Improvements**

* Added error handling and logging for failures during patient creation and active patient assignment in registration, including transaction rollback and clear log messages. [[1]](diffhunk://#diff-58cbf6b3617b377d3a8851669ad55bc36905fa9a231e7c942e1d2470d2c5f091L142-R179) [[2]](diffhunk://#diff-58cbf6b3617b377d3a8851669ad55bc36905fa9a231e7c942e1d2470d2c5f091R194-R195)