### PR TITLE
refactor: remove unused SPA routing setup from main.py

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,6 @@ from app.core.logging.middleware import RequestLoggingMiddleware
 from app.core.http.middleware import TrailingSlashMiddleware
 from app.core.logging.activity_middleware import ActivityTrackingMiddleware
 from app.core.logging.request_id_middleware import RequestIDMiddleware
-from app.core.http.spa_routing import setup_spa_routing
 from app.core.startup import startup_event
 from app.core.http.static_files import setup_static_files
 from app.core.logging.uvicorn_logging import configure_uvicorn_logging
@@ -65,7 +64,3 @@ def health():
         "Health check requested", extra={"category": "app", "event": "health_check"}
     )
     return {"status": "ok", "app": settings.APP_NAME, "version": settings.VERSION}
-
-
-# Setup SPA routing (only activates if React build exists)
-setup_spa_routing(app, static_dir, html_dir)


### PR DESCRIPTION
This pull request removes the duplicate setup for SPA (Single Page Application) routing from the application startup process. The code related to importing and calling `setup_spa_routing` has been deleted, meaning the app will no longer automatically configure SPA routing, even if a React build exists.

Removals related to SPA routing:

* Removed the import of `setup_spa_routing` from `app.core.http.spa_routing` in `app/main.py`.
* Deleted the call to `setup_spa_routing(app, static_dir, html_dir)` from the end of `app/main.py`, so SPA routing is no longer set up during app initialization.