### PR TITLE
feat: add pagination to VitalTrendTable component

### DIFF
--- a/frontend/src/components/medical/vitals/VitalTrendTable.tsx
+++ b/frontend/src/components/medical/vitals/VitalTrendTable.tsx
@@ -3,7 +3,7 @@
  * Displays historical vital sign data in a sortable table format
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import {
   Table,
   Text,
@@ -11,7 +11,10 @@ import {
   Group,
   UnstyledButton,
   Center,
-  ScrollArea
+  ScrollArea,
+  Stack,
+  Pagination,
+  Select,
 } from '@mantine/core';
 import { IconChevronUp, IconChevronDown, IconSelector } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
@@ -31,6 +34,16 @@ interface ThProps {
   reversed: boolean;
   onSort: () => void;
 }
+
+// Pagination constants
+const PAGE_SIZE_OPTIONS = [
+  { value: '10', label: '10' },
+  { value: '20', label: '20' },
+  { value: '25', label: '25' },
+  { value: '50', label: '50' },
+];
+const DEFAULT_PAGE_SIZE = 20;
+const VALID_PAGE_SIZES = [10, 20, 25, 50];
 
 function Th({ children, sorted, reversed, onSort }: ThProps) {
   const Icon = sorted ? (reversed ? IconChevronUp : IconChevronDown) : IconSelector;
@@ -56,6 +69,8 @@ const VitalTrendTable: React.FC<VitalTrendTableProps> = ({ trendData }) => {
   const { formatLongDate } = useDateFormat();
   const [sortField, setSortField] = useState<SortField>('date');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -86,6 +101,37 @@ const VitalTrendTable: React.FC<VitalTrendTableProps> = ({ trendData }) => {
 
     return data;
   }, [trendData.data_points, sortField, sortDirection]);
+
+  // Calculate pagination values
+  const totalRecords = sortedData.length;
+  const totalPages = Math.max(1, Math.ceil(totalRecords / pageSize));
+  const startIndex = (currentPage - 1) * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, totalRecords);
+
+  // Paginated data
+  const paginatedData = useMemo(() => {
+    return sortedData.slice(startIndex, endIndex);
+  }, [sortedData, startIndex, endIndex]);
+
+  // Reset to page 1 when sort or data changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [sortField, sortDirection, trendData.data_points]);
+
+  // Ensure currentPage stays valid when data changes
+  useEffect(() => {
+    if (currentPage > totalPages && totalPages > 0) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const handlePageSizeChange = (value: string | null) => {
+    if (value === null) return;
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue) || !VALID_PAGE_SIZES.includes(numericValue)) return;
+    setPageSize(numericValue);
+    setCurrentPage(1);
+  };
 
   if (trendData.data_points.length === 0) {
     return (
@@ -120,7 +166,7 @@ const VitalTrendTable: React.FC<VitalTrendTableProps> = ({ trendData }) => {
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
-            {sortedData.map((point: VitalDataPoint) => (
+            {paginatedData.map((point: VitalDataPoint) => (
               <Table.Tr key={point.id}>
                 <Table.Td>
                   <Text size="sm">{formatLongDate(point.recorded_date)}</Text>
@@ -141,6 +187,52 @@ const VitalTrendTable: React.FC<VitalTrendTableProps> = ({ trendData }) => {
           </Table.Tbody>
         </Table>
       </ScrollArea>
+
+      {/* Pagination Controls */}
+      {totalRecords > 0 && (
+        <Group justify={totalPages > 1 ? 'space-between' : 'flex-end'} align="center" mt="md" px="md" pb="md">
+          {/* Left: Record count (only show when multiple pages) */}
+          {totalPages > 1 && (
+            <Text size="sm" c="dimmed">
+              {t('pagination.showingRange', 'Showing {{start}} to {{end}} of {{total}} results', {
+                start: startIndex + 1,
+                end: endIndex,
+                total: totalRecords,
+              })}
+            </Text>
+          )}
+
+          {/* Center: Page navigation */}
+          {totalPages > 1 && (
+            <Pagination
+              total={totalPages}
+              value={currentPage}
+              onChange={setCurrentPage}
+              size="sm"
+              withEdges
+              siblings={1}
+              boundaries={1}
+            />
+          )}
+
+          {/* Right: Page size selector */}
+          <Group gap="xs">
+            <Text size="sm" c="dimmed">
+              {t('pagination.itemsPerPage', 'Items per page')}:
+            </Text>
+            <Select
+              value={String(pageSize)}
+              onChange={handlePageSizeChange}
+              data={PAGE_SIZE_OPTIONS}
+              size="xs"
+              w={70}
+              allowDeselect={false}
+              aria-label={t('pagination.itemsPerPage', 'Items per page')}
+              comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+            />
+          </Group>
+        </Group>
+      )}
     </Paper>
   );
 };


### PR DESCRIPTION
This pull request adds pagination support to the `VitalTrendTable` component, allowing users to control how many vital sign records are displayed per page and navigate through multiple pages of historical data. The update introduces new state management for page size and current page, ensures the table responds to sorting and data changes, and adds user interface controls for pagination.

**Pagination functionality and UI enhancements:**

* Added pagination state (`currentPage`, `pageSize`) and constants to support configurable page sizes and page navigation in `VitalTrendTable.tsx`. [[1]](diffhunk://#diff-db3fa12ca36c835760fefcc9dee62dfa5537b675abafe643cb4337edf8ce487aR38-R47) [[2]](diffhunk://#diff-db3fa12ca36c835760fefcc9dee62dfa5537b675abafe643cb4337edf8ce487aR72-R73)
* Implemented logic to slice sorted data for pagination and reset or validate page state when sorting or data changes.
* Updated table rendering to display only the records for the current page, improving performance and usability for large datasets.
* Added pagination controls below the table: record count, page navigation, and a selector for items per page, using Mantine `Pagination` and `Select` components.
* Improved imports and UI structure to support new pagination features and maintain code clarity.