### PR TITLE
refactor: improve input handling in CRUD operations to retain native python types

### DIFF
--- a/app/crud/base.py
+++ b/app/crud/base.py
@@ -450,9 +450,9 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType], QueryMixi
         Raises:
             TypeError: If input type is not supported
         """
-        # Handle plain dictionaries
+        # Handle plain dictionaries - return copy to prevent mutation
         if isinstance(obj_in, dict):
-            return obj_in
+            return obj_in.copy()
 
         # Handle Pydantic v2 models (check for callable model_dump)
         model_dump_attr = getattr(obj_in, "model_dump", None)
@@ -468,8 +468,12 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType], QueryMixi
         if isinstance(obj_in, Mapping):
             return dict(obj_in)
 
-        # Handle dataclasses
+        # Handle dataclasses (only instances, not classes)
         if is_dataclass(obj_in):
+            if isinstance(obj_in, type):
+                raise TypeError(
+                    f"Cannot normalize dataclass class '{obj_in.__name__}'; expected an instance."
+                )
             return asdict(obj_in)
 
         # Unsupported type - raise clear error


### PR DESCRIPTION
This pull request refactors the `create` and `update` methods in `app/crud/base.py` to improve how input data is handled before interacting with the database. The main change is to avoid unnecessary JSON serialization, which could break support for native Python types like `date` and `datetime` in SQLAlchemy, especially with SQLite and PostgreSQL. Instead, the code now preserves native Python types for all input scenarios.

Improvements to database input handling:

* In both `create` and `update` methods, removed use of `jsonable_encoder` for input data and now pass native Python types directly to SQLAlchemy, ensuring better compatibility with SQLite and PostgreSQL. [[1]](diffhunk://#diff-86801f59d9075ce15f6e45f82d0c1cc5bb02b8715103c06b87eb633ceb3e67c9L470-R485) [[2]](diffhunk://#diff-86801f59d9075ce15f6e45f82d0c1cc5bb02b8715103c06b87eb633ceb3e67c9L614-R633)
* Updated logic for handling Pydantic models and dictionaries, so that input is used as-is or converted to a dict only when necessary, without converting to JSON-serializable strings. [[1]](diffhunk://#diff-86801f59d9075ce15f6e45f82d0c1cc5bb02b8715103c06b87eb633ceb3e67c9L470-R485) [[2]](diffhunk://#diff-86801f59d9075ce15f6e45f82d0c1cc5bb02b8715103c06b87eb633ceb3e67c9L614-R633)