### PR TITLE
fix: activity dashboard n plus 1 bug

### DIFF
--- a/app/api/v1/endpoints/patients.py
+++ b/app/api/v1/endpoints/patients.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, File, Upl
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import desc
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.api import deps
 from app.api.activity_logging import log_create, log_delete, log_update
@@ -660,6 +660,7 @@ def get_user_recent_activity(
 
         activity_logs = (
             db.query(ActivityLog)
+            .options(joinedload(ActivityLog.user), joinedload(ActivityLog.patient))
             .filter(ActivityLog.entity_type.in_(medical_entity_types), main_filter)
             .order_by(desc(ActivityLog.timestamp))
             .limit(limit)


### PR DESCRIPTION
This pull request improves the efficiency of database queries related to user activity logs by optimizing how related data is loaded. The main change is the use of eager loading for related `user` and `patient` objects in activity log queries, which helps prevent performance issues due to repeated database access (the "N+1" query problem).

**Database query optimization:**

* Added `joinedload` imports and applied eager loading for `user` and `patient` relationships in the `get_user_recent_activity` function, ensuring related data is loaded in a single query. [[1]](diffhunk://#diff-86c18b47a2b8e99f42675aaa955cfdbc4577225f21b1cff93108501dba1f2097L8-R8) [[2]](diffhunk://#diff-86c18b47a2b8e99f42675aaa955cfdbc4577225f21b1cff93108501dba1f2097R663)e queries during activity log retrieval.