### PR TITLE
fix:  add disableCardClick prop to BaseMedicalCard and FamilyHistoryCard

### DIFF
--- a/frontend/src/components/medical/base/BaseMedicalCard.jsx
+++ b/frontend/src/components/medical/base/BaseMedicalCard.jsx
@@ -21,7 +21,8 @@ const BaseMedicalCard = ({
   onDelete,
   entityType,
   children,
-  onError
+  onError,
+  disableCardClick = false
 }) => {
   const { t } = useTranslation('common');
   const handleError = (error, action) => {
@@ -68,8 +69,8 @@ const BaseMedicalCard = ({
         shadow="sm"
         radius="md"
         h="100%"
-        className="clickable-card"
-        onClick={createCardClickHandler(safeOnView)}
+        className={disableCardClick ? undefined : "clickable-card"}
+        onClick={disableCardClick ? undefined : createCardClickHandler(safeOnView)}
         style={{
           display: 'flex',
           flexDirection: 'column',

--- a/frontend/src/components/medical/family-history/FamilyHistoryCard.jsx
+++ b/frontend/src/components/medical/family-history/FamilyHistoryCard.jsx
@@ -489,6 +489,7 @@ const FamilyHistoryCard = ({
           onEdit={!member.is_shared ? handleEditClick : undefined}
           onDelete={!member.is_shared ? handleDeleteClick : undefined}
           onError={handleError}
+          disableCardClick={bulkSelectionMode}
         >
           {conditionsContent}
           {additionalActionsContent}


### PR DESCRIPTION
This pull request introduces an enhancement to the `BaseMedicalCard` component, allowing its clickability to be conditionally disabled. This change is primarily aimed at supporting scenarios such as bulk selection mode in the `FamilyHistoryCard`, where card clicks should not trigger their default behavior.

**Component behavior improvements:**

* Added a new `disableCardClick` prop (defaulting to `false`) to the `BaseMedicalCard` component, enabling conditional disabling of the card's click event and related styling.
* Updated the card's rendering logic to omit the `clickable-card` class and `onClick` handler when `disableCardClick` is `true`.

**Usage updates:**

* Passed the `bulkSelectionMode` flag as the `disableCardClick` prop to `BaseMedicalCard` from within `FamilyHistoryCard`, ensuring cards are not clickable during bulk selection.