### PR TITLE
fix: LanguageSwitcher component switch consistency 

### DIFF
--- a/app/schemas/user_preferences.py
+++ b/app/schemas/user_preferences.py
@@ -4,7 +4,7 @@ from typing import Optional
 from pydantic import BaseModel, field_validator, ValidationInfo
 
 # Supported languages - single source of truth
-SUPPORTED_LANGUAGES = ["en", "fr", "de"]
+SUPPORTED_LANGUAGES = ["en", "fr", "de", "es", "it", "pt"]
 
 
 class UserPreferencesBase(BaseModel):

--- a/frontend/src/contexts/UserPreferencesContext.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.jsx
@@ -9,7 +9,7 @@ import { PAPERLESS_SETTING_DEFAULTS } from '../constants/paperlessSettings';
 import i18n from '../i18n';
 
 // Supported languages - must match backend validation
-const SUPPORTED_LANGUAGES = ['en', 'fr', 'de'];
+const SUPPORTED_LANGUAGES = ['en', 'fr', 'de', 'es', 'it', 'pt'];
 
 /**
  * User Preferences Context
@@ -86,12 +86,9 @@ export const UserPreferencesProvider = ({ children }) => {
       setLoading(false);
       setError(null);
 
-      // Only log logout if we're not in the initial loading state
-      if (!authLoading) {
-        frontendLogger.logInfo('User logged out, clearing preferences', {
-          component: 'UserPreferencesContext',
-        });
-      }
+      frontendLogger.logInfo('User logged out, clearing preferences', {
+        component: 'UserPreferencesContext',
+      });
     }
   }, [isAuthenticated, user?.id, authLoading]); // Depend on authentication state, user ID, and auth loading state
 

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -12,6 +12,10 @@ i18n
     fallbackLng: 'en',
     debug: isDevelopment(),
 
+    // Only load the primary language code (e.g., 'en' not 'en-US')
+    // This ensures i18n.language always matches our supported language codes
+    load: 'languageOnly',
+
     ns: ['common', 'medical', 'errors', 'navigation'],
     defaultNS: 'common',
 


### PR DESCRIPTION
This pull request expands language support and improves the language switching experience in the application. The main changes include adding new supported languages, updating the language switcher component for better UI responsiveness and robustness, and ensuring language code consistency across the frontend and backend. 

**Expanded language support:**

* Added Spanish (`es`), Italian (`it`), and Portuguese (`pt`) to the list of supported languages in both backend (`SUPPORTED_LANGUAGES` in `user_preferences.py`) and frontend (`SUPPORTED_LANGUAGES` in `UserPreferencesContext.jsx`). [[1]](diffhunk://#diff-b448b0cdd9571e72517c5253a26776ba2da704873639dd2f08d5e3f39547bfecL7-R7) [[2]](diffhunk://#diff-2a6ed226e1ba43eb965757dce729ace2aeca04a192834b8c881f6e09bb692458L12-R12)

**Language switcher improvements:**

* Refactored `LanguageSwitcher.tsx` to use a centralized `LANGUAGES` array, normalize language codes (handling cases like `en-US`), and ensure immediate UI feedback via local state. The component now prevents race conditions during async language changes and handles errors more gracefully, reverting the UI if a change fails. [[1]](diffhunk://#diff-2e1894ba7ca4dc48421f9a43118637be82ccaefa755e37b90a94045389e552e8R19-R49) [[2]](diffhunk://#diff-2e1894ba7ca4dc48421f9a43118637be82ccaefa755e37b90a94045389e552e8L34-R139)
* The language switcher now displays all supported languages and uses short labels in compact mode.

**Internationalization consistency:**

* Configured i18n to use only primary language codes (e.g., `en` instead of `en-US`) to ensure consistency with supported language codes throughout the app.

**Minor context improvements:**

* Cleaned up logging logic in `UserPreferencesContext.jsx` by removing unnecessary conditional checks around logout logging.