### PR TITLE
 fix: correct wrong column names in search API

### DIFF
--- a/app/api/v1/endpoints/search.py
+++ b/app/api/v1/endpoints/search.py
@@ -193,9 +193,9 @@ def search_patient_records(
         )
 
         if sort == "date_desc":
-            conditions_query = conditions_query.order_by(Condition.diagnosed_date.desc())
+            conditions_query = conditions_query.order_by(Condition.onset_date.desc())
         elif sort == "date_asc":
-            conditions_query = conditions_query.order_by(Condition.diagnosed_date.asc())
+            conditions_query = conditions_query.order_by(Condition.onset_date.asc())
 
         cond_count = conditions_query.count()
         conditions = conditions_query.offset(skip).limit(limit).all()
@@ -209,7 +209,7 @@ def search_patient_records(
                     condition_name=cond.condition_name,
                     diagnosis=cond.diagnosis,
                     status=cond.status,
-                    diagnosed_date=cond.diagnosed_date.isoformat() if cond.diagnosed_date else None,
+                    diagnosed_date=cond.onset_date.isoformat() if cond.onset_date else None,
                     tags=cond.tags or [],
                     highlight=cond.condition_name,
                     score=DEFAULT_SEARCH_SCORE
@@ -330,7 +330,7 @@ def search_patient_records(
                     type="immunization",
                     vaccine_name=imm.vaccine_name,
                     dose_number=imm.dose_number,
-                    status=imm.status,
+                    status=None,  # Immunization model has no status field
                     administered_date=imm.date_administered.isoformat() if imm.date_administered else None,
                     tags=imm.tags or [],
                     highlight=imm.vaccine_name,
@@ -440,9 +440,9 @@ def search_patient_records(
         )
 
         if sort == "date_desc":
-            allergies_query = allergies_query.order_by(Allergy.identified_date.desc())
+            allergies_query = allergies_query.order_by(Allergy.onset_date.desc())
         elif sort == "date_asc":
-            allergies_query = allergies_query.order_by(Allergy.identified_date.asc())
+            allergies_query = allergies_query.order_by(Allergy.onset_date.asc())
 
         allergy_count = allergies_query.count()
         allergies = allergies_query.offset(skip).limit(limit).all()
@@ -456,7 +456,7 @@ def search_patient_records(
                     allergen=allergy.allergen,
                     reaction=allergy.reaction,
                     severity=allergy.severity,
-                    identified_date=allergy.identified_date.isoformat() if allergy.identified_date else None,
+                    identified_date=allergy.onset_date.isoformat() if allergy.onset_date else None,
                     tags=allergy.tags or [],
                     highlight=allergy.allergen,
                     score=DEFAULT_SEARCH_SCORE

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -20,7 +20,6 @@ class TestSearchAPI:
     - populated_patient_data
     """
 
-    @pytest.mark.skip(reason="API bug: searching all types triggers conditions bug (diagnosed_date)")
     def test_search_basic_query(
         self, client: TestClient, populated_patient_data, authenticated_headers
     ):
@@ -56,7 +55,6 @@ class TestSearchAPI:
         found_items = [item for item in medications["items"] if "Lisinopril" in item["medication_name"]]
         assert len(found_items) > 0, "Search term not found in results"
 
-    @pytest.mark.skip(reason="API bug: Condition model uses 'onset_date' but search.py references 'diagnosed_date'")
     def test_search_conditions(
         self, client: TestClient, populated_patient_data, authenticated_headers
     ):
@@ -73,7 +71,6 @@ class TestSearchAPI:
         assert conditions["count"] >= 1
         assert any("Hypertension" in item["condition_name"] for item in conditions["items"])
 
-    @pytest.mark.skip(reason="API bug: Allergy model uses 'onset_date' but search.py references 'identified_date'")
     def test_search_allergies(
         self, client: TestClient, populated_patient_data, authenticated_headers
     ):
@@ -90,7 +87,6 @@ class TestSearchAPI:
         assert allergies["count"] >= 1
         assert any("Penicillin" in item["allergen"] for item in allergies["items"])
 
-    @pytest.mark.skip(reason="API bug: Immunization model has no 'status' attribute but search.py tries to access it")
     def test_search_immunizations(
         self, client: TestClient, populated_patient_data, authenticated_headers
     ):
@@ -107,7 +103,6 @@ class TestSearchAPI:
         assert immunizations["count"] >= 1
         assert any("COVID" in item["vaccine_name"] for item in immunizations["items"])
 
-    @pytest.mark.skip(reason="API bug: includes conditions which has 'diagnosed_date' bug")
     def test_search_multiple_types(
         self, client: TestClient, populated_patient_data, authenticated_headers
     ):
@@ -150,7 +145,6 @@ class TestSearchAPI:
         assert data["pagination"]["skip"] == 0
         assert data["pagination"]["limit"] == 1
 
-    @pytest.mark.skip(reason="API bug: date sorting triggers diagnosed_date/identified_date bugs in conditions/allergies")
     def test_search_sort_by_date_desc(
         self, client: TestClient, populated_patient_data, authenticated_headers
     ):
@@ -164,7 +158,6 @@ class TestSearchAPI:
         data = response.json()
         assert "results" in data
 
-    @pytest.mark.skip(reason="API bug: date sorting triggers diagnosed_date/identified_date bugs in conditions/allergies")
     def test_search_sort_by_date_asc(
         self, client: TestClient, populated_patient_data, authenticated_headers
     ):
@@ -178,7 +171,6 @@ class TestSearchAPI:
         data = response.json()
         assert "results" in data
 
-    @pytest.mark.skip(reason="API bug: search across all types triggers conditions/allergies/immunizations bugs")
     def test_search_sort_by_relevance(
         self, client: TestClient, populated_patient_data, authenticated_headers
     ):


### PR DESCRIPTION
This pull request updates the search API and its tests to use the correct date and status fields for conditions and allergies, and removes workarounds for previously misaligned model attributes. As a result, several tests that were previously skipped due to API bugs are now enabled.

**API fixes and field alignment:**

* Changed sorting and serialization in the search API to use `onset_date` instead of the incorrect `diagnosed_date` for `Condition` and `identified_date` for `Allergy` (`app/api/v1/endpoints/search.py`). [[1]](diffhunk://#diff-32fe9bd8e8051b8609d74f8acdcb8367125f7edc1a61902e5ba0370ae2134c82L196-R198) [[2]](diffhunk://#diff-32fe9bd8e8051b8609d74f8acdcb8367125f7edc1a61902e5ba0370ae2134c82L212-R212) [[3]](diffhunk://#diff-32fe9bd8e8051b8609d74f8acdcb8367125f7edc1a61902e5ba0370ae2134c82L443-R445) [[4]](diffhunk://#diff-32fe9bd8e8051b8609d74f8acdcb8367125f7edc1a61902e5ba0370ae2134c82L459-R459)
* Fixed immunization search result serialization to set `status=None` since the `Immunization` model does not have a `status` field (`app/api/v1/endpoints/search.py`).

**Test suite improvements:**

* Removed `@pytest.mark.skip` decorators from multiple tests now that the API bugs have been fixed, re-enabling tests for searching conditions, allergies, immunizations, sorting by date, and multi-type search (`tests/api/test_search.py`). [[1]](diffhunk://#diff-b3f6bf368f4c1db4f153b3d1f909c50aa1c06be9690210ced6bc4d79b4bd6aaaL23) [[2]](diffhunk://#diff-b3f6bf368f4c1db4f153b3d1f909c50aa1c06be9690210ced6bc4d79b4bd6aaaL59) [[3]](diffhunk://#diff-b3f6bf368f4c1db4f153b3d1f909c50aa1c06be9690210ced6bc4d79b4bd6aaaL76) [[4]](diffhunk://#diff-b3f6bf368f4c1db4f153b3d1f909c50aa1c06be9690210ced6bc4d79b4bd6aaaL93) [[5]](diffhunk://#diff-b3f6bf368f4c1db4f153b3d1f909c50aa1c06be9690210ced6bc4d79b4bd6aaaL110) [[6]](diffhunk://#diff-b3f6bf368f4c1db4f153b3d1f909c50aa1c06be9690210ced6bc4d79b4bd6aaaL153) [[7]](diffhunk://#diff-b3f6bf368f4c1db4f153b3d1f909c50aa1c06be9690210ced6bc4d79b4bd6aaaL167) [[8]](diffhunk://#diff-b3f6bf368f4c1db4f153b3d1f909c50aa1c06be9690210ced6bc4d79b4bd6aaaL181)