### PR TITLE
fix: filtering and sorting logic in medical page configurations

### DIFF
--- a/frontend/src/hooks/useFiltering.js
+++ b/frontend/src/hooks/useFiltering.js
@@ -175,7 +175,11 @@ export const useFiltering = (data = [], config = {}) => {
           const currentMonthEnd = new Date(
             now.getFullYear(),
             now.getMonth() + 1,
-            0
+            0,
+            23,
+            59,
+            59,
+            999
           );
 
           // If item has both start and end dates, check for overlap

--- a/frontend/src/utils/medicalPageConfigs/emergencyContacts.js
+++ b/frontend/src/utils/medicalPageConfigs/emergencyContacts.js
@@ -76,7 +76,7 @@ export const emergencyContactsPageConfig = {
         }
         // Finally by name
         const nameDiff = a.name.localeCompare(b.name);
-        return sortOrder === 'asc' ? -nameDiff : nameDiff;
+        return sortOrder === 'asc' ? nameDiff : -nameDiff;
       },
     },
   },

--- a/frontend/src/utils/medicalPageConfigs/insurance.js
+++ b/frontend/src/utils/medicalPageConfigs/insurance.js
@@ -118,12 +118,12 @@ export const insurancesPageConfig = {
         const bStatusIndex = statusOrder.indexOf(b.status);
         const statusDiff = (aStatusIndex === -1 ? 999 : aStatusIndex) - (bStatusIndex === -1 ? 999 : bStatusIndex);
         if (statusDiff !== 0) {
-          return sortOrder === 'asc' ? -statusDiff : statusDiff;
+          return sortOrder === 'asc' ? statusDiff : -statusDiff;
         }
 
         // Finally by insurance type alphabetically
         const typeDiff = a.insurance_type.localeCompare(b.insurance_type);
-        return sortOrder === 'asc' ? -typeDiff : typeDiff;
+        return sortOrder === 'asc' ? typeDiff : -typeDiff;
       },
     },
   },

--- a/frontend/src/utils/medicalPageConfigs/labResults.js
+++ b/frontend/src/utils/medicalPageConfigs/labResults.js
@@ -96,7 +96,7 @@ export const labresultsPageConfig = {
       },
     ],
     // Additional filter: Lab Results
-    resultField: 'labs_result',
+    // Note: resultField removed - custom filter handles all result filtering including 'pending'
     resultLabel: 'Test Results',
     resultOptions: [
       { value: 'all', label: 'All Results' },

--- a/frontend/src/utils/medicalPageConfigs/medications.js
+++ b/frontend/src/utils/medicalPageConfigs/medications.js
@@ -56,7 +56,7 @@ export const medicationsPageConfig = {
         }
         // Then by medication name
         const nameDiff = a.medication_name.localeCompare(b.medication_name);
-        return sortOrder === 'asc' ? -nameDiff : nameDiff;
+        return sortOrder === 'asc' ? nameDiff : -nameDiff;
       },
     },
   },


### PR DESCRIPTION
This pull request refactors and enhances the sorting and filtering logic across several medical-related page configurations in the frontend. The main improvements include making all custom sort functions aware of the sort order (ascending or descending), standardizing sort logic, and clarifying filter and sort key names for better consistency and maintainability.

**Sorting logic improvements and standardization:**

* All custom sort functions in `emergencyContactsPageConfig`, `insurancesPageConfig`, `medicationsPageConfig`, and `labresultsPageConfig` now accept a `sortOrder` argument and use it to determine the direction of sorting, ensuring consistent ascending/descending behavior. [[1]](diffhunk://#diff-06102d3f2bc821c84e8724a24b364ef4cc1eb72956d74a637769c2529b49ef31L68-R79) [[2]](diffhunk://#diff-738f74fbf70b52991e8d57ad3976afe52d534b8dedfa7e928809dc2a0c371f70L107-R126) [[3]](diffhunk://#diff-a9a3c75e31c59951ffece5a535fb6ab306acea41b19a09196a326894654fe2caL50-R59) [[4]](diffhunk://#diff-6b24a230da3654b1b1ea3f38bb10a110b2513390752446d7715076dc1bdc946fL351-R370)
* The sorting logic has been standardized: for example, primary/active items are now sorted based on `sortOrder`, and alphabetical sorts invert the comparison when sorting in descending order. [[1]](diffhunk://#diff-06102d3f2bc821c84e8724a24b364ef4cc1eb72956d74a637769c2529b49ef31L68-R79) [[2]](diffhunk://#diff-738f74fbf70b52991e8d57ad3976afe52d534b8dedfa7e928809dc2a0c371f70L107-R126) [[3]](diffhunk://#diff-a9a3c75e31c59951ffece5a535fb6ab306acea41b19a09196a326894654fe2caL50-R59)

**Lab results configuration enhancements:**

* The sort and filter keys in `labresultsPageConfig` have been clarified and aligned: the filter function was renamed from `labs_result` to `result`, and the sort functions were renamed from `priority`/`result` to `test_type`/`labs_result` for clarity and consistency. [[1]](diffhunk://#diff-6b24a230da3654b1b1ea3f38bb10a110b2513390752446d7715076dc1bdc946fL278-R278) [[2]](diffhunk://#diff-6b24a230da3654b1b1ea3f38bb10a110b2513390752446d7715076dc1bdc946fL351-R370)
* The sort order logic for lab test types, results, and statuses has been refactored for clarity and to ensure correct behavior when values are missing or unrecognized.

**Filtering improvements:**

* Added a new `'current_month'` filter option in the `useFiltering` hook to allow filtering items by the current calendar month.