### PR TITLE
fix: update ChangePasswordModal CSS to correct cancel button

### DIFF
--- a/frontend/src/components/auth/ChangePasswordModal.css
+++ b/frontend/src/components/auth/ChangePasswordModal.css
@@ -66,13 +66,13 @@
   border-top: 1px solid var(--color-border-light, #f1f3f5);
 }
 
-/* Override global button width styles from Login.css */
+/* Ensure buttons use their natural width */
 .change-password-content .form-actions button,
 .change-password-content .form-actions .mantine-Button-root {
-  flex: 0 0 auto !important;
-  width: auto !important;
-  min-width: auto !important;
-  max-width: none !important;
+  flex: 0 0 auto;
+  width: auto;
+  min-width: auto;
+  max-width: none;
 }
 
 /* Alert spacing in modal */

--- a/frontend/src/components/auth/ProfileCompletionModal.css
+++ b/frontend/src/components/auth/ProfileCompletionModal.css
@@ -1,4 +1,5 @@
-.profile-completion-modal .modal-content {
+/* Target Mantine Modal content area */
+.profile-completion-modal .mantine-Modal-content {
   max-width: 500px;
 }
 

--- a/frontend/src/styles/pages/Login.css
+++ b/frontend/src/styles/pages/Login.css
@@ -177,10 +177,10 @@ button[type="submit"]:disabled {
   transform: none;
 }
 
-/* Make buttons equal fixed width - target both regular and Mantine buttons */
-.form-actions .btn,
-.form-actions button,
-.form-actions .mantine-Button-root {
+/* Make buttons equal fixed width - scoped to login container only */
+.login-container .form-actions .btn,
+.login-container .form-actions button,
+.login-container .form-actions .mantine-Button-root {
   flex: none !important;
   width: 200px !important;
   min-width: 200px !important;


### PR DESCRIPTION
This pull request updates the styles for the Change Password modal to improve spacing and ensure consistent button sizing, especially when using Mantine components. The main focus is on refining the layout and overriding conflicting global styles.

**Modal layout and spacing improvements:**

* Changed the padding for the modal body by targeting `.mantine-Modal-body` to ensure proper spacing inside the Change Password modal.

**Button and form styling adjustments:**

* Removed the `max-width` restriction from the password form to allow it to use the full available width.
* Added overrides for button width styles within `.change-password-content .form-actions` to prevent global styles (from `Login.css`) from affecting the modal's buttons, ensuring buttons have appropriate sizing.