### PR TITLE
fix: rename filename variable to backup_filename to account for LogRecord attribute conflict

### DIFF
--- a/app/api/v1/admin/backup.py
+++ b/app/api/v1/admin/backup.py
@@ -83,7 +83,7 @@ async def create_database_backup(
             f"Database backup created: {backup_result['filename']}",
             user_id=current_user.id,
             backup_id=backup_result["id"],
-            filename=backup_result["filename"],
+            backup_filename=backup_result["filename"],
             size_bytes=backup_result["size_bytes"]
         )
 
@@ -136,7 +136,7 @@ async def create_files_backup(
             f"Files backup created: {backup_result['filename']}",
             user_id=current_user.id,
             backup_id=backup_result["id"],
-            filename=backup_result["filename"],
+            backup_filename=backup_result["filename"],
             size_bytes=backup_result["size_bytes"]
         )
 
@@ -189,7 +189,7 @@ async def create_full_backup(
             f"Full backup created: {backup_result['filename']}",
             user_id=current_user.id,
             backup_id=backup_result["id"],
-            filename=backup_result["filename"],
+            backup_filename=backup_result["filename"],
             size_bytes=backup_result["size_bytes"]
         )
 
@@ -289,7 +289,7 @@ async def download_backup(
             f"Backup downloaded: {backup['filename']}",
             user_id=current_user.id,
             backup_id=backup_id,
-            filename=backup["filename"]
+            backup_filename=backup["filename"]
         )
 
         return FileResponse(

--- a/app/api/v1/admin/restore.py
+++ b/app/api/v1/admin/restore.py
@@ -108,7 +108,7 @@ async def upload_backup_file(
                 f"Backup file uploaded: {file.filename}",
                 user_id=current_user.id,
                 username=current_user.username,
-                filename=file.filename,
+                backup_filename=file.filename,
                 backup_id=backup_record.id
             )
 

--- a/app/api/v1/endpoints/lab_result_file.py
+++ b/app/api/v1/endpoints/lab_result_file.py
@@ -132,7 +132,7 @@ async def upload_file(
         "lab_result_file_upload_started",
         message=f"Starting file upload for lab result {lab_result_id}",
         lab_result_id=lab_result_id,
-        filename=file.filename
+        uploaded_filename=file.filename
     )
 
     # Verify lab result exists


### PR DESCRIPTION
This pull request updates the naming of file-related parameters in several API endpoints to improve clarity and consistency, particularly distinguishing between backup files and uploaded files. The most significant changes involve renaming the `filename` parameter to either `backup_filename` or `uploaded_filename` in various logging and event calls.

**Backup-related parameter renaming:**

* Changed the parameter from `filename` to `backup_filename` when logging or handling backup creation, download, and upload events in `app/api/v1/admin/backup.py` and `app/api/v1/admin/restore.py` to clarify that the filename refers specifically to a backup file. [[1]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebL86-R86) [[2]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebL139-R139) [[3]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebL192-R192) [[4]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebL292-R292) [[5]](diffhunk://#diff-61ad9d9ccc0cd39de3b4c5324494f8926c52af4b2059e42cb810a09357a90b1fL111-R111)

**Lab result file upload parameter renaming:**

* Renamed the `filename` parameter to `uploaded_filename` in the event log for lab result file uploads in `app/api/v1/endpoints/lab_result_file.py` to better reflect its purpose.