### PR TITLE
fix: update date handling in medical forms

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -363,7 +363,7 @@ function App() {
               <MantineProvider theme={theme}>
                 <Notifications />
                 <ResponsiveProvider>
-                  <DatesProvider settings={{ timezone: 'UTC' }}>
+                  <DatesProvider settings={{}}>
                     <MantineIntegratedThemeProvider>
                     <NavigationTracker />
                     {/* <ActivityTracker /> */}

--- a/frontend/src/components/medical/MantineMedicationForm.jsx
+++ b/frontend/src/components/medical/MantineMedicationForm.jsx
@@ -22,7 +22,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { medicationFormFields } from '../../utils/medicalFormFields';
 import { useFormHandlers } from '../../hooks/useFormHandlers';
-import { formatDateInputChange } from '../../utils/dateUtils';
+import { formatDateInputChange, parseDateInput } from '../../utils/dateUtils';
 import FormLoadingOverlay from '../shared/FormLoadingOverlay';
 import DocumentManagerWithProgress from '../shared/DocumentManagerWithProgress';
 import { TagInput } from '../common/TagInput';
@@ -155,7 +155,7 @@ const MantineMedicationForm = ({
         return (
           <DateInput
             {...commonProps}
-            value={formData[field.name] ? new Date(formData[field.name]) : null}
+            value={parseDateInput(formData[field.name])}
             onChange={(date) => {
               const formattedDate = formatDateInputChange(date);
               onInputChange({ target: { name: field.name, value: formattedDate } });

--- a/frontend/src/components/medical/MantineVisitForm.jsx
+++ b/frontend/src/components/medical/MantineVisitForm.jsx
@@ -24,7 +24,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { visitFormFields } from '../../utils/medicalFormFields';
 import { useFormHandlers } from '../../hooks/useFormHandlers';
-import { formatDateInputChange } from '../../utils/dateUtils';
+import { formatDateInputChange, parseDateInput } from '../../utils/dateUtils';
 import { translateFieldConfig } from '../../utils/formFieldTranslations';
 import FormLoadingOverlay from '../shared/FormLoadingOverlay';
 import DocumentManagerWithProgress from '../shared/DocumentManagerWithProgress';
@@ -149,7 +149,7 @@ const MantineVisitForm = ({
         return (
           <DateInput
             {...commonProps}
-            value={formData[translatedField.name] ? new Date(formData[translatedField.name]) : null}
+            value={parseDateInput(formData[translatedField.name])}
             onChange={(date) => {
               const formattedDate = formatDateInputChange(date);
               onInputChange({ target: { name: translatedField.name, value: formattedDate } });

--- a/frontend/src/components/medical/insurance/InsuranceFormWrapper.jsx
+++ b/frontend/src/components/medical/insurance/InsuranceFormWrapper.jsx
@@ -26,7 +26,7 @@ import {
 } from '@tabler/icons-react';
 import { getFormFields } from '../../../utils/medicalFormFields';
 import { formatPhoneInput, cleanPhoneNumber, isValidPhoneNumber, isPhoneField } from '../../../utils/phoneUtils';
-import { formatDateInputChange } from '../../../utils/dateUtils';
+import { formatDateInputChange, parseDateInput } from '../../../utils/dateUtils';
 import { useFormHandlers } from '../../../hooks/useFormHandlers';
 import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
 import DocumentManagerWithProgress from '../../shared/DocumentManagerWithProgress';
@@ -421,7 +421,7 @@ const InsuranceFormWrapper = ({
         return (
           <DateInput
             {...commonProps}
-            value={formData[field.name] ? new Date(formData[field.name]) : null}
+            value={parseDateInput(formData[field.name])}
             onChange={(date) => {
               const formattedDate = formatDateInputChange(date);
               onInputChange({ target: { name: field.name, value: formattedDate } });

--- a/frontend/src/utils/medicalFormFields.js
+++ b/frontend/src/utils/medicalFormFields.js
@@ -8,9 +8,7 @@ import {
   MEDICATION_TYPE_LABELS,
 } from '../constants/medicationTypes';
 import { getTimeOfDayOptions } from '../constants/symptomEnums';
-
-// Static date reference for maxDate validation (prevents creating new Date on each render)
-const TODAY = new Date();
+import { getTodayEndOfDay } from './dateUtils';
 
 // Add tags field configuration that can be used across all forms
 const tagsFieldConfig = {
@@ -78,7 +76,7 @@ export const allergyFormFields = [
     placeholder: 'When did this allergy first occur',
     description: 'When this allergy was first discovered',
     gridColumn: 6,
-    maxDate: TODAY, // Can't be in the future
+    maxDate: getTodayEndOfDay, // Can't be in the future
   },
   {
     name: 'medication_id',
@@ -164,7 +162,7 @@ export const conditionFormFields = [
     description: 'When this condition was first diagnosed',
     gridColumn: 6,
 
-    maxDate: TODAY,
+    maxDate: getTodayEndOfDay,
   },
   {
     name: 'end_date',
@@ -173,7 +171,7 @@ export const conditionFormFields = [
     placeholder: 'When was this condition resolved',
     description: 'When this condition was resolved (optional)',
     gridColumn: 6,
-    maxDate: TODAY,
+    maxDate: getTodayEndOfDay,
   },
   {
     name: 'icd10_code',
@@ -903,7 +901,7 @@ export const visitFormFields = [
     required: true,
     description: 'When the visit occurred',
     gridColumn: 6,
-    maxDate: TODAY,
+    maxDate: getTodayEndOfDay,
   },
   {
     name: 'practitioner_id',
@@ -2084,7 +2082,7 @@ export const symptomParentFormFields = [
     required: true,
     description: 'When you first noticed this symptom',
     gridColumn: 6,
-    maxDate: TODAY,
+    maxDate: getTodayEndOfDay,
   },
   {
     name: 'status',
@@ -2150,7 +2148,7 @@ export const symptomOccurrenceFormFields = [
     required: true,
     description: 'Date of this specific episode',
     gridColumn: 6,
-    maxDate: TODAY,
+    maxDate: getTodayEndOfDay,
   },
   {
     name: 'time_of_day',
@@ -2271,7 +2269,7 @@ export const symptomOccurrenceFormFields = [
     placeholder: 'When did this episode resolve',
     description: 'Leave blank if still experiencing this episode',
     gridColumn: 6,
-    maxDate: TODAY,
+    maxDate: getTodayEndOfDay,
   },
   {
     name: 'resolution_notes',


### PR DESCRIPTION
This pull request improves date handling across several medical forms in the frontend codebase. The main changes include standardizing date parsing for form fields, updating how maximum selectable dates are set to ensure consistency, and cleaning up date utility usage.

**Date handling improvements:**

* Replaced direct `new Date(...)` conversion with the new `parseDateInput` utility in the `MantineMedicationForm`, `MantineVisitForm`, and `InsuranceFormWrapper` components to ensure consistent date parsing for form inputs. [[1]](diffhunk://#diff-4f21a36e6027585e468c9b11e62d561d2d126f613dbeb657a550370bc951a873L158-R158) [[2]](diffhunk://#diff-f8854d7f7161198fd74d5ca904558b2766ef9f65b229399692f00d80d1a39cb5L152-R152) [[3]](diffhunk://#diff-3bdf00dd356bc7905a362373f20ea729d9002fc0830ca1e6ef4547741fbaaf89L424-R424)
* Updated imports in the above components to include `parseDateInput` from `dateUtils`. [[1]](diffhunk://#diff-4f21a36e6027585e468c9b11e62d561d2d126f613dbeb657a550370bc951a873L25-R25) [[2]](diffhunk://#diff-f8854d7f7161198fd74d5ca904558b2766ef9f65b229399692f00d80d1a39cb5L27-R27) [[3]](diffhunk://#diff-3bdf00dd356bc7905a362373f20ea729d9002fc0830ca1e6ef4547741fbaaf89L29-R29)

**Date validation consistency:**

* Replaced static `TODAY` date references with the new `getTodayEndOfDay` utility in all form field definitions (`medicalFormFields.js`), ensuring that users cannot select future dates and that the max date is always up-to-date. [[1]](diffhunk://#diff-e397b56eeff492829735ccf9a62a4523635e0b99ead94c1f6fb1799be3e95111L81-R79) [[2]](diffhunk://#diff-e397b56eeff492829735ccf9a62a4523635e0b99ead94c1f6fb1799be3e95111L167-R165) [[3]](diffhunk://#diff-e397b56eeff492829735ccf9a62a4523635e0b99ead94c1f6fb1799be3e95111L176-R174) [[4]](diffhunk://#diff-e397b56eeff492829735ccf9a62a4523635e0b99ead94c1f6fb1799be3e95111L906-R904) [[5]](diffhunk://#diff-e397b56eeff492829735ccf9a62a4523635e0b99ead94c1f6fb1799be3e95111L2087-R2085) [[6]](diffhunk://#diff-e397b56eeff492829735ccf9a62a4523635e0b99ead94c1f6fb1799be3e95111L2153-R2151) [[7]](diffhunk://#diff-e397b56eeff492829735ccf9a62a4523635e0b99ead94c1f6fb1799be3e95111L2274-R2272)
* Updated imports in `medicalFormFields.js` to use `getTodayEndOfDay` instead of a static date.

**Provider configuration:**

* Changed the `DatesProvider` settings in `App.jsx` to use an empty object rather than a fixed UTC timezone, potentially allowing for more flexible date handling based on user or system settings.