### PR TITLE
fix: load environment variables and enable access logging in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -11,6 +11,10 @@ import os
 import sys
 
 import uvicorn
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
 
 # Add the app directory to Python path
 sys.path.append(os.path.join(os.path.dirname(__file__), "app"))
@@ -168,5 +172,6 @@ if __name__ == "__main__":
             reload_dirs=["app"],
             log_level=log_level,
             log_config=get_uvicorn_log_config(),
+            access_log=True,  # Enable access logging to see HTTP requests
             **ssl_kwargs,
         )


### PR DESCRIPTION
This pull request introduces improvements to the `run.py` startup script, focusing on environment configuration and logging for better development experience and observability.

Environment configuration:

* Added loading of environment variables from a `.env` file at startup using `load_dotenv`, allowing easier management of secrets and configuration values.

Logging enhancements:

* Enabled HTTP access logging in the Uvicorn server by setting `access_log=True`, making it easier to monitor incoming requests during development and debugging.