### PR TITLE
fix: ensure practitioner_id is a string in LabResults component

### DIFF
--- a/frontend/src/pages/medical/LabResults.jsx
+++ b/frontend/src/pages/medical/LabResults.jsx
@@ -282,7 +282,7 @@ const LabResults = () => {
       ordered_date: labResult.ordered_date || '',
       completed_date: labResult.completed_date || '',
       notes: labResult.notes || '',
-      practitioner_id: labResult.practitioner_id || '',
+      practitioner_id: labResult.practitioner_id ? String(labResult.practitioner_id) : '',
       tags: labResult.tags || [],
     });
 


### PR DESCRIPTION
This pull request makes a small adjustment to the `LabResults` component to ensure that the `practitioner_id` field is always stored as a string, even if it was previously a number or undefined. This helps maintain consistency in how the ID is handled throughout the application.