### PR TITLE
refactor: update timezone handling for date fields in CRUDSymptom classes

### DIFF
--- a/app/crud/symptom.py
+++ b/app/crud/symptom.py
@@ -41,7 +41,9 @@ class CRUDSymptomParent(CRUDBase[Symptom, SymptomCreate, SymptomUpdate]):
     """
 
     def __init__(self):
-        super().__init__(Symptom, timezone_fields=["first_occurrence_date", "last_occurrence_date"])
+        # Note: first_occurrence_date and last_occurrence_date are Date fields, not DateTime
+        # Date fields don't need timezone conversion (they're date-only)
+        super().__init__(Symptom, timezone_fields=[])
 
     def get_with_occurrences(
         self,
@@ -294,7 +296,9 @@ class CRUDSymptomOccurrence(CRUDBase[SymptomOccurrence, SymptomOccurrenceCreate,
     """
 
     def __init__(self):
-        super().__init__(SymptomOccurrence, timezone_fields=["occurrence_date", "resolved_date"])
+        # Note: occurrence_date and resolved_date are Date fields, not DateTime
+        # Date fields don't need timezone conversion (they're date-only)
+        super().__init__(SymptomOccurrence, timezone_fields=[])
 
     def create(
         self,


### PR DESCRIPTION
This pull request updates the initialization of the `CRUDSymptomParent` and `CRUDSymptomOccurrence` classes to correctly handle date fields. The main change is to stop treating date-only fields as requiring timezone conversion, which is only necessary for datetime fields.

Date/time handling improvements:

* Updated `CRUDSymptomParent` (`app/crud/symptom.py`) to no longer specify `first_occurrence_date` and `last_occurrence_date` as timezone fields, since they are date-only and do not require timezone conversion.
* Updated `CRUDSymptomOccurrence` (`app/crud/symptom.py`) to no longer specify `occurrence_date` and `resolved_date` as timezone fields, for the same reason.