### PR TITLE
fix: corrected vitals page to follow units setting

### DIFF
--- a/frontend/src/components/medical/VitalsList.jsx
+++ b/frontend/src/components/medical/VitalsList.jsx
@@ -58,6 +58,7 @@ import { useUserPreferences } from '../../contexts/UserPreferencesContext';
 import {
   formatMeasurement,
   convertForDisplay,
+  unitLabels,
 } from '../../utils/unitConversion';
 import {
   formatDate as formatDateHelper,
@@ -324,9 +325,18 @@ const VitalsList = ({
           },
           {
             label: 'Temperature',
-            value: selectedVital.temperature || 'N/A',
+            value: selectedVital.temperature
+              ? formatMeasurement(
+                  convertForDisplay(selectedVital.temperature, 'temperature', unitSystem),
+                  'temperature',
+                  unitSystem,
+                  false
+                )
+              : 'N/A',
             icon: IconThermometer,
-            unit: selectedVital.temperature ? '°F' : '',
+            unit: selectedVital.temperature
+              ? unitLabels[unitSystem].temperature
+              : '',
           },
           {
             label: 'Respiratory Rate',
@@ -348,9 +358,18 @@ const VitalsList = ({
         items: [
           {
             label: 'Weight',
-            value: selectedVital.weight || 'N/A',
+            value: selectedVital.weight
+              ? formatMeasurement(
+                  convertForDisplay(selectedVital.weight, 'weight', unitSystem),
+                  'weight',
+                  unitSystem,
+                  false
+                )
+              : 'N/A',
             icon: IconWeight,
-            unit: selectedVital.weight ? 'lbs' : '',
+            unit: selectedVital.weight
+              ? unitLabels[unitSystem].weight
+              : '',
           },
           {
             label: 'Height',

--- a/frontend/src/components/medical/vital/VitalCard.jsx
+++ b/frontend/src/components/medical/vital/VitalCard.jsx
@@ -5,6 +5,8 @@ import BaseMedicalCard from '../base/BaseMedicalCard';
 import { formatDate } from '../../../utils/helpers';
 import { navigateToEntity } from '../../../utils/linkNavigation';
 import logger from '../../../services/logger';
+import { useUserPreferences } from '../../../contexts/UserPreferencesContext';
+import { formatMeasurement, convertForDisplay } from '../../../utils/unitConversion';
 
 const VitalCard = ({
   vital,
@@ -16,6 +18,7 @@ const VitalCard = ({
   onError
 }) => {
   const { t } = useTranslation('common');
+  const { unitSystem } = useUserPreferences();
 
   const handleError = (error) => {
     logger.error('vital_card_error', {
@@ -70,12 +73,20 @@ const VitalCard = ({
       {
         label: t('vitals.stats.temperature', 'Temperature'),
         value: vital.temperature,
-        render: (value) => value ? `${value}${t('vitals.units.fahrenheit', '°F')}` : t('vitals.card.notRecorded', 'Not recorded')
+        render: (value) => value ? formatMeasurement(
+          convertForDisplay(value, 'temperature', unitSystem),
+          'temperature',
+          unitSystem
+        ) : t('vitals.card.notRecorded', 'Not recorded')
       },
       {
         label: t('vitals.stats.weight', 'Weight'),
         value: vital.weight,
-        render: (value) => value ? `${value} ${t('vitals.units.lbs', 'lbs')}` : t('vitals.card.notRecorded', 'Not recorded')
+        render: (value) => value ? formatMeasurement(
+          convertForDisplay(value, 'weight', unitSystem),
+          'weight',
+          unitSystem
+        ) : t('vitals.card.notRecorded', 'Not recorded')
       },
       {
         label: t('vitals.card.oxygenSaturation', 'Oxygen Saturation'),

--- a/frontend/src/pages/medical/Vitals.jsx
+++ b/frontend/src/pages/medical/Vitals.jsx
@@ -53,9 +53,12 @@ import { useDataManagement } from '../../hooks/useDataManagement';
 import { getMedicalPageConfig } from '../../utils/medicalPageConfigs';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { VITAL_FILTER_TYPES } from '../../constants/vitalFilters';
+import { useUserPreferences } from '../../contexts/UserPreferencesContext';
+import { convertForDisplay, unitLabels } from '../../utils/unitConversion';
 
 const Vitals = () => {
   const { t } = useTranslation('common');
+  const { unitSystem } = useUserPreferences();
 
   // Quick stats card configurations with Mantine icons and filter mappings
   const STATS_CONFIGS = useMemo(() => ({
@@ -93,8 +96,10 @@ const Vitals = () => {
       title: t('vitals.stats.temperature', 'Latest Temperature'),
       icon: IconTrendingUp,
       getValue: stats =>
-        stats.current_temperature ? stats.current_temperature.toFixed(1) : t('labels.notAvailable', 'N/A'),
-      getUnit: () => t('vitals.units.fahrenheit', '°F'),
+        stats.current_temperature
+          ? convertForDisplay(stats.current_temperature, 'temperature', unitSystem).toFixed(1)
+          : t('labels.notAvailable', 'N/A'),
+      getUnit: () => unitLabels[unitSystem].temperature,
       getCategory: stats => {
         if (!stats.current_temperature) return null;
         const temp = stats.current_temperature;
@@ -110,8 +115,10 @@ const Vitals = () => {
       title: t('vitals.stats.weight', 'Latest Weight'),
       icon: IconTrendingUp,
       getValue: stats =>
-        stats.current_weight ? stats.current_weight.toFixed(1) : t('labels.notAvailable', 'N/A'),
-      getUnit: () => t('vitals.units.lbs', 'lbs'),
+        stats.current_weight
+          ? convertForDisplay(stats.current_weight, 'weight', unitSystem).toFixed(1)
+          : t('labels.notAvailable', 'N/A'),
+      getUnit: () => unitLabels[unitSystem].weight,
       getCategory: () => null,
       color: 'violet',
       filterType: VITAL_FILTER_TYPES.WITH_WEIGHT,
@@ -156,7 +163,7 @@ const Vitals = () => {
       filterType: VITAL_FILTER_TYPES.WITH_A1C,
       description: t('vitals.stats.a1cDesc', 'Click to filter records with A1C')
     },
-  }), [t]);
+  }), [t, unitSystem]);
   const navigate = useNavigate();
   const location = useLocation();
 


### PR DESCRIPTION
This pull request updates how temperature and weight values are displayed across the vitals-related components to consistently respect the user's preferred unit system (e.g., metric or imperial). The changes ensure that both the values and their units are dynamically converted and labeled based on user preferences, improving the accuracy and user experience of medical data presentation.

**Vitals value formatting and unit display improvements:**

* [`frontend/src/components/medical/VitalsList.jsx`](diffhunk://#diff-f96b10f07ef0a79da16591d6d443831f32669844baedf57dbb42109bdd4e0fe1R61): Updated temperature and weight display logic to convert values and show units according to the user's selected unit system using `convertForDisplay`, `formatMeasurement`, and `unitLabels`. [[1]](diffhunk://#diff-f96b10f07ef0a79da16591d6d443831f32669844baedf57dbb42109bdd4e0fe1R61) [[2]](diffhunk://#diff-f96b10f07ef0a79da16591d6d443831f32669844baedf57dbb42109bdd4e0fe1L327-R339) [[3]](diffhunk://#diff-f96b10f07ef0a79da16591d6d443831f32669844baedf57dbb42109bdd4e0fe1L351-R372)
* [`frontend/src/components/medical/vital/VitalCard.jsx`](diffhunk://#diff-ede44ada65703f298d9bc409fc3e97134a6f62c48ef2391b12d66a2c1dce9f7bR8-R9): Modified temperature and weight rendering to use the same conversion and formatting utilities, ensuring consistency with the user's unit preferences. [[1]](diffhunk://#diff-ede44ada65703f298d9bc409fc3e97134a6f62c48ef2391b12d66a2c1dce9f7bR8-R9) [[2]](diffhunk://#diff-ede44ada65703f298d9bc409fc3e97134a6f62c48ef2391b12d66a2c1dce9f7bR21) [[3]](diffhunk://#diff-ede44ada65703f298d9bc409fc3e97134a6f62c48ef2391b12d66a2c1dce9f7bL73-R89)
* [`frontend/src/pages/medical/Vitals.jsx`](diffhunk://#diff-07d7432d5811f272fc7f3d8293d3cd902a4377b5e4c1406322761c7195a3510fR56-R61): Updated quick stats card logic to convert and format temperature and weight values and units dynamically based on user preferences, and ensured memoization dependencies include the unit system. [[1]](diffhunk://#diff-07d7432d5811f272fc7f3d8293d3cd902a4377b5e4c1406322761c7195a3510fR56-R61) [[2]](diffhunk://#diff-07d7432d5811f272fc7f3d8293d3cd902a4377b5e4c1406322761c7195a3510fL96-R102) [[3]](diffhunk://#diff-07d7432d5811f272fc7f3d8293d3cd902a4377b5e4c1406322761c7195a3510fL113-R121) [[4]](diffhunk://#diff-07d7432d5811f272fc7f3d8293d3cd902a4377b5e4c1406322761c7195a3510fL159-R166)experience across components.