### PR TITLE
fix: correct emergency contacts API test routes to use dependency injection

### DIFF
--- a/tests/api/test_emergency_contacts.py
+++ b/tests/api/test_emergency_contacts.py
@@ -89,7 +89,7 @@ class TestEmergencyContactAPI:
             created_contacts.append(response.json())
 
         # Get contacts for patient
-        response = authenticated_client.get(f"/api/v1/emergency-contacts/?patient_id={patient.id}")
+        response = authenticated_client.get("/api/v1/emergency-contacts/")
 
         assert response.status_code == 200
         data = response.json()
@@ -262,7 +262,7 @@ class TestEmergencyContactAPI:
             assert response.status_code == 200
 
         # Get active contacts only
-        response = authenticated_client.get(f"/api/v1/emergency-contacts/?patient_id={patient.id}&is_active=true")
+        response = authenticated_client.get("/api/v1/emergency-contacts/?is_active=true")
 
         assert response.status_code == 200
         data = response.json()
@@ -330,7 +330,7 @@ class TestEmergencyContactAPI:
         patient = test_patient_for_contacts
 
         # Test without authentication
-        response = client.get(f"/api/v1/emergency-contacts/?patient_id={patient.id}")
+        response = client.get("/api/v1/emergency-contacts/")
         assert response.status_code == 401
 
         # Test creating contact without auth


### PR DESCRIPTION
This pull request updates several tests in `tests/api/test_emergency_contacts.py` to remove the use of the `patient_id` query parameter in API requests when fetching emergency contacts. The main goal is to simplify the test cases and align them with updated endpoint requirements or expected usage.

Test updates:

* Emergency contact retrieval tests now use the endpoint `/api/v1/emergency-contacts/` without the `patient_id` query parameter. [[1]](diffhunk://#diff-44cd63908b118717ff9253e75c52348a2476d8752da62947f950582fa98b2e51L92-R92) [[2]](diffhunk://#diff-44cd63908b118717ff9253e75c52348a2476d8752da62947f950582fa98b2e51L333-R333)
* The test for fetching only active contacts now omits the `patient_id` parameter and uses only `is_active=true` in the query string.