### PR TITLE
fix: remove trailing slashes from lab result file upload test URLs

### DIFF
--- a/tests/api/test_lab_results.py
+++ b/tests/api/test_lab_results.py
@@ -97,7 +97,7 @@ class TestLabResultsAPI:
         }
 
         upload_response = client.post(
-            f"/api/v1/lab-results/{lab_result_id}/files/",
+            f"/api/v1/lab-results/{lab_result_id}/files",
             files=files,
             headers=authenticated_headers
         )
@@ -283,7 +283,7 @@ class TestLabResultsAPI:
         }
 
         upload_response = client.post(
-            f"/api/v1/lab-results/{lab_result_id}/files/",
+            f"/api/v1/lab-results/{lab_result_id}/files",
             files=files,
             headers=authenticated_headers
         )


### PR DESCRIPTION
Fixed 2 failing lab results tests by removing trailing slashes from file upload endpoint URLs. The tests were calling `/api/v1/lab-results/{id}/files/` but the endpoint is registered as `/api/v1/lab-results/{id}/files` without a trailing slash.