### PR TITLE
feat: add A1C measurement support in vitals tracking

### DIFF
--- a/alembic/migrations/versions/20251122_1200_add_a1c_to_vitals_table.py
+++ b/alembic/migrations/versions/20251122_1200_add_a1c_to_vitals_table.py
@@ -1,0 +1,29 @@
+"""Add a1c to vitals table
+
+Revision ID: add_a1c_to_vitals
+Revises: c57de5762af1
+Create Date: 2025-11-22 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_a1c_to_vitals'
+down_revision = 'c57de5762af1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add a1c column to vitals table (Hemoglobin A1C percentage)
+    op.add_column(
+        'vitals',
+        sa.Column('a1c', sa.Float(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    # Remove a1c column from vitals table
+    op.drop_column('vitals', 'a1c')

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -900,6 +900,7 @@ class Vitals(Base):
     oxygen_saturation = Column(Float, nullable=True)  # SpO2 percentage
     respiratory_rate = Column(Integer, nullable=True)  # Breaths per minute
     blood_glucose = Column(Float, nullable=True)  # Blood glucose (mg/dL)
+    a1c = Column(Float, nullable=True)  # Hemoglobin A1C (%)
 
     # Additional measurements
     bmi = Column(Float, nullable=True)  # Body Mass Index (calculated)

--- a/app/schemas/vitals.py
+++ b/app/schemas/vitals.py
@@ -17,6 +17,7 @@ class VitalsBase(BaseModel):
     oxygen_saturation: Optional[float] = None
     respiratory_rate: Optional[int] = None
     blood_glucose: Optional[float] = None
+    a1c: Optional[float] = None
     bmi: Optional[float] = None
     pain_scale: Optional[int] = None
     notes: Optional[str] = None
@@ -99,6 +100,14 @@ class VitalsBase(BaseModel):
                 raise ValueError("Blood glucose must be between 20-800 mg/dL")
         return v
 
+    @validator("a1c")
+    def validate_a1c(cls, v):
+        """Validate hemoglobin A1C (%)"""
+        if v is not None:
+            if v < 0.0 or v > 20.0:
+                raise ValueError("A1C must be between 0-20%")
+        return v
+
     @validator("bmi")
     def validate_bmi(cls, v):
         """Validate BMI"""
@@ -156,6 +165,7 @@ class VitalsUpdate(BaseModel):
     oxygen_saturation: Optional[float] = None
     respiratory_rate: Optional[int] = None
     blood_glucose: Optional[float] = None
+    a1c: Optional[float] = None
     bmi: Optional[float] = None
     pain_scale: Optional[int] = None
     notes: Optional[str] = None
@@ -215,6 +225,8 @@ class VitalsStats(BaseModel):
     current_weight: Optional[float] = None
     current_bmi: Optional[float] = None
     weight_change: Optional[float] = None  # Change from first to latest reading
+    current_blood_glucose: Optional[float] = None
+    current_a1c: Optional[float] = None
 
     class Config:
         from_attributes = True

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -80,7 +80,28 @@
   "vitals": {
     "form": {
       "selectDate": "Select date",
-      "selectDateTime": "Select date and time"
+      "selectDateTime": "Select date and time",
+      "validation": {
+        "bloodGlucoseMin": "Blood glucose must be at least 20 mg/dL",
+        "bloodGlucoseMax": "Blood glucose cannot exceed 800 mg/dL",
+        "a1cMin": "A1C must be at least 0%",
+        "a1cMax": "A1C cannot exceed 20%"
+      }
+    },
+    "modal": {
+      "bloodGlucose": "Blood Glucose",
+      "a1c": "A1C"
+    },
+    "units": {
+      "mgdl": "mg/dL"
+    },
+    "stats": {
+      "bloodGlucoseDesc": "Click to filter records with blood glucose",
+      "a1cDesc": "Click to filter records with A1C"
+    },
+    "categories": {
+      "prediabetes": "Pre-diabetes",
+      "diabetes": "Diabetes"
     }
   },
   "medications": {

--- a/frontend/src/components/medical/VitalsForm.jsx
+++ b/frontend/src/components/medical/VitalsForm.jsx
@@ -115,7 +115,7 @@ const VitalsForm = ({
     additional: {
       title: t('vitals.modal.additionalMeasurements', 'Additional Measurements'),
       icon: IconDropletFilled,
-      fields: ['blood_glucose', 'pain_scale'],
+      fields: ['blood_glucose', 'a1c', 'pain_scale'],
       description: t('vitals.form.additionalMeasurementsDesc', 'Supplementary health indicators'),
     },
     metadata: {
@@ -274,6 +274,20 @@ const VitalsForm = ({
           max: { value: 800, message: t('vitals.form.validation.bloodGlucoseMax', 'Blood glucose cannot exceed 800 mg/dL') },
         },
       },
+      a1c: {
+        label: t('vitals.modal.a1c', 'A1C'),
+        type: 'number',
+        unit: '%',
+        placeholder: '5.7',
+        icon: IconDropletFilled,
+        min: 0,
+        max: 20,
+        step: 0.1,
+        validation: {
+          min: { value: 0, message: t('vitals.form.validation.a1cMin', 'A1C must be at least 0%') },
+          max: { value: 20, message: t('vitals.form.validation.a1cMax', 'A1C cannot exceed 20%') },
+        },
+      },
       pain_scale: {
         label: t('vitals.modal.painScale', 'Pain Scale'),
         type: 'number',
@@ -344,6 +358,7 @@ const VitalsForm = ({
     respiratory_rate: '',
     oxygen_saturation: '',
     blood_glucose: '',
+    a1c: '',
     pain_scale: '',
     location: '',
     device_used: '',
@@ -382,6 +397,7 @@ const VitalsForm = ({
         respiratory_rate: vitals.respiratory_rate || '',
         oxygen_saturation: vitals.oxygen_saturation || '',
         blood_glucose: vitals.blood_glucose || '',
+        a1c: vitals.a1c || '',
         pain_scale: vitals.pain_scale || '',
         location: vitals.location || '',
         device_used: vitals.device_used || '',
@@ -532,6 +548,9 @@ const VitalsForm = ({
           : null,
         blood_glucose: formData.blood_glucose
           ? parseFloat(formData.blood_glucose)
+          : null,
+        a1c: formData.a1c
+          ? parseFloat(formData.a1c)
           : null,
         pain_scale: formData.pain_scale ? parseInt(formData.pain_scale) : null,
         // Text fields

--- a/frontend/src/components/medical/VitalsList.jsx
+++ b/frontend/src/components/medical/VitalsList.jsx
@@ -376,6 +376,12 @@ const VitalsList = ({
             unit: selectedVital.blood_glucose ? 'mg/dL' : '',
           },
           {
+            label: 'A1C',
+            value: selectedVital.a1c || 'N/A',
+            icon: IconDroplet,
+            unit: selectedVital.a1c ? '%' : '',
+          },
+          {
             label: 'Pain Scale',
             value:
               selectedVital.pain_scale !== null
@@ -617,6 +623,28 @@ const VitalsList = ({
         )}
       </Table.Td>
       <Table.Td>
+        {vital.blood_glucose ? (
+          <Text size="sm" fw={500}>
+            {vital.blood_glucose} mg/dL
+          </Text>
+        ) : (
+          <Text size="sm" c="dimmed">
+            N/A
+          </Text>
+        )}
+      </Table.Td>
+      <Table.Td>
+        {vital.a1c ? (
+          <Text size="sm" fw={500}>
+            {vital.a1c}%
+          </Text>
+        ) : (
+          <Text size="sm" c="dimmed">
+            N/A
+          </Text>
+        )}
+      </Table.Td>
+      <Table.Td>
         {vital.oxygen_saturation ? (
           <Text size="sm" fw={500}>
             {vital.oxygen_saturation}%
@@ -719,6 +747,22 @@ const VitalsList = ({
                 <Table.Th>
                   <ThComponent sorted="bmi" onSort={() => handleSort('bmi')}>
                     {t('vitals.stats.bmi', 'BMI')}
+                  </ThComponent>
+                </Table.Th>
+                <Table.Th>
+                  <ThComponent
+                    sorted="blood_glucose"
+                    onSort={() => handleSort('blood_glucose')}
+                  >
+                    {t('vitals.modal.bloodGlucose', 'Glucose')}
+                  </ThComponent>
+                </Table.Th>
+                <Table.Th>
+                  <ThComponent
+                    sorted="a1c"
+                    onSort={() => handleSort('a1c')}
+                  >
+                    {t('vitals.modal.a1c', 'A1C')}
                   </ThComponent>
                 </Table.Th>
                 <Table.Th>

--- a/frontend/src/components/medical/vital/VitalViewModal.jsx
+++ b/frontend/src/components/medical/vital/VitalViewModal.jsx
@@ -164,6 +164,12 @@ const VitalViewModal = ({
           unit: vital.blood_glucose ? t('vitals.units.mgdl', 'mg/dL') : '',
         },
         {
+          label: t('vitals.modal.a1c', 'A1C'),
+          value: vital.a1c || t('labels.notAvailable', 'N/A'),
+          icon: IconDroplet,
+          unit: vital.a1c ? '%' : '',
+        },
+        {
           label: t('vitals.modal.painScale', 'Pain Scale'),
           value: vital.pain_scale !== null ? `${vital.pain_scale}/10` : t('labels.notAvailable', 'N/A'),
           icon: IconMoodSad,

--- a/frontend/src/constants/vitalFilters.js
+++ b/frontend/src/constants/vitalFilters.js
@@ -9,6 +9,8 @@ export const VITAL_FILTER_TYPES = {
   WITH_HEART_RATE: 'with_heart_rate',
   WITH_TEMPERATURE: 'with_temperature',
   WITH_WEIGHT: 'with_weight',
+  WITH_BLOOD_GLUCOSE: 'with_blood_glucose',
+  WITH_A1C: 'with_a1c',
   WITH_VITALS: 'with_vitals',
   COMPLETE: 'complete',
 };
@@ -19,6 +21,8 @@ export const VITAL_FILTER_LABELS = {
   [VITAL_FILTER_TYPES.WITH_HEART_RATE]: 'With Heart Rate',
   [VITAL_FILTER_TYPES.WITH_TEMPERATURE]: 'With Temperature',
   [VITAL_FILTER_TYPES.WITH_WEIGHT]: 'With Weight',
+  [VITAL_FILTER_TYPES.WITH_BLOOD_GLUCOSE]: 'With Blood Glucose',
+  [VITAL_FILTER_TYPES.WITH_A1C]: 'With A1C',
   [VITAL_FILTER_TYPES.WITH_VITALS]: 'With Core Vitals',
   [VITAL_FILTER_TYPES.COMPLETE]: 'Complete Records',
 };

--- a/frontend/src/pages/medical/Vitals.jsx
+++ b/frontend/src/pages/medical/Vitals.jsx
@@ -36,6 +36,7 @@ import {
   IconPlus,
   IconAlertTriangle,
   IconCheck,
+  IconDroplet,
 } from '@tabler/icons-react';
 import { PageHeader } from '../../components';
 import MantineFilters from '../../components/mantine/MantineFilters';
@@ -126,6 +127,34 @@ const Vitals = () => {
       color: 'yellow',
       filterType: VITAL_FILTER_TYPES.WITH_WEIGHT,
       description: t('vitals.stats.bmiDesc', 'Click to filter records with weight measurements')
+    },
+    blood_glucose: {
+      title: t('vitals.modal.bloodGlucose', 'Blood Glucose'),
+      icon: IconDroplet,
+      getValue: stats =>
+        stats.current_blood_glucose ? stats.current_blood_glucose.toFixed(0) : t('labels.notAvailable', 'N/A'),
+      getUnit: () => t('vitals.units.mgdl', 'mg/dL'),
+      getCategory: stats => {
+        if (!stats.current_blood_glucose) return null;
+        const glucose = stats.current_blood_glucose;
+        if (glucose < 70) return t('vitals.categories.low', 'Low');
+        if (glucose > 180) return t('vitals.categories.high', 'High');
+        return t('vitals.categories.normal', 'Normal');
+      },
+      color: 'orange',
+      filterType: VITAL_FILTER_TYPES.WITH_BLOOD_GLUCOSE,
+      description: t('vitals.stats.bloodGlucoseDesc', 'Click to filter records with blood glucose')
+    },
+    a1c: {
+      title: t('vitals.modal.a1c', 'A1C'),
+      icon: IconChartBar,
+      getValue: stats =>
+        stats.current_a1c ? stats.current_a1c.toFixed(1) : t('labels.notAvailable', 'N/A'),
+      getUnit: () => '%',
+      getCategory: () => null,
+      color: 'pink',
+      filterType: VITAL_FILTER_TYPES.WITH_A1C,
+      description: t('vitals.stats.a1cDesc', 'Click to filter records with A1C')
     },
   }), [t]);
   const navigate = useNavigate();

--- a/frontend/src/services/medical/vitalsService.jsx
+++ b/frontend/src/services/medical/vitalsService.jsx
@@ -251,6 +251,20 @@ class VitalsService {
       }
     }
 
+    // Blood glucose validation
+    if (vitalsData.blood_glucose) {
+      if (vitalsData.blood_glucose < 20 || vitalsData.blood_glucose > 800) {
+        errors.blood_glucose = 'Blood glucose must be between 20-800 mg/dL';
+      }
+    }
+
+    // A1C validation
+    if (vitalsData.a1c) {
+      if (vitalsData.a1c < 0 || vitalsData.a1c > 20) {
+        errors.a1c = 'A1C must be between 0-20%';
+      }
+    }
+
     // Add warnings for unusual values
     if (vitalsData.systolic_bp && vitalsData.diastolic_bp) {
       const bpCategory = this.getBloodPressureCategory(

--- a/frontend/src/utils/medicalPageConfigs.js
+++ b/frontend/src/utils/medicalPageConfigs.js
@@ -1035,6 +1035,8 @@ export const medicalPageConfigs = {
         { value: 'with_heart_rate', label: 'With Heart Rate' },
         { value: 'with_temperature', label: 'With Temperature' },
         { value: 'with_weight', label: 'With Weight' },
+        { value: 'with_blood_glucose', label: 'With Blood Glucose' },
+        { value: 'with_a1c', label: 'With A1C' },
         { value: 'with_vitals', label: 'With Core Vitals' },
         { value: 'complete', label: 'Complete Records' },
       ],
@@ -1049,6 +1051,10 @@ export const medicalPageConfigs = {
               return item.temperature != null;
             case 'with_weight':
               return item.weight != null;
+            case 'with_blood_glucose':
+              return item.blood_glucose != null;
+            case 'with_a1c':
+              return item.a1c != null;
             case 'with_vitals':
               return (
                 (item.systolic_bp != null && item.diastolic_bp != null) ||


### PR DESCRIPTION
This pull request adds support for tracking Hemoglobin A1C (%) as a new vital measurement throughout the backend and frontend of the application. It introduces the `a1c` field to the database, API schemas, business logic, and user interface, including validation and filtering capabilities. The changes ensure that A1C values can be created, updated, displayed, filtered, and validated in a manner consistent with other vital measurements.

**Backend changes:**

* Added an `a1c` column (Hemoglobin A1C %) to the `vitals` table via Alembic migration (`alembic/migrations/versions/20251122_1200_add_a1c_to_vitals_table.py`).
* Updated the `Vitals` model, API schemas (`VitalsBase`, `VitalsUpdate`, `VitalsStats`), and CRUD logic to support the new `a1c` field, including retrieval, statistics calculation, and validation (range 0-20%). [[1]](diffhunk://#diff-6136b7719b4607d189578925ce8b2785a6304e57812f17d99ebbb90a11fe4867R903) [[2]](diffhunk://#diff-e014c0bd5cb77cd4f28fa5be1be9f78d2529e7f0fa971214374b7a54d216d465R20) [[3]](diffhunk://#diff-e014c0bd5cb77cd4f28fa5be1be9f78d2529e7f0fa971214374b7a54d216d465R103-R110) [[4]](diffhunk://#diff-e014c0bd5cb77cd4f28fa5be1be9f78d2529e7f0fa971214374b7a54d216d465R168) [[5]](diffhunk://#diff-e014c0bd5cb77cd4f28fa5be1be9f78d2529e7f0fa971214374b7a54d216d465R228-R229) [[6]](diffhunk://#diff-7f1e67ef5db1937e5ff51a76f899dafbf9e1d189205a701c158b74d5048ee0aeR82-R83) [[7]](diffhunk://#diff-7f1e67ef5db1937e5ff51a76f899dafbf9e1d189205a701c158b74d5048ee0aeR108-R109) [[8]](diffhunk://#diff-7f1e67ef5db1937e5ff51a76f899dafbf9e1d189205a701c158b74d5048ee0aeR214-R239) [[9]](diffhunk://#diff-7f1e67ef5db1937e5ff51a76f899dafbf9e1d189205a701c158b74d5048ee0aeR258-R259)

**Frontend changes:**

* Added A1C input to the vitals form, list, modal, and validation messages, ensuring users can enter and view A1C values, with appropriate validation and display logic. [[1]](diffhunk://#diff-9fb74c081b44298f080800971e2baf7b42b0df8606714cd81abec508ce9f9467L118-R118) [[2]](diffhunk://#diff-9fb74c081b44298f080800971e2baf7b42b0df8606714cd81abec508ce9f9467R277-R290) [[3]](diffhunk://#diff-9fb74c081b44298f080800971e2baf7b42b0df8606714cd81abec508ce9f9467R361) [[4]](diffhunk://#diff-9fb74c081b44298f080800971e2baf7b42b0df8606714cd81abec508ce9f9467R400) [[5]](diffhunk://#diff-9fb74c081b44298f080800971e2baf7b42b0df8606714cd81abec508ce9f9467R552-R554) [[6]](diffhunk://#diff-f96b10f07ef0a79da16591d6d443831f32669844baedf57dbb42109bdd4e0fe1R378-R383) [[7]](diffhunk://#diff-f96b10f07ef0a79da16591d6d443831f32669844baedf57dbb42109bdd4e0fe1R625-R646) [[8]](diffhunk://#diff-f96b10f07ef0a79da16591d6d443831f32669844baedf57dbb42109bdd4e0fe1R752-R767) [[9]](diffhunk://#diff-09cfc8a62b712084b0aab98244b991e9feb799aa8429338e9422c8ff83e2f768R166-R171) [[10]](diffhunk://#diff-33c499047fc22cc766f0d8b1be2a6103ce9c582c107b84d8219031120f04bd7aL83-R104) [[11]](diffhunk://#diff-5d2f9f91a682ca94c9164f527570b98a8459ecf291fb3f8472e8169151ad2904R254-R267)

**Filtering and statistics:**

* Introduced new filter types and labels for A1C and blood glucose, allowing users to filter records by the presence of these measurements in both backend and frontend filtering logic. [[1]](diffhunk://#diff-c441b53cbca3548d2b4bf60a191e0c072853487f422df00f6930c2d94beebf88R12-R13) [[2]](diffhunk://#diff-c441b53cbca3548d2b4bf60a191e0c072853487f422df00f6930c2d94beebf88R24-R25) [[3]](diffhunk://#diff-1883bea589ffd8ccbd105ae1de1bda91b514008b72ab1fd9067c6d2976e73f2cR1038-R1039) [[4]](diffhunk://#diff-1883bea589ffd8ccbd105ae1de1bda91b514008b72ab1fd9067c6d2976e73f2cR1054-R1057) [[5]](diffhunk://#diff-07d7432d5811f272fc7f3d8293d3cd902a4377b5e4c1406322761c7195a3510fR131-R158)

**Testing:**

* Updated API tests to include the new A1C field in vital creation requests.