### PR TITLE
fix: add patient ownership verification to UPDATE/DELETE endpoints

### DIFF
--- a/app/api/v1/endpoints/allergy.py
+++ b/app/api/v1/endpoints/allergy.py
@@ -18,6 +18,7 @@ from app.core.logging.constants import LogFields
 from app.core.logging.helpers import log_data_access
 from app.crud.allergy import allergy
 from app.models.activity_log import EntityType
+from app.models.models import User
 from app.schemas.allergy import (
     AllergyCreate,
     AllergyResponse,
@@ -158,6 +159,8 @@ def update_allergy(
     allergy_id: int,
     allergy_in: AllergyUpdate,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """
     Update an allergy record.
@@ -171,6 +174,8 @@ def update_allergy(
         user_id=current_user_id,
         entity_name="Allergy",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 
@@ -181,6 +186,8 @@ def delete_allergy(
     db: Session = Depends(deps.get_db),
     allergy_id: int,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """
     Delete an allergy record.
@@ -193,6 +200,8 @@ def delete_allergy(
         user_id=current_user_id,
         entity_name="Allergy",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/app/api/v1/endpoints/condition.py
+++ b/app/api/v1/endpoints/condition.py
@@ -584,6 +584,8 @@ def update_condition(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Update a condition."""
     return handle_update_with_logging(
@@ -595,6 +597,8 @@ def update_condition(
         user_id=current_user_id,
         entity_name="Condition",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 
@@ -605,6 +609,8 @@ def delete_condition(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Delete a condition."""
     return handle_delete_with_logging(
@@ -615,6 +621,8 @@ def delete_condition(
         user_id=current_user_id,
         entity_name="Condition",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/app/api/v1/endpoints/emergency_contact.py
+++ b/app/api/v1/endpoints/emergency_contact.py
@@ -18,7 +18,7 @@ from app.api.v1.endpoints.utils import (
 from app.api.activity_logging import log_create, log_delete, log_update
 from app.crud.emergency_contact import emergency_contact
 from app.models.activity_log import EntityType
-from app.models.models import EmergencyContact
+from app.models.models import EmergencyContact, User
 from app.schemas.emergency_contact import (
     EmergencyContactCreate,
     EmergencyContactResponse,
@@ -154,6 +154,8 @@ def update_emergency_contact(
     emergency_contact_id: int,
     emergency_contact_in: EmergencyContactUpdate,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     target_patient_id: int = Depends(deps.get_accessible_patient_id),
 ) -> Any:
     """Update an emergency contact."""
@@ -166,6 +168,8 @@ def update_emergency_contact(
         user_id=current_user_id,
         entity_name="Emergency Contact",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 
@@ -176,6 +180,8 @@ def delete_emergency_contact(
     db: Session = Depends(deps.get_db),
     emergency_contact_id: int,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     target_patient_id: int = Depends(deps.get_accessible_patient_id),
 ) -> Any:
     """Delete an emergency contact."""
@@ -187,6 +193,8 @@ def delete_emergency_contact(
         user_id=current_user_id,
         entity_name="Emergency Contact",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/app/api/v1/endpoints/encounter.py
+++ b/app/api/v1/endpoints/encounter.py
@@ -17,6 +17,7 @@ from app.api.v1.endpoints.utils import (
 )
 from app.crud.encounter import encounter
 from app.models.activity_log import EntityType
+from app.models.models import User
 from app.schemas.encounter import (
     EncounterCreate,
     EncounterResponse,
@@ -144,6 +145,8 @@ def update_encounter(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Update an encounter."""
     return handle_update_with_logging(
@@ -155,6 +158,8 @@ def update_encounter(
         user_id=current_user_id,
         entity_name="Encounter",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 
@@ -165,6 +170,8 @@ def delete_encounter(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Delete an encounter."""
     return handle_delete_with_logging(
@@ -175,6 +182,8 @@ def delete_encounter(
         user_id=current_user_id,
         entity_name="Encounter",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/app/api/v1/endpoints/immunization.py
+++ b/app/api/v1/endpoints/immunization.py
@@ -19,6 +19,7 @@ from app.api.v1.endpoints.utils import (
 )
 from app.crud.immunization import immunization
 from app.models.activity_log import EntityType
+from app.models.models import User
 from app.schemas.immunization import (
     ImmunizationCreate,
     ImmunizationResponse,
@@ -157,6 +158,8 @@ def update_immunization(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Update an immunization record."""
     return handle_update_with_logging(
@@ -168,6 +171,8 @@ def update_immunization(
         user_id=current_user_id,
         entity_name="Immunization",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 
@@ -178,6 +183,8 @@ def delete_immunization(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Delete an immunization record."""
     return handle_delete_with_logging(
@@ -188,6 +195,8 @@ def delete_immunization(
         user_id=current_user_id,
         entity_name="Immunization",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/app/api/v1/endpoints/medication.py
+++ b/app/api/v1/endpoints/medication.py
@@ -167,6 +167,8 @@ def update_medication(
     medication_id: int,
     medication_in: MedicationUpdate,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Update a medication."""
     updated_medication = handle_update_with_logging(
@@ -178,6 +180,8 @@ def update_medication(
         user_id=current_user_id,
         entity_name="Medication",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
     # Return with relationships loaded
@@ -193,6 +197,8 @@ def delete_medication(
     db: Session = Depends(deps.get_db),
     medication_id: int,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Delete a medication."""
     return handle_delete_with_logging(
@@ -203,6 +209,8 @@ def delete_medication(
         user_id=current_user_id,
         entity_name="Medication",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/app/api/v1/endpoints/procedure.py
+++ b/app/api/v1/endpoints/procedure.py
@@ -19,6 +19,7 @@ from app.api.v1.endpoints.utils import (
 )
 from app.crud.procedure import procedure
 from app.models.activity_log import EntityType
+from app.models.models import User
 from app.schemas.procedure import (
     ProcedureCreate,
     ProcedureResponse,
@@ -158,6 +159,8 @@ def update_procedure(
     procedure_id: int,
     procedure_in: ProcedureUpdate,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """
     Update a procedure.
@@ -171,6 +174,8 @@ def update_procedure(
         user_id=current_user_id,
         entity_name="Procedure",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 
@@ -181,6 +186,8 @@ def delete_procedure(
     db: Session = Depends(deps.get_db),
     procedure_id: int,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """
     Delete a procedure.
@@ -193,6 +200,8 @@ def delete_procedure(
         user_id=current_user_id,
         entity_name="Procedure",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/app/api/v1/endpoints/symptom.py
+++ b/app/api/v1/endpoints/symptom.py
@@ -180,6 +180,8 @@ def update_symptom(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Update symptom definition."""
     return handle_update_with_logging(
@@ -191,6 +193,8 @@ def update_symptom(
         user_id=current_user_id,
         entity_name="Symptom",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 
@@ -201,6 +205,8 @@ def delete_symptom(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Delete a symptom definition (and all its occurrences via cascade)."""
     return handle_delete_with_logging(
@@ -211,6 +217,8 @@ def delete_symptom(
         user_id=current_user_id,
         entity_name="Symptom",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/app/api/v1/endpoints/treatment.py
+++ b/app/api/v1/endpoints/treatment.py
@@ -19,6 +19,7 @@ from app.api.v1.endpoints.utils import (
 )
 from app.crud.treatment import treatment
 from app.models.activity_log import EntityType
+from app.models.models import User
 from app.schemas.treatment import (
     TreatmentCreate,
     TreatmentResponse,
@@ -161,6 +162,8 @@ def update_treatment(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Update a treatment."""
     return handle_update_with_logging(
@@ -172,6 +175,8 @@ def update_treatment(
         user_id=current_user_id,
         entity_name="Treatment",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 
@@ -182,6 +187,8 @@ def delete_treatment(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Delete a treatment."""
     return handle_delete_with_logging(
@@ -192,6 +199,8 @@ def delete_treatment(
         user_id=current_user_id,
         entity_name="Treatment",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/app/api/v1/endpoints/vitals.py
+++ b/app/api/v1/endpoints/vitals.py
@@ -19,6 +19,7 @@ from app.api.v1.endpoints.utils import (
 )
 from app.crud.vitals import vitals
 from app.models.activity_log import EntityType
+from app.models.models import User
 from app.schemas.vitals import VitalsCreate, VitalsResponse, VitalsStats, VitalsUpdate
 
 router = APIRouter()
@@ -147,6 +148,8 @@ def update_vitals(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Update vitals reading."""
     return handle_update_with_logging(
@@ -158,6 +161,8 @@ def update_vitals(
         user_id=current_user_id,
         entity_name="Vitals",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 
@@ -168,6 +173,8 @@ def delete_vitals(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Delete a vitals reading."""
     return handle_delete_with_logging(
@@ -178,6 +185,8 @@ def delete_vitals(
         user_id=current_user_id,
         entity_name="Vitals",
         request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
     )
 
 

--- a/tests/api/test_allergies.py
+++ b/tests/api/test_allergies.py
@@ -455,6 +455,10 @@ class TestAllergiesAPI:
         patient1 = patient_crud.create_for_user(
             db_session, user_id=user1_data["user"].id, patient_data=patient1_data
         )
+        # Set active patient for multi-patient system
+        user1_data["user"].active_patient_id = patient1.id
+        db_session.commit()
+        db_session.refresh(user1_data["user"])
         headers1 = create_user_token_headers(user1_data["user"].username)
 
         user2_data = create_random_user(db_session)
@@ -467,6 +471,10 @@ class TestAllergiesAPI:
         patient2 = patient_crud.create_for_user(
             db_session, user_id=user2_data["user"].id, patient_data=patient2_data
         )
+        # Set active patient for multi-patient system
+        user2_data["user"].active_patient_id = patient2.id
+        db_session.commit()
+        db_session.refresh(user2_data["user"])
         headers2 = create_user_token_headers(user2_data["user"].username)
 
         # User1 creates an allergy
@@ -476,7 +484,7 @@ class TestAllergiesAPI:
             "reaction": "Confidential reaction",
             "onset_date": "2023-01-15",
             "status": "active",
-            "patient_id": user_with_patient["patient"].id
+            "patient_id": patient1.id
         }
 
         create_response = client.post(

--- a/tests/api/test_medications.py
+++ b/tests/api/test_medications.py
@@ -289,18 +289,14 @@ class TestMedicationAPI:
         )
         assert response.status_code == 404
 
-        # User2 tries to update User1's medication - should fail
-        # TODO: PRODUCTION BUG - This currently returns 200 (succeeds) instead of 404
-        # See TECHNICAL_DEBT.md: "Patient Data Isolation Bypass in UPDATE Endpoints"
-        # This is a CRITICAL SECURITY VULNERABILITY that needs to be fixed
+        # User2 tries to update User1's medication - should fail with 404
         update_response = client.put(
             f"/api/v1/medications/{medication_id}",
             json={"dosage": "200mg"},
             headers=headers2
         )
-        # TEMPORARY: Expecting 200 due to production bug (should be 404)
-        assert update_response.status_code == 200, \
-            "SECURITY BUG: User2 can update User1's medication! This should return 404."
+        assert update_response.status_code == 404, \
+            "User2 should NOT be able to update User1's medication"
 
     def test_medication_search_and_filtering(self, client: TestClient, user_with_patient, authenticated_headers):
         """Test medication search and filtering capabilities."""


### PR DESCRIPTION
  SECURITY FIX - Critical vulnerability where users could modify/delete
  other users' medical records through UPDATE and DELETE operations.

  Root Cause:
  - UPDATE/DELETE endpoints checked record existence but NOT ownership
  - Users could modify any patient's data by knowing the record ID
  - Affected all 14 patient-specific medical record endpoints

  Fix Implementation:
  - Modified verify_patient_record_access() to accept dynamic permission parameter
  - Updated handle_update_with_logging() to verify ownership BEFORE updating
  - Updated handle_delete_with_logging() to verify ownership BEFORE deleting
  - Added current_user and current_user_patient_id to all UPDATE/DELETE endpoints
  - Ownership verification now checks permission level (edit=2 required)

  Endpoints Secured (14 files):
  - medication, allergy, procedure, condition, immunization, vitals
  - symptom, treatment, lab_result, encounter, emergency_contact
  - family_member (including family_condition), insurance

  Tests:
  - Fixed test_allergy_patient_isolation (undefined variable + missing active_patient_id)
  - Updated test_medication_patient_isolation expectations (404 instead of 200)
  - All 8 patient isolation security tests now PASSING

  Files Modified:
  - app/api/deps.py (verify_patient_record_access)
  - app/api/v1/endpoints/utils.py (handle_update/delete_with_logging)
  - app/api/v1/endpoints/*.py (14 endpoint files)
  - tests/api/test_allergies.py (test fixes)
  - tests/api/test_medications.py (test expectations)
  - docs/working_docs/TECHNICAL_DEBT.md (marked as RESOLVED)