### PR TITLE
fix: update procedure date field in ProcedureFormWrapper component

### DIFF
--- a/frontend/src/components/medical/procedures/ProcedureFormWrapper.jsx
+++ b/frontend/src/components/medical/procedures/ProcedureFormWrapper.jsx
@@ -192,10 +192,10 @@ const ProcedureFormWrapper = ({
                   <Grid.Col span={{ base: 12, sm: 6 }}>
                     <DateInput
                       label={t('procedures.form.procedureDate', 'Procedure Date')}
-                      value={parseDateInput(formData.date)}
+                      value={parseDateInput(formData.procedure_date)}
                       onChange={(date) => {
                         const formattedDate = formatDateInputChange(date);
-                        onInputChange({ target: { name: 'date', value: formattedDate } });
+                        onInputChange({ target: { name: 'procedure_date', value: formattedDate } });
                       }}
                       placeholder={t('procedures.form.procedureDatePlaceholder', 'Select procedure date')}
                       description={t('procedures.form.procedureDateDesc', 'When the procedure was performed')}


### PR DESCRIPTION
This pull request updates the procedure date field in the procedure form to use a more consistent naming convention. The field name and its usage have been changed from `date` to `procedure_date` to improve clarity and maintain consistency across the codebase. 

* Updated the `DateInput` component in `ProcedureFormWrapper.jsx` to use `formData.procedure_date` instead of `formData.date`, and changed the input change handler to use the `procedure_date` field name.