### PR TITLE
fix/ emergency contact ordering

### DIFF
--- a/app/crud/emergency_contact.py
+++ b/app/crud/emergency_contact.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
 from app.crud.base import CRUDBase
@@ -120,17 +121,24 @@ class CRUDEmergencyContact(
         """
         Get all active emergency contacts for a patient.
 
+        Returns contacts ordered by primary status (primary first),
+        then alphabetically by name.
+
         Args:
             db: Database session
             patient_id: ID of the patient
 
         Returns:
-            List of active emergency contacts
+            List of active emergency contacts ordered by is_primary DESC, name ASC
         """
-        return self.query(
-            db=db,
-            filters={"patient_id": patient_id, "is_active": True},
-            order_by=[("-is_primary", "name")],
+        return (
+            db.query(self.model)
+            .filter(
+                self.model.patient_id == patient_id,
+                self.model.is_active == True
+            )
+            .order_by(desc(self.model.is_primary), self.model.name)
+            .all()
         )
 
 


### PR DESCRIPTION
This pull request updates the logic for retrieving active emergency contacts for a patient, ensuring the contacts are returned in a more meaningful order. Now, primary contacts are listed first, followed by others sorted alphabetically by name.

**Improvements to emergency contact retrieval:**

* The `get_active_contacts` method in `app/crud/emergency_contact.py` now returns contacts ordered by primary status (primary contacts first) and then by name alphabetically, improving usability for users viewing emergency contacts.
* Added import of `desc` from SQLAlchemy to support ordering by descending primary status.