### PR TITLE
feature: expand treatments into comprehensive treatment plans system

### DIFF
--- a/alembic/migrations/versions/20260204_1000_add_treatment_plan_relationship_tables.py
+++ b/alembic/migrations/versions/20260204_1000_add_treatment_plan_relationship_tables.py
@@ -1,0 +1,149 @@
+"""Add treatment plan relationship tables
+
+Revision ID: add_treatment_plan_tables
+Revises: 3a4ccf83e967
+Create Date: 2026-02-04 10:00:00.000000
+
+This migration adds:
+- medical_equipment: Track medical equipment (CPAP, inhalers, etc.)
+- treatment_medications: Junction table for treatment-medication relationships
+- treatment_encounters: Junction table for treatment-encounter relationships
+- treatment_lab_results: Junction table for treatment-lab result relationships
+- treatment_equipment: Junction table for treatment-equipment relationships
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_treatment_plan_tables'
+down_revision = 'a9b8c7d6e5f4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create medical_equipment table
+    op.create_table('medical_equipment',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('patient_id', sa.Integer(), nullable=False),
+        sa.Column('practitioner_id', sa.Integer(), nullable=True),
+        sa.Column('equipment_name', sa.String(), nullable=False),
+        sa.Column('equipment_type', sa.String(), nullable=False),
+        sa.Column('manufacturer', sa.String(), nullable=True),
+        sa.Column('model_number', sa.String(), nullable=True),
+        sa.Column('serial_number', sa.String(), nullable=True),
+        sa.Column('prescribed_date', sa.Date(), nullable=True),
+        sa.Column('last_service_date', sa.Date(), nullable=True),
+        sa.Column('next_service_date', sa.Date(), nullable=True),
+        sa.Column('usage_instructions', sa.String(), nullable=True),
+        sa.Column('status', sa.String(), nullable=False, server_default='active'),
+        sa.Column('supplier', sa.String(), nullable=True),
+        sa.Column('notes', sa.String(), nullable=True),
+        sa.Column('tags', sa.JSON(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['patient_id'], ['patients.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['practitioner_id'], ['practitioners.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index('idx_medical_equipment_patient_id', 'medical_equipment', ['patient_id'], unique=False)
+    op.create_index('idx_medical_equipment_status', 'medical_equipment', ['status'], unique=False)
+
+    # Create treatment_medications junction table
+    op.create_table('treatment_medications',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('treatment_id', sa.Integer(), nullable=False),
+        sa.Column('medication_id', sa.Integer(), nullable=False),
+        sa.Column('specific_dosage', sa.String(), nullable=True),
+        sa.Column('specific_frequency', sa.String(), nullable=True),
+        sa.Column('specific_duration', sa.String(), nullable=True),
+        sa.Column('timing_instructions', sa.String(), nullable=True),
+        sa.Column('relevance_note', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['treatment_id'], ['treatments.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['medication_id'], ['medications.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('treatment_id', 'medication_id', name='uq_treatment_medication')
+    )
+    op.create_index('idx_treatment_medication_treatment_id', 'treatment_medications', ['treatment_id'], unique=False)
+    op.create_index('idx_treatment_medication_medication_id', 'treatment_medications', ['medication_id'], unique=False)
+
+    # Create treatment_encounters junction table
+    op.create_table('treatment_encounters',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('treatment_id', sa.Integer(), nullable=False),
+        sa.Column('encounter_id', sa.Integer(), nullable=False),
+        sa.Column('visit_label', sa.String(), nullable=True),
+        sa.Column('visit_sequence', sa.Integer(), nullable=True),
+        sa.Column('relevance_note', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['treatment_id'], ['treatments.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['encounter_id'], ['encounters.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('treatment_id', 'encounter_id', name='uq_treatment_encounter')
+    )
+    op.create_index('idx_treatment_encounter_treatment_id', 'treatment_encounters', ['treatment_id'], unique=False)
+    op.create_index('idx_treatment_encounter_encounter_id', 'treatment_encounters', ['encounter_id'], unique=False)
+
+    # Create treatment_lab_results junction table
+    op.create_table('treatment_lab_results',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('treatment_id', sa.Integer(), nullable=False),
+        sa.Column('lab_result_id', sa.Integer(), nullable=False),
+        sa.Column('purpose', sa.String(), nullable=True),
+        sa.Column('expected_frequency', sa.String(), nullable=True),
+        sa.Column('relevance_note', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['treatment_id'], ['treatments.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['lab_result_id'], ['lab_results.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('treatment_id', 'lab_result_id', name='uq_treatment_lab_result')
+    )
+    op.create_index('idx_treatment_lab_result_treatment_id', 'treatment_lab_results', ['treatment_id'], unique=False)
+    op.create_index('idx_treatment_lab_result_lab_result_id', 'treatment_lab_results', ['lab_result_id'], unique=False)
+
+    # Create treatment_equipment junction table
+    op.create_table('treatment_equipment',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('treatment_id', sa.Integer(), nullable=False),
+        sa.Column('equipment_id', sa.Integer(), nullable=False),
+        sa.Column('usage_frequency', sa.String(), nullable=True),
+        sa.Column('specific_settings', sa.String(), nullable=True),
+        sa.Column('relevance_note', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['treatment_id'], ['treatments.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['equipment_id'], ['medical_equipment.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('treatment_id', 'equipment_id', name='uq_treatment_equipment')
+    )
+    op.create_index('idx_treatment_equipment_treatment_id', 'treatment_equipment', ['treatment_id'], unique=False)
+    op.create_index('idx_treatment_equipment_equipment_id', 'treatment_equipment', ['equipment_id'], unique=False)
+
+
+def downgrade() -> None:
+    # Drop junction tables first (due to foreign key dependencies)
+    op.drop_index('idx_treatment_equipment_equipment_id', table_name='treatment_equipment')
+    op.drop_index('idx_treatment_equipment_treatment_id', table_name='treatment_equipment')
+    op.drop_table('treatment_equipment')
+
+    op.drop_index('idx_treatment_lab_result_lab_result_id', table_name='treatment_lab_results')
+    op.drop_index('idx_treatment_lab_result_treatment_id', table_name='treatment_lab_results')
+    op.drop_table('treatment_lab_results')
+
+    op.drop_index('idx_treatment_encounter_encounter_id', table_name='treatment_encounters')
+    op.drop_index('idx_treatment_encounter_treatment_id', table_name='treatment_encounters')
+    op.drop_table('treatment_encounters')
+
+    op.drop_index('idx_treatment_medication_medication_id', table_name='treatment_medications')
+    op.drop_index('idx_treatment_medication_treatment_id', table_name='treatment_medications')
+    op.drop_table('treatment_medications')
+
+    # Drop medical_equipment table last
+    op.drop_index('idx_medical_equipment_status', table_name='medical_equipment')
+    op.drop_index('idx_medical_equipment_patient_id', table_name='medical_equipment')
+    op.drop_table('medical_equipment')

--- a/alembic/migrations/versions/20260204_1051_2afb50647b47_make_treatment_type_and_start_date_.py
+++ b/alembic/migrations/versions/20260204_1051_2afb50647b47_make_treatment_type_and_start_date_.py
@@ -1,0 +1,35 @@
+"""make_treatment_type_and_start_date_optional
+
+Revision ID: 2afb50647b47
+Revises: add_treatment_plan_tables
+Create Date: 2026-02-04 10:51:35.227585
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '2afb50647b47'
+down_revision = 'add_treatment_plan_tables'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Make treatment_type and start_date optional (nullable=True)
+    op.alter_column('treatments', 'treatment_type',
+               existing_type=sa.VARCHAR(),
+               nullable=True)
+    op.alter_column('treatments', 'start_date',
+               existing_type=sa.DATE(),
+               nullable=True)
+
+
+def downgrade() -> None:
+    # Revert to non-nullable (will fail if NULL values exist)
+    op.alter_column('treatments', 'start_date',
+               existing_type=sa.DATE(),
+               nullable=False)
+    op.alter_column('treatments', 'treatment_type',
+               existing_type=sa.VARCHAR(),
+               nullable=False)

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -21,6 +21,7 @@ from app.api.v1.endpoints import (
     lab_result,
     lab_result_file,
     lab_test_component,
+    medical_equipment,
     medication,
     notifications,
     paperless,
@@ -94,6 +95,7 @@ api_router.include_router(
 api_router.include_router(insurance.router, prefix="/insurances", tags=["insurance"])
 api_router.include_router(procedure.router, prefix="/procedures", tags=["procedures"])
 api_router.include_router(treatment.router, prefix="/treatments", tags=["treatments"])
+api_router.include_router(medical_equipment.router, prefix="/medical-equipment", tags=["medical-equipment"])
 api_router.include_router(allergy.router, prefix="/allergies", tags=["allergies"])
 api_router.include_router(vitals.router, prefix="/vitals", tags=["vitals"])
 api_router.include_router(symptom.router, prefix="/symptoms", tags=["symptoms"])

--- a/app/api/v1/endpoints/medical_equipment.py
+++ b/app/api/v1/endpoints/medical_equipment.py
@@ -1,0 +1,250 @@
+"""API endpoints for Medical Equipment."""
+from typing import Any, List, Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.orm import Session
+
+from app.api import deps
+from app.core.http.error_handling import handle_database_errors
+from app.core.logging.config import get_logger
+from app.core.logging.helpers import log_data_access
+from app.api.v1.endpoints.utils import (
+    handle_create_with_logging,
+    handle_delete_with_logging,
+    handle_not_found,
+    handle_update_with_logging,
+    verify_patient_ownership,
+)
+from app.crud.medical_equipment import medical_equipment
+from app.models.activity_log import EntityType
+from app.models.models import User
+from app.schemas.medical_equipment import (
+    MedicalEquipmentCreate,
+    MedicalEquipmentResponse,
+    MedicalEquipmentUpdate,
+    MedicalEquipmentWithRelations,
+    MedicalEquipmentSummary,
+)
+
+router = APIRouter()
+
+# Initialize logger
+logger = get_logger(__name__, "app")
+
+
+@router.post("/", response_model=MedicalEquipmentResponse)
+def create_medical_equipment(
+    *,
+    equipment_in: MedicalEquipmentCreate,
+    request: Request,
+    db: Session = Depends(deps.get_db),
+    current_user_id: int = Depends(deps.get_current_user_id),
+) -> Any:
+    """Create new medical equipment record."""
+    return handle_create_with_logging(
+        db=db,
+        crud_obj=medical_equipment,
+        obj_in=equipment_in,
+        entity_type=EntityType.MEDICAL_EQUIPMENT,
+        user_id=current_user_id,
+        entity_name="MedicalEquipment",
+        request=request,
+    )
+
+
+@router.get("/", response_model=List[MedicalEquipmentResponse])
+def read_medical_equipment(
+    *,
+    request: Request,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = Query(default=100, le=100),
+    status: Optional[str] = Query(None),
+    equipment_type: Optional[str] = Query(None),
+    tags: Optional[List[str]] = Query(None, description="Filter by tags"),
+    tag_match_all: bool = Query(False, description="Match all tags (AND) vs any tag (OR)"),
+    target_patient_id: int = Depends(deps.get_accessible_patient_id),
+    current_user_id: int = Depends(deps.get_current_user_id),
+) -> Any:
+    """Retrieve medical equipment for the current user or accessible patient."""
+    with handle_database_errors(request=request):
+        if tags:
+            filters = {"patient_id": target_patient_id}
+            if status:
+                filters["status"] = status
+            if equipment_type:
+                filters["equipment_type"] = equipment_type.lower()
+            equipment_list = medical_equipment.get_multi_with_tag_filters(
+                db,
+                tags=tags,
+                tag_match_all=tag_match_all,
+                skip=skip,
+                limit=limit,
+                **filters
+            )
+        elif equipment_type:
+            equipment_list = medical_equipment.get_by_type(
+                db,
+                patient_id=target_patient_id,
+                equipment_type=equipment_type,
+                skip=skip,
+                limit=limit,
+            )
+        else:
+            equipment_list = medical_equipment.get_by_patient(
+                db,
+                patient_id=target_patient_id,
+                skip=skip,
+                limit=limit,
+                status=status,
+            )
+
+        log_data_access(
+            logger,
+            request,
+            current_user_id,
+            "read",
+            "MedicalEquipment",
+            patient_id=target_patient_id,
+            count=len(equipment_list)
+        )
+
+        return equipment_list
+
+
+@router.get("/active", response_model=List[MedicalEquipmentResponse])
+def get_active_equipment(
+    *,
+    request: Request,
+    db: Session = Depends(deps.get_db),
+    target_patient_id: int = Depends(deps.get_accessible_patient_id),
+    current_user_id: int = Depends(deps.get_current_user_id),
+) -> Any:
+    """Get all active equipment for a patient."""
+    with handle_database_errors(request=request):
+        equipment_list = medical_equipment.get_active_equipment(
+            db, patient_id=target_patient_id
+        )
+
+        log_data_access(
+            logger,
+            request,
+            current_user_id,
+            "read",
+            "MedicalEquipment",
+            patient_id=target_patient_id,
+            count=len(equipment_list),
+            status="active"
+        )
+
+        return equipment_list
+
+
+@router.get("/needing-service", response_model=List[MedicalEquipmentResponse])
+def get_equipment_needing_service(
+    *,
+    request: Request,
+    db: Session = Depends(deps.get_db),
+    target_patient_id: int = Depends(deps.get_accessible_patient_id),
+    current_user_id: int = Depends(deps.get_current_user_id),
+) -> Any:
+    """Get equipment that needs service soon (within 30 days or overdue)."""
+    with handle_database_errors(request=request):
+        equipment_list = medical_equipment.get_needing_service(
+            db, patient_id=target_patient_id
+        )
+
+        log_data_access(
+            logger,
+            request,
+            current_user_id,
+            "read",
+            "MedicalEquipment",
+            patient_id=target_patient_id,
+            count=len(equipment_list),
+            filter="needing_service"
+        )
+
+        return equipment_list
+
+
+@router.get("/{equipment_id}", response_model=MedicalEquipmentWithRelations)
+def read_single_equipment(
+    *,
+    request: Request,
+    db: Session = Depends(deps.get_db),
+    equipment_id: int,
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user_id: int = Depends(deps.get_current_user_id),
+) -> Any:
+    """Get medical equipment by ID with related information."""
+    with handle_database_errors(request=request):
+        equipment_obj = medical_equipment.get_with_relations(
+            db=db,
+            record_id=equipment_id,
+            relations=["patient", "practitioner"],
+        )
+        handle_not_found(equipment_obj, "MedicalEquipment", request)
+        verify_patient_ownership(equipment_obj, current_user_patient_id, "medical equipment")
+
+        log_data_access(
+            logger,
+            request,
+            current_user_id,
+            "read",
+            "MedicalEquipment",
+            record_id=equipment_id,
+            patient_id=current_user_patient_id
+        )
+
+        return equipment_obj
+
+
+@router.put("/{equipment_id}", response_model=MedicalEquipmentResponse)
+def update_medical_equipment(
+    *,
+    equipment_id: int,
+    equipment_in: MedicalEquipmentUpdate,
+    request: Request,
+    db: Session = Depends(deps.get_db),
+    current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+) -> Any:
+    """Update medical equipment."""
+    return handle_update_with_logging(
+        db=db,
+        crud_obj=medical_equipment,
+        entity_id=equipment_id,
+        obj_in=equipment_in,
+        entity_type=EntityType.MEDICAL_EQUIPMENT,
+        user_id=current_user_id,
+        entity_name="MedicalEquipment",
+        request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
+    )
+
+
+@router.delete("/{equipment_id}")
+def delete_medical_equipment(
+    *,
+    equipment_id: int,
+    request: Request,
+    db: Session = Depends(deps.get_db),
+    current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+) -> Any:
+    """Delete medical equipment."""
+    return handle_delete_with_logging(
+        db=db,
+        crud_obj=medical_equipment,
+        entity_id=equipment_id,
+        entity_type=EntityType.MEDICAL_EQUIPMENT,
+        user_id=current_user_id,
+        entity_name="MedicalEquipment",
+        request=request,
+        current_user=current_user,
+        current_user_patient_id=current_user_patient_id,
+    )

--- a/app/crud/medical_equipment.py
+++ b/app/crud/medical_equipment.py
@@ -1,0 +1,140 @@
+"""CRUD operations for Medical Equipment."""
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.crud.base import CRUDBase
+from app.crud.base_tags import TagFilterMixin
+from app.models.models import MedicalEquipment
+from app.schemas.medical_equipment import MedicalEquipmentCreate, MedicalEquipmentUpdate
+
+
+class CRUDMedicalEquipment(
+    CRUDBase[MedicalEquipment, MedicalEquipmentCreate, MedicalEquipmentUpdate],
+    TagFilterMixin
+):
+    """
+    Medical Equipment-specific CRUD operations.
+
+    Handles medical equipment records like CPAP machines, nebulizers, etc.
+    """
+
+    def get_by_patient(
+        self,
+        db: Session,
+        *,
+        patient_id: int,
+        skip: int = 0,
+        limit: int = 100,
+        status: Optional[str] = None,
+    ) -> List[MedicalEquipment]:
+        """
+        Retrieve all equipment for a specific patient.
+
+        Args:
+            db: SQLAlchemy database session
+            patient_id: ID of the patient
+            skip: Number of records to skip (for pagination)
+            limit: Maximum number of records to return
+            status: Optional status filter
+
+        Returns:
+            List of medical equipment records
+        """
+        filters = {"patient_id": patient_id}
+        if status:
+            filters["status"] = status
+
+        return self.query(
+            db=db,
+            filters=filters,
+            skip=skip,
+            limit=limit,
+            order_by="prescribed_date",
+            order_desc=True,
+        )
+
+    def get_active_equipment(
+        self, db: Session, *, patient_id: int
+    ) -> List[MedicalEquipment]:
+        """
+        Get all active equipment for a patient.
+
+        Args:
+            db: SQLAlchemy database session
+            patient_id: ID of the patient
+
+        Returns:
+            List of active equipment
+        """
+        return self.query(
+            db=db,
+            filters={"status": "active", "patient_id": patient_id},
+            order_by="equipment_name",
+            order_desc=False,
+        )
+
+    def get_by_type(
+        self,
+        db: Session,
+        *,
+        patient_id: int,
+        equipment_type: str,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> List[MedicalEquipment]:
+        """
+        Get equipment by type for a patient.
+
+        Args:
+            db: SQLAlchemy database session
+            patient_id: ID of the patient
+            equipment_type: Type of equipment to filter by
+            skip: Number of records to skip
+            limit: Maximum number of records to return
+
+        Returns:
+            List of equipment of the specified type
+        """
+        return self.query(
+            db=db,
+            filters={"patient_id": patient_id, "equipment_type": equipment_type.lower()},
+            skip=skip,
+            limit=limit,
+            order_by="prescribed_date",
+            order_desc=True,
+        )
+
+    def get_needing_service(
+        self, db: Session, *, patient_id: Optional[int] = None
+    ) -> List[MedicalEquipment]:
+        """
+        Get equipment that needs service (next_service_date is past or upcoming).
+
+        Args:
+            db: SQLAlchemy database session
+            patient_id: Optional patient ID to filter by
+
+        Returns:
+            List of equipment needing service
+        """
+        from datetime import date, timedelta
+
+        # Get equipment where next_service_date is within 30 days or past
+        upcoming_date = date.today() + timedelta(days=30)
+
+        query = (
+            db.query(self.model)
+            .filter(self.model.status == "active")
+            .filter(self.model.next_service_date.isnot(None))
+            .filter(self.model.next_service_date <= upcoming_date)
+        )
+
+        if patient_id:
+            query = query.filter(self.model.patient_id == patient_id)
+
+        return query.order_by(self.model.next_service_date.asc()).all()
+
+
+# Create the medical equipment CRUD instance
+medical_equipment = CRUDMedicalEquipment(MedicalEquipment)

--- a/app/crud/treatment.py
+++ b/app/crud/treatment.py
@@ -1,11 +1,33 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
+from sqlalchemy import and_
 from sqlalchemy.orm import Session, joinedload
 
 from app.crud.base import CRUDBase
 from app.crud.base_tags import TagFilterMixin
-from app.models.models import Treatment
-from app.schemas.treatment import TreatmentCreate, TreatmentUpdate
+from app.models.models import (
+    Treatment,
+    TreatmentMedication,
+    TreatmentEncounter,
+    TreatmentLabResult,
+    TreatmentEquipment,
+)
+from app.schemas.treatment import (
+    TreatmentCreate,
+    TreatmentUpdate,
+    TreatmentMedicationCreate,
+    TreatmentMedicationUpdate,
+    TreatmentMedicationBulkCreate,
+    TreatmentEncounterCreate,
+    TreatmentEncounterUpdate,
+    TreatmentEncounterBulkCreate,
+    TreatmentLabResultCreate,
+    TreatmentLabResultUpdate,
+    TreatmentLabResultBulkCreate,
+    TreatmentEquipmentCreate,
+    TreatmentEquipmentUpdate,
+    TreatmentEquipmentBulkCreate,
+)
 
 
 class CRUDTreatment(CRUDBase[Treatment, TreatmentCreate, TreatmentUpdate], TagFilterMixin):
@@ -101,5 +123,387 @@ class CRUDTreatment(CRUDBase[Treatment, TreatmentCreate, TreatmentUpdate], TagFi
         return query.order_by(self.model.start_date.desc()).all()
 
 
-# Create the treatment CRUD instance
+# =============================================================================
+# Treatment-Medication Relationship CRUD
+# =============================================================================
+
+
+class CRUDTreatmentMedication(CRUDBase[TreatmentMedication, TreatmentMedicationCreate, TreatmentMedicationUpdate]):
+    """CRUD operations for TreatmentMedication junction table."""
+
+    def __init__(self):
+        super().__init__(TreatmentMedication)
+
+    def get_by_treatment(
+        self, db: Session, *, treatment_id: int
+    ) -> List[TreatmentMedication]:
+        """Get all medication relationships for a specific treatment."""
+        return (
+            db.query(self.model)
+            .filter(self.model.treatment_id == treatment_id)
+            .all()
+        )
+
+    def get_by_medication(
+        self, db: Session, *, medication_id: int
+    ) -> List[TreatmentMedication]:
+        """Get all treatment relationships for a specific medication."""
+        return (
+            db.query(self.model)
+            .filter(self.model.medication_id == medication_id)
+            .all()
+        )
+
+    def get_by_treatment_and_medication(
+        self, db: Session, *, treatment_id: int, medication_id: int
+    ) -> Optional[TreatmentMedication]:
+        """Get specific relationship between treatment and medication."""
+        return (
+            db.query(self.model)
+            .filter(
+                and_(
+                    self.model.treatment_id == treatment_id,
+                    self.model.medication_id == medication_id
+                )
+            )
+            .first()
+        )
+
+    def delete_by_treatment_and_medication(
+        self, db: Session, *, treatment_id: int, medication_id: int
+    ) -> bool:
+        """Delete specific relationship between treatment and medication."""
+        relationship = self.get_by_treatment_and_medication(
+            db, treatment_id=treatment_id, medication_id=medication_id
+        )
+        if relationship:
+            db.delete(relationship)
+            db.commit()
+            return True
+        return False
+
+    def create_bulk(
+        self,
+        db: Session,
+        *,
+        treatment_id: int,
+        bulk_data: TreatmentMedicationBulkCreate,
+    ) -> Tuple[List[TreatmentMedication], List[int]]:
+        """Create multiple treatment-medication relationships at once."""
+        created = []
+        skipped = []
+
+        for medication_id in bulk_data.medication_ids:
+            existing = self.get_by_treatment_and_medication(
+                db, treatment_id=treatment_id, medication_id=medication_id
+            )
+            if existing:
+                skipped.append(medication_id)
+                continue
+
+            relationship = TreatmentMedication(
+                treatment_id=treatment_id,
+                medication_id=medication_id,
+                relevance_note=bulk_data.relevance_note,
+            )
+            db.add(relationship)
+            created.append(relationship)
+
+        if created:
+            db.commit()
+            for rel in created:
+                db.refresh(rel)
+
+        return created, skipped
+
+
+# =============================================================================
+# Treatment-Encounter Relationship CRUD
+# =============================================================================
+
+
+class CRUDTreatmentEncounter(CRUDBase[TreatmentEncounter, TreatmentEncounterCreate, TreatmentEncounterUpdate]):
+    """CRUD operations for TreatmentEncounter junction table."""
+
+    def __init__(self):
+        super().__init__(TreatmentEncounter)
+
+    def get_by_treatment(
+        self, db: Session, *, treatment_id: int
+    ) -> List[TreatmentEncounter]:
+        """Get all encounter relationships for a specific treatment."""
+        return (
+            db.query(self.model)
+            .filter(self.model.treatment_id == treatment_id)
+            .order_by(self.model.visit_sequence.asc().nulls_last())
+            .all()
+        )
+
+    def get_by_encounter(
+        self, db: Session, *, encounter_id: int
+    ) -> List[TreatmentEncounter]:
+        """Get all treatment relationships for a specific encounter."""
+        return (
+            db.query(self.model)
+            .filter(self.model.encounter_id == encounter_id)
+            .all()
+        )
+
+    def get_by_treatment_and_encounter(
+        self, db: Session, *, treatment_id: int, encounter_id: int
+    ) -> Optional[TreatmentEncounter]:
+        """Get specific relationship between treatment and encounter."""
+        return (
+            db.query(self.model)
+            .filter(
+                and_(
+                    self.model.treatment_id == treatment_id,
+                    self.model.encounter_id == encounter_id
+                )
+            )
+            .first()
+        )
+
+    def delete_by_treatment_and_encounter(
+        self, db: Session, *, treatment_id: int, encounter_id: int
+    ) -> bool:
+        """Delete specific relationship between treatment and encounter."""
+        relationship = self.get_by_treatment_and_encounter(
+            db, treatment_id=treatment_id, encounter_id=encounter_id
+        )
+        if relationship:
+            db.delete(relationship)
+            db.commit()
+            return True
+        return False
+
+    def create_bulk(
+        self,
+        db: Session,
+        *,
+        treatment_id: int,
+        bulk_data: TreatmentEncounterBulkCreate,
+    ) -> Tuple[List[TreatmentEncounter], List[int]]:
+        """Create multiple treatment-encounter relationships at once."""
+        created = []
+        skipped = []
+
+        for encounter_id in bulk_data.encounter_ids:
+            existing = self.get_by_treatment_and_encounter(
+                db, treatment_id=treatment_id, encounter_id=encounter_id
+            )
+            if existing:
+                skipped.append(encounter_id)
+                continue
+
+            relationship = TreatmentEncounter(
+                treatment_id=treatment_id,
+                encounter_id=encounter_id,
+                relevance_note=bulk_data.relevance_note,
+            )
+            db.add(relationship)
+            created.append(relationship)
+
+        if created:
+            db.commit()
+            for rel in created:
+                db.refresh(rel)
+
+        return created, skipped
+
+
+# =============================================================================
+# Treatment-LabResult Relationship CRUD
+# =============================================================================
+
+
+class CRUDTreatmentLabResult(CRUDBase[TreatmentLabResult, TreatmentLabResultCreate, TreatmentLabResultUpdate]):
+    """CRUD operations for TreatmentLabResult junction table."""
+
+    def __init__(self):
+        super().__init__(TreatmentLabResult)
+
+    def get_by_treatment(
+        self, db: Session, *, treatment_id: int
+    ) -> List[TreatmentLabResult]:
+        """Get all lab result relationships for a specific treatment."""
+        return (
+            db.query(self.model)
+            .filter(self.model.treatment_id == treatment_id)
+            .all()
+        )
+
+    def get_by_lab_result(
+        self, db: Session, *, lab_result_id: int
+    ) -> List[TreatmentLabResult]:
+        """Get all treatment relationships for a specific lab result."""
+        return (
+            db.query(self.model)
+            .filter(self.model.lab_result_id == lab_result_id)
+            .all()
+        )
+
+    def get_by_treatment_and_lab_result(
+        self, db: Session, *, treatment_id: int, lab_result_id: int
+    ) -> Optional[TreatmentLabResult]:
+        """Get specific relationship between treatment and lab result."""
+        return (
+            db.query(self.model)
+            .filter(
+                and_(
+                    self.model.treatment_id == treatment_id,
+                    self.model.lab_result_id == lab_result_id
+                )
+            )
+            .first()
+        )
+
+    def delete_by_treatment_and_lab_result(
+        self, db: Session, *, treatment_id: int, lab_result_id: int
+    ) -> bool:
+        """Delete specific relationship between treatment and lab result."""
+        relationship = self.get_by_treatment_and_lab_result(
+            db, treatment_id=treatment_id, lab_result_id=lab_result_id
+        )
+        if relationship:
+            db.delete(relationship)
+            db.commit()
+            return True
+        return False
+
+    def create_bulk(
+        self,
+        db: Session,
+        *,
+        treatment_id: int,
+        bulk_data: TreatmentLabResultBulkCreate,
+    ) -> Tuple[List[TreatmentLabResult], List[int]]:
+        """Create multiple treatment-lab result relationships at once."""
+        created = []
+        skipped = []
+
+        for lab_result_id in bulk_data.lab_result_ids:
+            existing = self.get_by_treatment_and_lab_result(
+                db, treatment_id=treatment_id, lab_result_id=lab_result_id
+            )
+            if existing:
+                skipped.append(lab_result_id)
+                continue
+
+            relationship = TreatmentLabResult(
+                treatment_id=treatment_id,
+                lab_result_id=lab_result_id,
+                purpose=bulk_data.purpose,
+                relevance_note=bulk_data.relevance_note,
+            )
+            db.add(relationship)
+            created.append(relationship)
+
+        if created:
+            db.commit()
+            for rel in created:
+                db.refresh(rel)
+
+        return created, skipped
+
+
+# =============================================================================
+# Treatment-Equipment Relationship CRUD
+# =============================================================================
+
+
+class CRUDTreatmentEquipment(CRUDBase[TreatmentEquipment, TreatmentEquipmentCreate, TreatmentEquipmentUpdate]):
+    """CRUD operations for TreatmentEquipment junction table."""
+
+    def __init__(self):
+        super().__init__(TreatmentEquipment)
+
+    def get_by_treatment(
+        self, db: Session, *, treatment_id: int
+    ) -> List[TreatmentEquipment]:
+        """Get all equipment relationships for a specific treatment."""
+        return (
+            db.query(self.model)
+            .filter(self.model.treatment_id == treatment_id)
+            .all()
+        )
+
+    def get_by_equipment(
+        self, db: Session, *, equipment_id: int
+    ) -> List[TreatmentEquipment]:
+        """Get all treatment relationships for a specific equipment."""
+        return (
+            db.query(self.model)
+            .filter(self.model.equipment_id == equipment_id)
+            .all()
+        )
+
+    def get_by_treatment_and_equipment(
+        self, db: Session, *, treatment_id: int, equipment_id: int
+    ) -> Optional[TreatmentEquipment]:
+        """Get specific relationship between treatment and equipment."""
+        return (
+            db.query(self.model)
+            .filter(
+                and_(
+                    self.model.treatment_id == treatment_id,
+                    self.model.equipment_id == equipment_id
+                )
+            )
+            .first()
+        )
+
+    def delete_by_treatment_and_equipment(
+        self, db: Session, *, treatment_id: int, equipment_id: int
+    ) -> bool:
+        """Delete specific relationship between treatment and equipment."""
+        relationship = self.get_by_treatment_and_equipment(
+            db, treatment_id=treatment_id, equipment_id=equipment_id
+        )
+        if relationship:
+            db.delete(relationship)
+            db.commit()
+            return True
+        return False
+
+    def create_bulk(
+        self,
+        db: Session,
+        *,
+        treatment_id: int,
+        bulk_data: TreatmentEquipmentBulkCreate,
+    ) -> Tuple[List[TreatmentEquipment], List[int]]:
+        """Create multiple treatment-equipment relationships at once."""
+        created = []
+        skipped = []
+
+        for equipment_id in bulk_data.equipment_ids:
+            existing = self.get_by_treatment_and_equipment(
+                db, treatment_id=treatment_id, equipment_id=equipment_id
+            )
+            if existing:
+                skipped.append(equipment_id)
+                continue
+
+            relationship = TreatmentEquipment(
+                treatment_id=treatment_id,
+                equipment_id=equipment_id,
+                relevance_note=bulk_data.relevance_note,
+            )
+            db.add(relationship)
+            created.append(relationship)
+
+        if created:
+            db.commit()
+            for rel in created:
+                db.refresh(rel)
+
+        return created, skipped
+
+
+# Create the CRUD instances
 treatment = CRUDTreatment(Treatment)
+treatment_medication = CRUDTreatmentMedication()
+treatment_encounter = CRUDTreatmentEncounter()
+treatment_lab_result = CRUDTreatmentLabResult()
+treatment_equipment = CRUDTreatmentEquipment()

--- a/app/models/activity_log.py
+++ b/app/models/activity_log.py
@@ -153,6 +153,7 @@ class EntityType:
     SYMPTOM = "symptom"
     INJURY = "injury"
     INJURY_TYPE = "injury_type"
+    MEDICAL_EQUIPMENT = "medical_equipment"
 
     # System entities
     SYSTEM = "system"

--- a/app/schemas/medical_equipment.py
+++ b/app/schemas/medical_equipment.py
@@ -1,0 +1,158 @@
+"""Schemas for Medical Equipment."""
+from datetime import date, datetime
+from typing import Optional, List
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator, ValidationInfo
+
+from app.schemas.base_tags import TaggedEntityMixin
+
+
+# Valid equipment types
+EQUIPMENT_TYPES = [
+    "cpap",
+    "bipap",
+    "nebulizer",
+    "inhaler",
+    "blood_pressure_monitor",
+    "glucose_monitor",
+    "pulse_oximeter",
+    "wheelchair",
+    "walker",
+    "cane",
+    "crutches",
+    "oxygen_concentrator",
+    "oxygen_tank",
+    "hearing_aid",
+    "insulin_pump",
+    "continuous_glucose_monitor",
+    "tens_unit",
+    "brace",
+    "prosthetic",
+    "other",
+]
+
+# Valid equipment statuses
+EQUIPMENT_STATUSES = ["active", "inactive", "replaced", "returned", "lost"]
+
+
+class MedicalEquipmentBase(TaggedEntityMixin):
+    """Base schema for medical equipment."""
+    equipment_name: str = Field(
+        ..., min_length=2, max_length=200, description="Name of the equipment"
+    )
+    equipment_type: str = Field(
+        ..., min_length=2, max_length=100, description="Type of equipment"
+    )
+    manufacturer: Optional[str] = Field(None, max_length=200)
+    model_number: Optional[str] = Field(None, max_length=100)
+    serial_number: Optional[str] = Field(None, max_length=100)
+    prescribed_date: Optional[date] = None
+    last_service_date: Optional[date] = None
+    next_service_date: Optional[date] = None
+    usage_instructions: Optional[str] = Field(None, max_length=1000)
+    status: Optional[str] = Field("active", max_length=50)
+    supplier: Optional[str] = Field(None, max_length=200)
+    notes: Optional[str] = Field(None, max_length=1000)
+    patient_id: int = Field(..., gt=0, description="ID of the patient")
+    practitioner_id: Optional[int] = Field(
+        None, gt=0, description="ID of the prescribing practitioner"
+    )
+
+    @field_validator("equipment_type")
+    @classmethod
+    def validate_equipment_type(cls, v):
+        if v is not None:
+            v_lower = v.lower().replace(" ", "_").replace("-", "_")
+            if v_lower not in EQUIPMENT_TYPES:
+                # Allow custom types but normalize known ones
+                return v.strip()
+            return v_lower
+        return v
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v):
+        if v is None:
+            return "active"
+        if v.lower() not in EQUIPMENT_STATUSES:
+            raise ValueError(f"Status must be one of: {', '.join(EQUIPMENT_STATUSES)}")
+        return v.lower()
+
+    @model_validator(mode="after")
+    def validate_dates(self):
+        """Validate that service dates are logical."""
+        if self.last_service_date and self.next_service_date:
+            if self.next_service_date < self.last_service_date:
+                raise ValueError("Next service date cannot be before last service date")
+        return self
+
+
+class MedicalEquipmentCreate(MedicalEquipmentBase):
+    """Schema for creating medical equipment."""
+    pass
+
+
+class MedicalEquipmentUpdate(BaseModel):
+    """Schema for updating medical equipment."""
+    equipment_name: Optional[str] = Field(None, min_length=2, max_length=200)
+    equipment_type: Optional[str] = Field(None, min_length=2, max_length=100)
+    manufacturer: Optional[str] = Field(None, max_length=200)
+    model_number: Optional[str] = Field(None, max_length=100)
+    serial_number: Optional[str] = Field(None, max_length=100)
+    prescribed_date: Optional[date] = None
+    last_service_date: Optional[date] = None
+    next_service_date: Optional[date] = None
+    usage_instructions: Optional[str] = Field(None, max_length=1000)
+    status: Optional[str] = Field(None, max_length=50)
+    supplier: Optional[str] = Field(None, max_length=200)
+    notes: Optional[str] = Field(None, max_length=1000)
+    practitioner_id: Optional[int] = Field(None, gt=0)
+    tags: Optional[List[str]] = None
+
+    @field_validator("equipment_type")
+    @classmethod
+    def validate_equipment_type(cls, v):
+        if v is not None:
+            v_lower = v.lower().replace(" ", "_").replace("-", "_")
+            if v_lower not in EQUIPMENT_TYPES:
+                return v.strip()
+            return v_lower
+        return v
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v):
+        if v is not None:
+            if v.lower() not in EQUIPMENT_STATUSES:
+                raise ValueError(f"Status must be one of: {', '.join(EQUIPMENT_STATUSES)}")
+            return v.lower()
+        return v
+
+
+class MedicalEquipmentResponse(MedicalEquipmentBase):
+    """Schema for medical equipment response."""
+    id: int
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MedicalEquipmentWithRelations(MedicalEquipmentResponse):
+    """Schema for medical equipment with related entities."""
+    patient: Optional[dict] = None
+    practitioner: Optional[dict] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MedicalEquipmentSummary(BaseModel):
+    """Summary schema for medical equipment."""
+    id: int
+    equipment_name: str
+    equipment_type: str
+    status: str
+    prescribed_date: Optional[date] = None
+    next_service_date: Optional[date] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/frontend/public/locales/en/navigation.json
+++ b/frontend/public/locales/en/navigation.json
@@ -45,7 +45,8 @@
     "symptoms": "Symptoms",
     "injuries": "Injuries",
     "practitioners": "Practitioners",
-    "pharmacies": "Pharmacies"
+    "pharmacies": "Pharmacies",
+    "medicalEquipment": "Medical Equipment"
   },
   "dashboard": {
     "title": "MediKeep Dashboard",
@@ -85,6 +86,7 @@
       "exportRecords": "Export Records",
       "practitioners": "Practitioners",
       "pharmacies": "Pharmacies",
+      "medicalEquipment": "Medical Equipment",
       "adminDashboard": "Admin Dashboard"
     },
     "activity": {
@@ -153,6 +155,7 @@
       "practitioners": "Practitioners",
       "pharmacies": "Pharmacies",
       "insurance": "Insurance",
+      "medicalEquipment": "Medical Equipment",
       "emergencyContacts": "Emergency Contacts",
       "tagManagement": "Tag Management",
       "customReports": "Custom Reports",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -57,6 +57,7 @@ import Visits from './pages/medical/Visits';
 import Vitals from './pages/medical/Vitals';
 import Symptoms from './pages/medical/Symptoms';
 import Injuries from './pages/medical/Injuries';
+import MedicalEquipment from './pages/medical/MedicalEquipment';
 import Practitioners from './pages/medical/Practitioners';
 import Pharmacies from './pages/medical/Pharmacies';
 import EmergencyContacts from './pages/medical/EmergencyContacts';
@@ -432,6 +433,15 @@ function App() {
                           element={
                             <ProtectedRoute>
                               <Symptoms />
+                            </ProtectedRoute>
+                          }
+                        />
+                        {/* Medical Equipment Route */}
+                        <Route
+                          path="/medical-equipment"
+                          element={
+                            <ProtectedRoute>
+                              <MedicalEquipment />
                             </ProtectedRoute>
                           }
                         />

--- a/frontend/src/components/medical/equipment/EquipmentCard.jsx
+++ b/frontend/src/components/medical/equipment/EquipmentCard.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Text, Group } from '@mantine/core';
+import { useTranslation } from 'react-i18next';
+import BaseMedicalCard from '../base/BaseMedicalCard';
+import StatusBadge from '../StatusBadge';
+import { useDateFormat } from '../../../hooks/useDateFormat';
+import logger from '../../../services/logger';
+import {
+  getEquipmentTypeLabel,
+  getEquipmentStatusColor,
+} from '../../../constants/equipmentConstants';
+
+const EquipmentCard = ({
+  equipment,
+  onEdit,
+  onDelete,
+  onView,
+  fileCount = 0,
+  fileCountLoading = false,
+  onError
+}) => {
+  const { t } = useTranslation('common');
+  const { formatLongDate } = useDateFormat();
+
+  const handleError = (error) => {
+    logger.error('equipment_card_error', {
+      message: 'Error in EquipmentCard',
+      equipmentId: equipment?.id,
+      error: error.message,
+      component: 'EquipmentCard',
+    });
+
+    if (onError) {
+      onError(error);
+    }
+  };
+
+  try {
+    const badges = [];
+
+    if (equipment.equipment_type) {
+      badges.push({
+        label: getEquipmentTypeLabel(equipment.equipment_type),
+        color: 'blue'
+      });
+    }
+
+    if (equipment.manufacturer) {
+      badges.push({
+        label: equipment.manufacturer,
+        color: 'gray',
+        variant: 'outline'
+      });
+    }
+
+    const fields = [
+      {
+        label: t('equipment.fields.modelNumber', 'Model'),
+        value: equipment.model_number,
+        render: (value) => value || t('labels.notSpecified', 'Not specified')
+      },
+      {
+        label: t('equipment.fields.serialNumber', 'Serial #'),
+        value: equipment.serial_number,
+        render: (value) => value || t('labels.notSpecified', 'Not specified')
+      },
+      {
+        label: t('equipment.fields.prescribedDate', 'Prescribed'),
+        value: equipment.prescribed_date,
+        render: (value) => value ? formatLongDate(value) : t('labels.notSpecified', 'Not specified')
+      },
+      {
+        label: t('equipment.fields.nextService', 'Next Service'),
+        value: equipment.next_service_date,
+        render: (value) => value ? formatLongDate(value) : t('labels.notSpecified', 'Not specified')
+      },
+      {
+        label: t('equipment.fields.supplier', 'Supplier'),
+        value: equipment.supplier,
+        render: (value) => value || t('labels.notSpecified', 'Not specified')
+      },
+    ].filter(field => field.value);
+
+    const titleContent = (
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', width: '100%' }}>
+        <Text fw={600} size="lg" style={{ flex: 1 }}>
+          {equipment.equipment_name}
+        </Text>
+        <StatusBadge
+          status={equipment.status}
+          color={getEquipmentStatusColor(equipment.status)}
+        />
+      </div>
+    );
+
+    return (
+      <BaseMedicalCard
+        title={titleContent}
+        subtitle={equipment.equipment_type ? getEquipmentTypeLabel(equipment.equipment_type) : null}
+        badges={badges}
+        fields={fields}
+        notes={equipment.notes}
+        entityType="medical_equipment"
+        fileCount={fileCount}
+        fileCountLoading={fileCountLoading}
+        onView={() => onView(equipment)}
+        onEdit={() => onEdit(equipment)}
+        onDelete={() => onDelete(equipment.id)}
+        onError={handleError}
+      />
+    );
+  } catch (error) {
+    handleError(error);
+    return null;
+  }
+};
+
+EquipmentCard.propTypes = {
+  equipment: PropTypes.shape({
+    id: PropTypes.number,
+    equipment_name: PropTypes.string,
+    equipment_type: PropTypes.string,
+    manufacturer: PropTypes.string,
+    model_number: PropTypes.string,
+    serial_number: PropTypes.string,
+    prescribed_date: PropTypes.string,
+    next_service_date: PropTypes.string,
+    supplier: PropTypes.string,
+    status: PropTypes.string,
+    notes: PropTypes.string,
+  }).isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onView: PropTypes.func.isRequired,
+  fileCount: PropTypes.number,
+  fileCountLoading: PropTypes.bool,
+  onError: PropTypes.func,
+};
+
+export default EquipmentCard;

--- a/frontend/src/components/medical/equipment/EquipmentFormWrapper.jsx
+++ b/frontend/src/components/medical/equipment/EquipmentFormWrapper.jsx
@@ -1,0 +1,312 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Modal,
+  Stack,
+  Group,
+  Button,
+  Grid,
+  TextInput,
+  Textarea,
+  Select,
+} from '@mantine/core';
+import { DateInput } from '@mantine/dates';
+import { useTranslation } from 'react-i18next';
+import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
+import SubmitButton from '../../shared/SubmitButton';
+import { useFormHandlers } from '../../../hooks/useFormHandlers';
+import { parseDateInput, formatDateInputChange } from '../../../utils/dateUtils';
+import { TagInput } from '../../common/TagInput';
+import {
+  EQUIPMENT_TYPE_OPTIONS,
+  EQUIPMENT_STATUS_OPTIONS,
+} from '../../../constants/equipmentConstants';
+
+const EquipmentFormWrapper = ({
+  isOpen,
+  onClose,
+  title,
+  editingEquipment = null,
+  formData,
+  onInputChange,
+  onSubmit,
+  practitionersOptions = [],
+  practitionersLoading = false,
+  isLoading = false,
+}) => {
+  const { t } = useTranslation('common');
+
+  const {
+    handleTextInputChange,
+  } = useFormHandlers(onInputChange);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await onSubmit(e);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <Modal
+      opened={isOpen}
+      onClose={onClose}
+      title={title}
+      size="lg"
+      centered
+      zIndex={2000}
+      closeOnClickOutside={!isLoading}
+      closeOnEscape={!isLoading}
+    >
+      <FormLoadingOverlay
+        visible={isLoading}
+        message={t('equipment.form.saving', 'Saving equipment...')}
+      />
+
+      <form onSubmit={handleSubmit}>
+        <Stack gap="md">
+          <Grid>
+            {/* Basic Info */}
+            <Grid.Col span={{ base: 12, sm: 6 }}>
+              <TextInput
+                label={t('equipment.form.name', 'Equipment Name')}
+                value={formData.equipment_name || ''}
+                onChange={handleTextInputChange('equipment_name')}
+                placeholder={t('equipment.form.namePlaceholder', 'e.g., ResMed AirSense 11')}
+                required
+              />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 6 }}>
+              <Select
+                label={t('equipment.form.type', 'Equipment Type')}
+                value={formData.equipment_type || null}
+                data={EQUIPMENT_TYPE_OPTIONS}
+                onChange={(value) => {
+                  onInputChange({ target: { name: 'equipment_type', value: value || '' } });
+                }}
+                placeholder={t('equipment.form.typePlaceholder', 'Select type')}
+                searchable
+                required
+                comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+              />
+            </Grid.Col>
+
+            {/* Status and Practitioner */}
+            <Grid.Col span={{ base: 12, sm: 6 }}>
+              <Select
+                label={t('equipment.form.status', 'Status')}
+                value={formData.status || 'active'}
+                data={EQUIPMENT_STATUS_OPTIONS}
+                onChange={(value) => {
+                  onInputChange({ target: { name: 'status', value: value || 'active' } });
+                }}
+                comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+              />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 6 }}>
+              <Select
+                label={t('equipment.form.practitioner', 'Prescribed By')}
+                value={formData.practitioner_id || null}
+                data={practitionersOptions.map(prac => ({
+                  value: prac.id.toString(),
+                  label: `${prac.name}${prac.specialty ? ` - ${prac.specialty}` : ''}`,
+                }))}
+                onChange={(value) => {
+                  onInputChange({ target: { name: 'practitioner_id', value: value || '' } });
+                }}
+                placeholder={t('equipment.form.practitionerPlaceholder', 'Select practitioner')}
+                searchable
+                clearable
+                comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+                disabled={practitionersLoading}
+              />
+            </Grid.Col>
+
+            {/* Manufacturer Details */}
+            <Grid.Col span={{ base: 12, sm: 6 }}>
+              <TextInput
+                label={t('equipment.form.manufacturer', 'Manufacturer')}
+                value={formData.manufacturer || ''}
+                onChange={handleTextInputChange('manufacturer')}
+                placeholder={t('equipment.form.manufacturerPlaceholder', 'e.g., ResMed, Philips')}
+              />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 6 }}>
+              <TextInput
+                label={t('equipment.form.modelNumber', 'Model Number')}
+                value={formData.model_number || ''}
+                onChange={handleTextInputChange('model_number')}
+                placeholder={t('equipment.form.modelPlaceholder', 'e.g., AirSense 11')}
+              />
+            </Grid.Col>
+
+            <Grid.Col span={{ base: 12, sm: 6 }}>
+              <TextInput
+                label={t('equipment.form.serialNumber', 'Serial Number')}
+                value={formData.serial_number || ''}
+                onChange={handleTextInputChange('serial_number')}
+                placeholder={t('equipment.form.serialPlaceholder', 'Equipment serial number')}
+              />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 6 }}>
+              <TextInput
+                label={t('equipment.form.supplier', 'Supplier')}
+                value={formData.supplier || ''}
+                onChange={handleTextInputChange('supplier')}
+                placeholder={t('equipment.form.supplierPlaceholder', 'Equipment supplier')}
+              />
+            </Grid.Col>
+
+            {/* Dates */}
+            <Grid.Col span={{ base: 12, sm: 4 }}>
+              <DateInput
+                label={t('equipment.form.prescribedDate', 'Prescribed Date')}
+                value={parseDateInput(formData.prescribed_date)}
+                onChange={(date) => {
+                  const formattedDate = formatDateInputChange(date);
+                  onInputChange({ target: { name: 'prescribed_date', value: formattedDate } });
+                }}
+                placeholder={t('equipment.form.datePlaceholder', 'Select date')}
+                clearable
+                popoverProps={{ withinPortal: true, zIndex: 3000 }}
+              />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 4 }}>
+              <DateInput
+                label={t('equipment.form.lastService', 'Last Service Date')}
+                value={parseDateInput(formData.last_service_date)}
+                onChange={(date) => {
+                  const formattedDate = formatDateInputChange(date);
+                  onInputChange({ target: { name: 'last_service_date', value: formattedDate } });
+                }}
+                placeholder={t('equipment.form.datePlaceholder', 'Select date')}
+                clearable
+                popoverProps={{ withinPortal: true, zIndex: 3000 }}
+              />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 4 }}>
+              <DateInput
+                label={t('equipment.form.nextService', 'Next Service Date')}
+                value={parseDateInput(formData.next_service_date)}
+                onChange={(date) => {
+                  const formattedDate = formatDateInputChange(date);
+                  onInputChange({ target: { name: 'next_service_date', value: formattedDate } });
+                }}
+                placeholder={t('equipment.form.datePlaceholder', 'Select date')}
+                clearable
+                minDate={parseDateInput(formData.last_service_date) || undefined}
+                popoverProps={{ withinPortal: true, zIndex: 3000 }}
+              />
+            </Grid.Col>
+
+            {/* Usage Instructions */}
+            <Grid.Col span={12}>
+              <Textarea
+                label={t('equipment.form.usageInstructions', 'Usage Instructions')}
+                value={formData.usage_instructions || ''}
+                onChange={handleTextInputChange('usage_instructions')}
+                placeholder={t('equipment.form.usagePlaceholder', 'How to use this equipment')}
+                rows={3}
+                autosize
+                minRows={2}
+              />
+            </Grid.Col>
+
+            {/* Notes */}
+            <Grid.Col span={12}>
+              <Textarea
+                label={t('equipment.form.notes', 'Notes')}
+                value={formData.notes || ''}
+                onChange={handleTextInputChange('notes')}
+                placeholder={t('equipment.form.notesPlaceholder', 'Additional notes about this equipment')}
+                rows={3}
+                autosize
+                minRows={2}
+              />
+            </Grid.Col>
+
+            {/* Tags */}
+            <Grid.Col span={12}>
+              <TagInput
+                value={formData.tags || []}
+                onChange={(tags) => {
+                  onInputChange({ target: { name: 'tags', value: tags } });
+                }}
+                label={t('equipment.form.tags', 'Tags')}
+                placeholder={t('equipment.form.tagsPlaceholder', 'Add tags...')}
+              />
+            </Grid.Col>
+          </Grid>
+
+          {/* Form Actions */}
+          <Group justify="flex-end" gap="sm">
+            <Button variant="default" onClick={onClose} disabled={isLoading}>
+              {t('buttons.cancel', 'Cancel')}
+            </Button>
+            <SubmitButton
+              loading={isLoading}
+              disabled={!formData.equipment_name?.trim() || !formData.equipment_type}
+            >
+              {editingEquipment
+                ? t('equipment.form.update', 'Update Equipment')
+                : t('equipment.form.create', 'Create Equipment')
+              }
+            </SubmitButton>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  );
+};
+
+EquipmentFormWrapper.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  editingEquipment: PropTypes.shape({
+    id: PropTypes.number,
+    equipment_name: PropTypes.string,
+    equipment_type: PropTypes.string,
+    manufacturer: PropTypes.string,
+    model_number: PropTypes.string,
+    serial_number: PropTypes.string,
+    prescribed_date: PropTypes.string,
+    last_service_date: PropTypes.string,
+    next_service_date: PropTypes.string,
+    supplier: PropTypes.string,
+    status: PropTypes.string,
+    usage_instructions: PropTypes.string,
+    notes: PropTypes.string,
+    tags: PropTypes.arrayOf(PropTypes.string),
+    practitioner_id: PropTypes.number,
+  }),
+  formData: PropTypes.shape({
+    equipment_name: PropTypes.string,
+    equipment_type: PropTypes.string,
+    manufacturer: PropTypes.string,
+    model_number: PropTypes.string,
+    serial_number: PropTypes.string,
+    prescribed_date: PropTypes.string,
+    last_service_date: PropTypes.string,
+    next_service_date: PropTypes.string,
+    supplier: PropTypes.string,
+    status: PropTypes.string,
+    usage_instructions: PropTypes.string,
+    notes: PropTypes.string,
+    tags: PropTypes.arrayOf(PropTypes.string),
+    practitioner_id: PropTypes.string,
+  }).isRequired,
+  onInputChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  practitionersOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+      specialty: PropTypes.string,
+    })
+  ),
+  practitionersLoading: PropTypes.bool,
+  isLoading: PropTypes.bool,
+};
+
+export default EquipmentFormWrapper;

--- a/frontend/src/components/medical/equipment/EquipmentViewModal.jsx
+++ b/frontend/src/components/medical/equipment/EquipmentViewModal.jsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Modal,
+  Stack,
+  Group,
+  Text,
+  Badge,
+  Button,
+  Box,
+  SimpleGrid,
+  Title,
+  Paper,
+} from '@mantine/core';
+import { IconEdit } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
+import StatusBadge from '../StatusBadge';
+import { useDateFormat } from '../../../hooks/useDateFormat';
+import {
+  getEquipmentTypeLabel,
+  getEquipmentStatusColor,
+} from '../../../constants/equipmentConstants';
+
+const EquipmentViewModal = ({
+  isOpen,
+  onClose,
+  equipment,
+  onEdit,
+  practitioners = [],
+}) => {
+  const { t } = useTranslation('common');
+  const { formatDate } = useDateFormat();
+
+  if (!isOpen || !equipment) return null;
+
+  const handleEdit = () => {
+    onEdit(equipment);
+    onClose();
+  };
+
+  const getPractitionerName = (practitionerId) => {
+    if (!practitionerId || !practitioners || practitioners.length === 0) {
+      return null;
+    }
+    const practitioner = practitioners.find(p => p.id === practitionerId);
+    return practitioner ? practitioner.name : null;
+  };
+
+  return (
+    <Modal
+      opened={isOpen}
+      onClose={onClose}
+      title={t('equipment.viewModal.title', 'Equipment Details')}
+      size="lg"
+      centered
+      zIndex={2000}
+    >
+      <Stack gap="lg">
+        {/* Header Card */}
+        <Paper withBorder p="md" style={{ backgroundColor: '#f8f9fa' }}>
+          <Group justify="space-between" align="center">
+            <div>
+              <Title order={3} mb="xs">{equipment.equipment_name}</Title>
+              <Group gap="xs">
+                {equipment.equipment_type && (
+                  <Badge variant="light" color="blue" size="sm">
+                    {getEquipmentTypeLabel(equipment.equipment_type)}
+                  </Badge>
+                )}
+                <StatusBadge
+                  status={equipment.status}
+                  color={getEquipmentStatusColor(equipment.status)}
+                />
+              </Group>
+            </div>
+            {equipment.prescribed_date && (
+              <Badge variant="light" color="gray" size="lg">
+                {formatDate(equipment.prescribed_date)}
+              </Badge>
+            )}
+          </Group>
+        </Paper>
+
+        {/* Equipment Details */}
+        <Box>
+          <Stack gap="lg">
+            {/* Basic Information */}
+            <div>
+              <Title order={4} mb="sm">{t('equipment.viewModal.basicInfo', 'Basic Information')}</Title>
+              <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.name', 'Equipment Name')}</Text>
+                  <Text size="sm">{equipment.equipment_name}</Text>
+                </Stack>
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.type', 'Equipment Type')}</Text>
+                  <Text size="sm" c={equipment.equipment_type ? 'inherit' : 'dimmed'}>
+                    {getEquipmentTypeLabel(equipment.equipment_type) || t('labels.notSpecified', 'Not specified')}
+                  </Text>
+                </Stack>
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.status', 'Status')}</Text>
+                  <StatusBadge status={equipment.status} color={getEquipmentStatusColor(equipment.status)} />
+                </Stack>
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.prescribedBy', 'Prescribed By')}</Text>
+                  <Text size="sm" c={equipment.practitioner_id ? 'inherit' : 'dimmed'}>
+                    {equipment.practitioner_id
+                      ? (equipment.practitioner?.name || getPractitionerName(equipment.practitioner_id) || `Practitioner #${equipment.practitioner_id}`)
+                      : t('labels.notSpecified', 'Not specified')}
+                  </Text>
+                </Stack>
+              </SimpleGrid>
+            </div>
+
+            {/* Manufacturer Details */}
+            <div>
+              <Title order={4} mb="sm">{t('equipment.viewModal.manufacturerDetails', 'Manufacturer Details')}</Title>
+              <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.manufacturer', 'Manufacturer')}</Text>
+                  <Text size="sm" c={equipment.manufacturer ? 'inherit' : 'dimmed'}>
+                    {equipment.manufacturer || t('labels.notSpecified', 'Not specified')}
+                  </Text>
+                </Stack>
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.modelNumber', 'Model Number')}</Text>
+                  <Text size="sm" c={equipment.model_number ? 'inherit' : 'dimmed'}>
+                    {equipment.model_number || t('labels.notSpecified', 'Not specified')}
+                  </Text>
+                </Stack>
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.serialNumber', 'Serial Number')}</Text>
+                  <Text size="sm" c={equipment.serial_number ? 'inherit' : 'dimmed'}>
+                    {equipment.serial_number || t('labels.notSpecified', 'Not specified')}
+                  </Text>
+                </Stack>
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.supplier', 'Supplier')}</Text>
+                  <Text size="sm" c={equipment.supplier ? 'inherit' : 'dimmed'}>
+                    {equipment.supplier || t('labels.notSpecified', 'Not specified')}
+                  </Text>
+                </Stack>
+              </SimpleGrid>
+            </div>
+
+            {/* Dates */}
+            <div>
+              <Title order={4} mb="sm">{t('equipment.viewModal.dates', 'Important Dates')}</Title>
+              <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.prescribedDate', 'Prescribed Date')}</Text>
+                  <Text size="sm" c={equipment.prescribed_date ? 'inherit' : 'dimmed'}>
+                    {equipment.prescribed_date ? formatDate(equipment.prescribed_date) : t('labels.notSpecified', 'Not specified')}
+                  </Text>
+                </Stack>
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.lastService', 'Last Service')}</Text>
+                  <Text size="sm" c={equipment.last_service_date ? 'inherit' : 'dimmed'}>
+                    {equipment.last_service_date ? formatDate(equipment.last_service_date) : t('labels.notSpecified', 'Not specified')}
+                  </Text>
+                </Stack>
+                <Stack gap="xs">
+                  <Text fw={500} size="sm" c="dimmed">{t('equipment.viewModal.nextService', 'Next Service')}</Text>
+                  <Text size="sm" c={equipment.next_service_date ? 'inherit' : 'dimmed'}>
+                    {equipment.next_service_date ? formatDate(equipment.next_service_date) : t('labels.notSpecified', 'Not specified')}
+                  </Text>
+                </Stack>
+              </SimpleGrid>
+            </div>
+
+            {/* Usage Instructions */}
+            {equipment.usage_instructions && (
+              <div>
+                <Title order={4} mb="sm">{t('equipment.viewModal.usageInstructions', 'Usage Instructions')}</Title>
+                <Text size="sm">{equipment.usage_instructions}</Text>
+              </div>
+            )}
+
+            {/* Notes */}
+            {equipment.notes && (
+              <div>
+                <Title order={4} mb="sm">{t('equipment.viewModal.notes', 'Notes')}</Title>
+                <Text size="sm">{equipment.notes}</Text>
+              </div>
+            )}
+
+            {/* Tags */}
+            {equipment.tags && equipment.tags.length > 0 && (
+              <div>
+                <Title order={4} mb="sm">{t('equipment.viewModal.tags', 'Tags')}</Title>
+                <Group gap="xs">
+                  {equipment.tags.map((tag, index) => (
+                    <Badge key={index} variant="light" color="blue" size="sm" radius="md">
+                      {tag}
+                    </Badge>
+                  ))}
+                </Group>
+              </div>
+            )}
+          </Stack>
+        </Box>
+
+        {/* Action Buttons */}
+        <Group justify="flex-end" gap="sm">
+          <Button variant="default" onClick={onClose}>
+            {t('buttons.close', 'Close')}
+          </Button>
+          <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />}>
+            {t('buttons.edit', 'Edit')}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+};
+
+EquipmentViewModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  equipment: PropTypes.shape({
+    id: PropTypes.number,
+    equipment_name: PropTypes.string,
+    equipment_type: PropTypes.string,
+    manufacturer: PropTypes.string,
+    model_number: PropTypes.string,
+    serial_number: PropTypes.string,
+    prescribed_date: PropTypes.string,
+    last_service_date: PropTypes.string,
+    next_service_date: PropTypes.string,
+    supplier: PropTypes.string,
+    status: PropTypes.string,
+    usage_instructions: PropTypes.string,
+    notes: PropTypes.string,
+    tags: PropTypes.arrayOf(PropTypes.string),
+    practitioner_id: PropTypes.number,
+    practitioner: PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    }),
+  }),
+  onEdit: PropTypes.func.isRequired,
+  practitioners: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    })
+  ),
+};
+
+export default EquipmentViewModal;

--- a/frontend/src/components/medical/equipment/__tests__/EquipmentCard.test.jsx
+++ b/frontend/src/components/medical/equipment/__tests__/EquipmentCard.test.jsx
@@ -1,0 +1,406 @@
+import { vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MantineProvider } from '@mantine/core';
+import '@testing-library/jest-dom';
+import EquipmentCard from '../EquipmentCard';
+
+// Mock useDateFormat hook
+vi.mock('../../../../hooks/useDateFormat', () => ({
+  useDateFormat: () => ({
+    formatLongDate: (date) => date ? new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) : null,
+  }),
+}));
+
+// Mock logger
+vi.mock('../../../../services/logger', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// Mock i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, defaultValue) => defaultValue || key,
+  }),
+}));
+
+// Wrapper component with Mantine provider
+const MantineWrapper = ({ children }) => (
+  <MantineProvider>{children}</MantineProvider>
+);
+
+describe('EquipmentCard', () => {
+  const defaultEquipment = {
+    id: 1,
+    equipment_name: 'ResMed AirSense 11',
+    equipment_type: 'cpap',
+    manufacturer: 'ResMed',
+    model_number: 'AirSense 11',
+    serial_number: 'SN-12345',
+    prescribed_date: '2024-01-15',
+    next_service_date: '2024-07-15',
+    supplier: 'Sleep Solutions Inc',
+    status: 'active',
+    notes: 'Use nightly for sleep apnea',
+  };
+
+  const defaultProps = {
+    equipment: defaultEquipment,
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onView: vi.fn(),
+    fileCount: 0,
+    fileCountLoading: false,
+    onError: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    test('renders equipment name', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('ResMed AirSense 11')).toBeInTheDocument();
+    });
+
+    test('renders equipment type badge', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      // Equipment type appears in multiple places (subtitle and badge)
+      expect(screen.getAllByText('CPAP Machine').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('renders manufacturer badge', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('ResMed')).toBeInTheDocument();
+    });
+
+    test('renders status badge', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      // StatusBadge capitalizes the status
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
+    test('renders model number when provided', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('AirSense 11')).toBeInTheDocument();
+    });
+
+    test('renders serial number when provided', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('SN-12345')).toBeInTheDocument();
+    });
+
+    test('renders supplier when provided', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Sleep Solutions Inc')).toBeInTheDocument();
+    });
+
+    test('renders notes when provided', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Use nightly for sleep apnea')).toBeInTheDocument();
+    });
+  });
+
+  describe('Equipment Types', () => {
+    test('renders CPAP equipment correctly', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      // Equipment type may appear multiple times
+      expect(screen.getAllByText('CPAP Machine').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('renders nebulizer equipment correctly', () => {
+      const nebulizer = {
+        ...defaultEquipment,
+        equipment_name: 'Portable Nebulizer',
+        equipment_type: 'nebulizer',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} equipment={nebulizer} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getAllByText('Nebulizer').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('renders inhaler equipment correctly', () => {
+      const inhaler = {
+        ...defaultEquipment,
+        equipment_name: 'Ventolin Inhaler',
+        equipment_type: 'inhaler',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} equipment={inhaler} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getAllByText('Inhaler').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('renders glucose monitor equipment correctly', () => {
+      const glucoseMonitor = {
+        ...defaultEquipment,
+        equipment_name: 'Freestyle Libre',
+        equipment_type: 'glucose_monitor',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} equipment={glucoseMonitor} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getAllByText('Glucose Monitor').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('Status Display', () => {
+    test('renders active status correctly', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
+    test('renders inactive status correctly', () => {
+      const inactiveEquipment = {
+        ...defaultEquipment,
+        status: 'inactive',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} equipment={inactiveEquipment} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Inactive')).toBeInTheDocument();
+    });
+
+    test('renders replaced status correctly', () => {
+      const replacedEquipment = {
+        ...defaultEquipment,
+        status: 'replaced',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} equipment={replacedEquipment} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Replaced')).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interactions', () => {
+    test('calls onView when view action is triggered', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      // BaseMedicalCard may use action icons or buttons - look for any clickable element
+      const buttons = screen.getAllByRole('button');
+      // Find the view button (usually first or has view text/icon)
+      const viewButton = buttons.find(btn => btn.getAttribute('aria-label')?.toLowerCase().includes('view')) || buttons[0];
+      if (viewButton) {
+        await user.click(viewButton);
+        expect(defaultProps.onView).toHaveBeenCalled();
+      }
+    });
+
+    test('calls onEdit when edit action is triggered', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const buttons = screen.getAllByRole('button');
+      const editButton = buttons.find(btn => btn.getAttribute('aria-label')?.toLowerCase().includes('edit'));
+      if (editButton) {
+        await user.click(editButton);
+        expect(defaultProps.onEdit).toHaveBeenCalled();
+      }
+    });
+
+    test('calls onDelete when delete action is triggered', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const buttons = screen.getAllByRole('button');
+      const deleteButton = buttons.find(btn => btn.getAttribute('aria-label')?.toLowerCase().includes('delete'));
+      if (deleteButton) {
+        await user.click(deleteButton);
+        expect(defaultProps.onDelete).toHaveBeenCalledWith(1);
+      }
+    });
+  });
+
+  describe('File Count Display', () => {
+    test('displays file count when provided', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} fileCount={3} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    test('does not display file count when zero', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} fileCount={0} />
+        </MantineWrapper>
+      );
+
+      // File count of 0 shouldn't display
+      expect(screen.queryByText('0 files')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Minimal Data', () => {
+    test('renders with minimal required fields only', () => {
+      const minimalEquipment = {
+        id: 2,
+        equipment_name: 'Basic Equipment',
+        status: 'active',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} equipment={minimalEquipment} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Basic Equipment')).toBeInTheDocument();
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
+    test('handles null/undefined optional fields gracefully', () => {
+      const sparseEquipment = {
+        id: 3,
+        equipment_name: 'Sparse Equipment',
+        equipment_type: null,
+        manufacturer: undefined,
+        model_number: null,
+        serial_number: undefined,
+        prescribed_date: null,
+        next_service_date: undefined,
+        supplier: null,
+        status: 'active',
+        notes: undefined,
+      };
+
+      expect(() => {
+        render(
+          <MantineWrapper>
+            <EquipmentCard {...defaultProps} equipment={sparseEquipment} />
+          </MantineWrapper>
+        );
+      }).not.toThrow();
+
+      expect(screen.getByText('Sparse Equipment')).toBeInTheDocument();
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('calls onError when an error occurs', () => {
+      const errorEquipment = {
+        ...defaultEquipment,
+        equipment_name: null, // This might cause an error
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} equipment={errorEquipment} />
+        </MantineWrapper>
+      );
+
+      // Component should handle the error gracefully
+      // The exact behavior depends on implementation
+    });
+
+    test('returns null when rendering fails', () => {
+      // This test ensures the component handles errors gracefully
+      const invalidEquipment = null;
+
+      const { container } = render(
+        <MantineWrapper>
+          <EquipmentCard {...defaultProps} equipment={invalidEquipment} />
+        </MantineWrapper>
+      );
+
+      // Should not crash and may return null or empty
+    });
+  });
+});

--- a/frontend/src/components/medical/equipment/__tests__/EquipmentFormWrapper.test.jsx
+++ b/frontend/src/components/medical/equipment/__tests__/EquipmentFormWrapper.test.jsx
@@ -1,0 +1,615 @@
+import { vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MantineProvider } from '@mantine/core';
+import '@testing-library/jest-dom';
+import EquipmentFormWrapper from '../EquipmentFormWrapper';
+
+// Mock Date Input component
+vi.mock('@mantine/dates', () => ({
+  DateInput: ({ label, value, onChange, required, ...props }) => (
+    <div>
+      <label htmlFor={`date-${label}`}>{label}{required && ' *'}</label>
+      <input
+        id={`date-${label}`}
+        type="date"
+        value={value ? (value instanceof Date ? value.toISOString().split('T')[0] : value) : ''}
+        onChange={(e) => onChange(e.target.value ? new Date(e.target.value) : null)}
+        data-testid={`date-${label.toLowerCase().replace(/\s+/g, '-')}`}
+        {...props}
+      />
+    </div>
+  ),
+}));
+
+// Mock i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, defaultValue) => defaultValue || key,
+  }),
+}));
+
+// Mock useFormHandlers
+vi.mock('../../../../hooks/useFormHandlers', () => ({
+  useFormHandlers: (onInputChange) => ({
+    handleTextInputChange: (name) => (e) => {
+      onInputChange({ target: { name, value: e.target.value } });
+    },
+  }),
+}));
+
+// Mock TagInput
+vi.mock('../../../common/TagInput', () => ({
+  TagInput: ({ label, value, onChange, placeholder }) => (
+    <div>
+      <label htmlFor="tag-input">{label}</label>
+      <input
+        id="tag-input"
+        type="text"
+        placeholder={placeholder}
+        value={value?.join(', ') || ''}
+        onChange={(e) => onChange(e.target.value.split(', ').filter(Boolean))}
+        data-testid="tag-input"
+      />
+    </div>
+  ),
+}));
+
+// Wrapper component with Mantine provider
+const MantineWrapper = ({ children }) => (
+  <MantineProvider>{children}</MantineProvider>
+);
+
+describe('EquipmentFormWrapper', () => {
+  const defaultFormData = {
+    equipment_name: '',
+    equipment_type: '',
+    manufacturer: '',
+    model_number: '',
+    serial_number: '',
+    prescribed_date: '',
+    last_service_date: '',
+    next_service_date: '',
+    supplier: '',
+    status: 'active',
+    usage_instructions: '',
+    notes: '',
+    tags: [],
+    practitioner_id: '',
+  };
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    title: 'Add New Equipment',
+    editingEquipment: null,
+    formData: defaultFormData,
+    onInputChange: vi.fn(),
+    onSubmit: vi.fn(),
+    practitionersOptions: [
+      { id: 1, name: 'Dr. Smith', specialty: 'Pulmonology' },
+      { id: 2, name: 'Dr. Jones', specialty: 'Sleep Medicine' },
+    ],
+    practitionersLoading: false,
+    isLoading: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    test('renders form modal when open', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Add New Equipment')).toBeInTheDocument();
+    });
+
+    test('does not render when closed', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} isOpen={false} />
+        </MantineWrapper>
+      );
+
+      expect(screen.queryByText('Add New Equipment')).not.toBeInTheDocument();
+    });
+
+    test('renders all form fields', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      // Required fields
+      expect(screen.getByLabelText('Equipment Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Equipment Type')).toBeInTheDocument();
+
+      // Optional fields
+      expect(screen.getByLabelText('Status')).toBeInTheDocument();
+      expect(screen.getByLabelText('Prescribed By')).toBeInTheDocument();
+      expect(screen.getByLabelText('Manufacturer')).toBeInTheDocument();
+      expect(screen.getByLabelText('Model Number')).toBeInTheDocument();
+      expect(screen.getByLabelText('Serial Number')).toBeInTheDocument();
+      expect(screen.getByLabelText('Supplier')).toBeInTheDocument();
+      expect(screen.getByLabelText('Usage Instructions')).toBeInTheDocument();
+      expect(screen.getByLabelText('Notes')).toBeInTheDocument();
+      expect(screen.getByLabelText('Tags')).toBeInTheDocument();
+    });
+
+    test('renders date fields', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByTestId('date-prescribed-date')).toBeInTheDocument();
+      expect(screen.getByTestId('date-last-service-date')).toBeInTheDocument();
+      expect(screen.getByTestId('date-next-service-date')).toBeInTheDocument();
+    });
+
+    test('shows edit mode title and button when editing', () => {
+      const editProps = {
+        ...defaultProps,
+        title: 'Edit Equipment',
+        editingEquipment: { id: 1, equipment_name: 'CPAP Machine' },
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...editProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Edit Equipment')).toBeInTheDocument();
+      expect(screen.getByText('Update Equipment')).toBeInTheDocument();
+    });
+
+    test('shows create button in add mode', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Create Equipment')).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Interactions', () => {
+    test('handles equipment name input changes', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const nameInput = screen.getByLabelText('Equipment Name');
+      await user.type(nameInput, 'ResMed AirSense 11');
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'equipment_name', value: 'ResMed AirSense 11' },
+      });
+    });
+
+    test('handles manufacturer input changes', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const manufacturerInput = screen.getByLabelText('Manufacturer');
+      await user.type(manufacturerInput, 'ResMed');
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'manufacturer', value: 'ResMed' },
+      });
+    });
+
+    test('handles model number input changes', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const modelInput = screen.getByLabelText('Model Number');
+      await user.type(modelInput, 'AS11-Pro');
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'model_number', value: 'AS11-Pro' },
+      });
+    });
+
+    test('handles serial number input changes', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const serialInput = screen.getByLabelText('Serial Number');
+      await user.type(serialInput, 'SN-12345-XYZ');
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'serial_number', value: 'SN-12345-XYZ' },
+      });
+    });
+
+    test('handles equipment type select changes', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const typeSelect = screen.getByLabelText('Equipment Type');
+      await user.click(typeSelect);
+
+      const cpapOption = screen.getByText('CPAP Machine');
+      await user.click(cpapOption);
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'equipment_type', value: 'cpap' },
+      });
+    });
+
+    test('handles status select changes', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const statusSelect = screen.getByLabelText('Status');
+      await user.click(statusSelect);
+
+      const inactiveOption = screen.getByText('Inactive');
+      await user.click(inactiveOption);
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'status', value: 'inactive' },
+      });
+    });
+
+    test('handles practitioner select changes', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const practitionerSelect = screen.getByLabelText('Prescribed By');
+      await user.click(practitionerSelect);
+
+      const doctorOption = screen.getByText('Dr. Smith - Pulmonology');
+      await user.click(doctorOption);
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: '1' },
+      });
+    });
+
+    test('handles usage instructions textarea changes', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const instructionsTextarea = screen.getByLabelText('Usage Instructions');
+      await user.type(instructionsTextarea, 'Use every night for 8 hours');
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'usage_instructions', value: 'Use every night for 8 hours' },
+      });
+    });
+
+    test('handles notes textarea changes', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const notesTextarea = screen.getByLabelText('Notes');
+      await user.type(notesTextarea, 'Patient prefers nasal mask');
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'notes', value: 'Patient prefers nasal mask' },
+      });
+    });
+  });
+
+  describe('Form Submission', () => {
+    test('calls onSubmit when form is submitted', async () => {
+      const user = userEvent.setup();
+      const propsWithData = {
+        ...defaultProps,
+        formData: {
+          ...defaultFormData,
+          equipment_name: 'CPAP Machine',
+          equipment_type: 'cpap',
+        },
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...propsWithData} />
+        </MantineWrapper>
+      );
+
+      const submitButton = screen.getByText('Create Equipment');
+      await user.click(submitButton);
+
+      expect(defaultProps.onSubmit).toHaveBeenCalled();
+    });
+
+    test('calls onClose when cancel button is clicked', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const cancelButton = screen.getByText('Cancel');
+      await user.click(cancelButton);
+
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+
+    test('submit button is disabled without required fields', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const submitButton = screen.getByText('Create Equipment');
+      expect(submitButton).toBeDisabled();
+    });
+
+    test('submit button is enabled with required fields', () => {
+      const propsWithData = {
+        ...defaultProps,
+        formData: {
+          ...defaultFormData,
+          equipment_name: 'CPAP Machine',
+          equipment_type: 'cpap',
+        },
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...propsWithData} />
+        </MantineWrapper>
+      );
+
+      const submitButton = screen.getByText('Create Equipment');
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+
+  describe('Data Population', () => {
+    test('populates form with existing equipment data', () => {
+      const populatedData = {
+        equipment_name: 'Portable Nebulizer',
+        equipment_type: 'nebulizer',
+        manufacturer: 'Omron',
+        model_number: 'NE-C801',
+        serial_number: 'SN-98765',
+        prescribed_date: '2024-02-01',
+        last_service_date: '2024-05-01',
+        next_service_date: '2024-11-01',
+        supplier: 'Medical Supply Co',
+        status: 'active',
+        usage_instructions: 'Use as needed for breathing treatments',
+        notes: 'Keep clean and dry',
+        tags: ['respiratory', 'home use'],
+        practitioner_id: '1',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} formData={populatedData} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByDisplayValue('Portable Nebulizer')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Omron')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('NE-C801')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('SN-98765')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Medical Supply Co')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Use as needed for breathing treatments')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Keep clean and dry')).toBeInTheDocument();
+    });
+  });
+
+  describe('Equipment Type Options', () => {
+    test('displays all equipment type options', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const typeSelect = screen.getByLabelText('Equipment Type');
+      await user.click(typeSelect);
+
+      expect(screen.getByText('CPAP Machine')).toBeInTheDocument();
+      expect(screen.getByText('BiPAP Machine')).toBeInTheDocument();
+      expect(screen.getByText('Nebulizer')).toBeInTheDocument();
+      expect(screen.getByText('Inhaler')).toBeInTheDocument();
+      expect(screen.getByText('Glucose Monitor')).toBeInTheDocument();
+      expect(screen.getByText('Blood Pressure Monitor')).toBeInTheDocument();
+    });
+  });
+
+  describe('Status Options', () => {
+    test('displays all status options', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const statusSelect = screen.getByLabelText('Status');
+      await user.click(statusSelect);
+
+      expect(screen.getByText('Active')).toBeInTheDocument();
+      expect(screen.getByText('Inactive')).toBeInTheDocument();
+      expect(screen.getByText('Replaced')).toBeInTheDocument();
+      expect(screen.getByText('Needs Repair')).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading State', () => {
+    test('shows loading overlay when isLoading is true', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} isLoading={true} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Saving equipment...')).toBeInTheDocument();
+    });
+
+    test('disables cancel button when loading', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} isLoading={true} />
+        </MantineWrapper>
+      );
+
+      const cancelButton = screen.getByText('Cancel');
+      expect(cancelButton).toBeDisabled();
+    });
+
+    test('disables practitioner select when practitioners loading', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} practitionersLoading={true} />
+        </MantineWrapper>
+      );
+
+      const practitionerSelect = screen.getByLabelText('Prescribed By');
+      expect(practitionerSelect).toBeDisabled();
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('handles null/undefined form data gracefully', () => {
+      const propsWithNullData = {
+        ...defaultProps,
+        formData: {
+          equipment_name: null,
+          equipment_type: undefined,
+          manufacturer: '',
+          status: 'active',
+        },
+      };
+
+      expect(() => {
+        render(
+          <MantineWrapper>
+            <EquipmentFormWrapper {...propsWithNullData} />
+          </MantineWrapper>
+        );
+      }).not.toThrow();
+    });
+
+    test('handles empty practitioners list gracefully', () => {
+      const propsWithNoPractitioners = {
+        ...defaultProps,
+        practitionersOptions: [],
+      };
+
+      expect(() => {
+        render(
+          <MantineWrapper>
+            <EquipmentFormWrapper {...propsWithNoPractitioners} />
+          </MantineWrapper>
+        );
+      }).not.toThrow();
+    });
+  });
+
+  describe('Accessibility', () => {
+    test('has proper form structure', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      // Should have form element
+      expect(screen.getByRole('form')).toBeInTheDocument();
+    });
+
+    test('required fields have proper attributes', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const nameInput = screen.getByLabelText('Equipment Name');
+      const typeSelect = screen.getByLabelText('Equipment Type');
+
+      expect(nameInput).toBeRequired();
+      expect(typeSelect).toBeRequired();
+    });
+
+    test('buttons have proper types', () => {
+      const propsWithData = {
+        ...defaultProps,
+        formData: {
+          ...defaultFormData,
+          equipment_name: 'Test',
+          equipment_type: 'cpap',
+        },
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentFormWrapper {...propsWithData} />
+        </MantineWrapper>
+      );
+
+      const submitButton = screen.getByText('Create Equipment');
+      expect(submitButton).toHaveAttribute('type', 'submit');
+    });
+  });
+});

--- a/frontend/src/components/medical/equipment/__tests__/EquipmentViewModal.test.jsx
+++ b/frontend/src/components/medical/equipment/__tests__/EquipmentViewModal.test.jsx
@@ -1,0 +1,670 @@
+import { vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MantineProvider } from '@mantine/core';
+import '@testing-library/jest-dom';
+import EquipmentViewModal from '../EquipmentViewModal';
+
+// Mock useDateFormat hook
+vi.mock('../../../../hooks/useDateFormat', () => ({
+  useDateFormat: () => ({
+    formatDate: (date) => date ? new Date(date).toLocaleDateString('en-US') : null,
+  }),
+}));
+
+// Mock i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, defaultValue) => defaultValue || key,
+  }),
+}));
+
+// Wrapper component with Mantine provider
+const MantineWrapper = ({ children }) => (
+  <MantineProvider>{children}</MantineProvider>
+);
+
+describe('EquipmentViewModal', () => {
+  const defaultEquipment = {
+    id: 1,
+    equipment_name: 'ResMed AirSense 11',
+    equipment_type: 'cpap',
+    manufacturer: 'ResMed',
+    model_number: 'AirSense 11 AutoSet',
+    serial_number: 'SN-12345-CPAP',
+    prescribed_date: '2024-01-15',
+    last_service_date: '2024-06-15',
+    next_service_date: '2024-12-15',
+    supplier: 'Sleep Solutions Inc',
+    status: 'active',
+    usage_instructions: 'Use nightly for 7-8 hours. Clean mask weekly.',
+    notes: 'Patient uses nasal pillow mask. Pressure setting: 10-15 cmH2O',
+    tags: ['sleep apnea', 'nightly use'],
+    practitioner_id: 1,
+    practitioner: { id: 1, name: 'Dr. Smith' },
+  };
+
+  const defaultPractitioners = [
+    { id: 1, name: 'Dr. Smith' },
+    { id: 2, name: 'Dr. Jones' },
+  ];
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    equipment: defaultEquipment,
+    onEdit: vi.fn(),
+    practitioners: defaultPractitioners,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    test('renders modal when open', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Equipment Details')).toBeInTheDocument();
+    });
+
+    test('does not render when closed', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} isOpen={false} />
+        </MantineWrapper>
+      );
+
+      expect(screen.queryByText('Equipment Details')).not.toBeInTheDocument();
+    });
+
+    test('does not render when equipment is null', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={null} />
+        </MantineWrapper>
+      );
+
+      expect(screen.queryByText('Equipment Details')).not.toBeInTheDocument();
+    });
+
+    test('renders equipment name prominently', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      // Equipment name may appear multiple times
+      expect(screen.getAllByText('ResMed AirSense 11').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('renders equipment type badge', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      // Equipment type may appear multiple times
+      expect(screen.getAllByText('CPAP Machine').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('renders status badge', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      // Status may be displayed as is or capitalized by StatusBadge
+      const statusText = screen.queryByText('active') || screen.queryByText('Active');
+      expect(statusText).toBeInTheDocument();
+    });
+  });
+
+  describe('Basic Information Section', () => {
+    test('displays equipment name field', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Equipment Name')).toBeInTheDocument();
+      // Equipment name appears multiple times (header and details)
+      expect(screen.getAllByText('ResMed AirSense 11').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('displays equipment type', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Equipment Type')).toBeInTheDocument();
+      // Equipment type may appear multiple times
+      expect(screen.getAllByText('CPAP Machine').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('displays status', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Status')).toBeInTheDocument();
+    });
+
+    test('displays practitioner when available', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Prescribed By')).toBeInTheDocument();
+      expect(screen.getByText('Dr. Smith')).toBeInTheDocument();
+    });
+
+    test('displays "Not specified" for missing practitioner', () => {
+      const noPractitionerEquipment = {
+        ...defaultEquipment,
+        practitioner_id: null,
+        practitioner: null,
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={noPractitionerEquipment} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getAllByText('Not specified').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Manufacturer Details Section', () => {
+    test('displays manufacturer', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Manufacturer')).toBeInTheDocument();
+      expect(screen.getByText('ResMed')).toBeInTheDocument();
+    });
+
+    test('displays model number', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Model Number')).toBeInTheDocument();
+      expect(screen.getByText('AirSense 11 AutoSet')).toBeInTheDocument();
+    });
+
+    test('displays serial number', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Serial Number')).toBeInTheDocument();
+      expect(screen.getByText('SN-12345-CPAP')).toBeInTheDocument();
+    });
+
+    test('displays supplier', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Supplier')).toBeInTheDocument();
+      expect(screen.getByText('Sleep Solutions Inc')).toBeInTheDocument();
+    });
+  });
+
+  describe('Important Dates Section', () => {
+    test('displays prescribed date', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Prescribed Date')).toBeInTheDocument();
+      expect(screen.getByText('1/15/2024')).toBeInTheDocument();
+    });
+
+    test('displays last service date', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Last Service')).toBeInTheDocument();
+      expect(screen.getByText('6/15/2024')).toBeInTheDocument();
+    });
+
+    test('displays next service date', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Next Service')).toBeInTheDocument();
+      expect(screen.getByText('12/15/2024')).toBeInTheDocument();
+    });
+
+    test('displays "Not specified" for missing dates', () => {
+      const noDatesEquipment = {
+        ...defaultEquipment,
+        prescribed_date: null,
+        last_service_date: null,
+        next_service_date: null,
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={noDatesEquipment} />
+        </MantineWrapper>
+      );
+
+      const notSpecifiedElements = screen.getAllByText('Not specified');
+      expect(notSpecifiedElements.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('Usage Instructions Section', () => {
+    test('displays usage instructions when available', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Usage Instructions')).toBeInTheDocument();
+      expect(screen.getByText('Use nightly for 7-8 hours. Clean mask weekly.')).toBeInTheDocument();
+    });
+
+    test('hides usage instructions section when not available', () => {
+      const noInstructionsEquipment = {
+        ...defaultEquipment,
+        usage_instructions: null,
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={noInstructionsEquipment} />
+        </MantineWrapper>
+      );
+
+      expect(screen.queryByText('Usage Instructions')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Notes Section', () => {
+    test('displays notes when available', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Notes')).toBeInTheDocument();
+      expect(screen.getByText('Patient uses nasal pillow mask. Pressure setting: 10-15 cmH2O')).toBeInTheDocument();
+    });
+
+    test('hides notes section when not available', () => {
+      const noNotesEquipment = {
+        ...defaultEquipment,
+        notes: null,
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={noNotesEquipment} />
+        </MantineWrapper>
+      );
+
+      // Notes header should not appear (as a section title)
+      const sections = screen.queryAllByText('Notes');
+      // May appear in form context but not as a data display section
+    });
+  });
+
+  describe('Tags Section', () => {
+    test('displays tags when available', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Tags')).toBeInTheDocument();
+      expect(screen.getByText('sleep apnea')).toBeInTheDocument();
+      expect(screen.getByText('nightly use')).toBeInTheDocument();
+    });
+
+    test('hides tags section when not available', () => {
+      const noTagsEquipment = {
+        ...defaultEquipment,
+        tags: [],
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={noTagsEquipment} />
+        </MantineWrapper>
+      );
+
+      expect(screen.queryByText('sleep apnea')).not.toBeInTheDocument();
+    });
+
+    test('hides tags section when tags is null', () => {
+      const nullTagsEquipment = {
+        ...defaultEquipment,
+        tags: null,
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={nullTagsEquipment} />
+        </MantineWrapper>
+      );
+
+      // Tags section should not render with null tags
+    });
+  });
+
+  describe('User Interactions', () => {
+    test('calls onClose when close button is clicked', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const closeButton = screen.getByText('Close');
+      await user.click(closeButton);
+
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+
+    test('calls onEdit and onClose when edit button is clicked', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const editButton = screen.getByText('Edit');
+      await user.click(editButton);
+
+      expect(defaultProps.onEdit).toHaveBeenCalledWith(defaultEquipment);
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Equipment Types', () => {
+    test('displays CPAP type correctly', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getAllByText('CPAP Machine').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('displays BiPAP type correctly', () => {
+      const bipapEquipment = {
+        ...defaultEquipment,
+        equipment_type: 'bipap',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={bipapEquipment} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getAllByText('BiPAP Machine').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('displays nebulizer type correctly', () => {
+      const nebulizerEquipment = {
+        ...defaultEquipment,
+        equipment_type: 'nebulizer',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={nebulizerEquipment} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getAllByText('Nebulizer').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('displays glucose monitor type correctly', () => {
+      const glucoseEquipment = {
+        ...defaultEquipment,
+        equipment_type: 'glucose_monitor',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={glucoseEquipment} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getAllByText('Glucose Monitor').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('displays "Not specified" for unknown type', () => {
+      const unknownTypeEquipment = {
+        ...defaultEquipment,
+        equipment_type: null,
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={unknownTypeEquipment} />
+        </MantineWrapper>
+      );
+
+      // Should show "Not specified" for equipment type
+      expect(screen.getAllByText('Not specified').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Status Display', () => {
+    test('displays active status', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const statusText = screen.queryByText('active') || screen.queryByText('Active');
+      expect(statusText).toBeInTheDocument();
+    });
+
+    test('displays inactive status', () => {
+      const inactiveEquipment = {
+        ...defaultEquipment,
+        status: 'inactive',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={inactiveEquipment} />
+        </MantineWrapper>
+      );
+
+      const statusText = screen.queryByText('inactive') || screen.queryByText('Inactive');
+      expect(statusText).toBeInTheDocument();
+    });
+
+    test('displays replaced status', () => {
+      const replacedEquipment = {
+        ...defaultEquipment,
+        status: 'replaced',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={replacedEquipment} />
+        </MantineWrapper>
+      );
+
+      const statusText = screen.queryByText('replaced') || screen.queryByText('Replaced');
+      expect(statusText).toBeInTheDocument();
+    });
+
+    test('displays needs_repair status', () => {
+      const needsRepairEquipment = {
+        ...defaultEquipment,
+        status: 'needs_repair',
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={needsRepairEquipment} />
+        </MantineWrapper>
+      );
+
+      const statusText = screen.queryByText('needs_repair') || screen.queryByText('Needs Repair');
+      expect(statusText).toBeInTheDocument();
+    });
+  });
+
+  describe('Practitioner Lookup', () => {
+    test('uses practitioner from equipment object when available', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Dr. Smith')).toBeInTheDocument();
+    });
+
+    test('looks up practitioner from practitioners list when not embedded', () => {
+      const equipmentWithIdOnly = {
+        ...defaultEquipment,
+        practitioner: null,
+        practitioner_id: 2,
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={equipmentWithIdOnly} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Dr. Jones')).toBeInTheDocument();
+    });
+
+    test('shows practitioner ID when not found in list', () => {
+      const equipmentWithUnknownPractitioner = {
+        ...defaultEquipment,
+        practitioner: null,
+        practitioner_id: 999,
+      };
+
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} equipment={equipmentWithUnknownPractitioner} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByText('Practitioner #999')).toBeInTheDocument();
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('handles minimal equipment data gracefully', () => {
+      const minimalEquipment = {
+        id: 99,
+        equipment_name: 'Basic Equipment',
+        status: 'active',
+      };
+
+      expect(() => {
+        render(
+          <MantineWrapper>
+            <EquipmentViewModal {...defaultProps} equipment={minimalEquipment} />
+          </MantineWrapper>
+        );
+      }).not.toThrow();
+
+      // Equipment name may appear multiple times (title and details)
+      expect(screen.getAllByText('Basic Equipment').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('handles empty practitioners list gracefully', () => {
+      expect(() => {
+        render(
+          <MantineWrapper>
+            <EquipmentViewModal {...defaultProps} practitioners={[]} />
+          </MantineWrapper>
+        );
+      }).not.toThrow();
+    });
+  });
+
+  describe('Accessibility', () => {
+    test('has proper modal structure', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    test('has edit button with icon', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const editButton = screen.getByText('Edit');
+      expect(editButton).toBeInTheDocument();
+    });
+
+    test('has close button', () => {
+      render(
+        <MantineWrapper>
+          <EquipmentViewModal {...defaultProps} />
+        </MantineWrapper>
+      );
+
+      const closeButton = screen.getByText('Close');
+      expect(closeButton).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/medical/treatments/RelationshipComponents.jsx
+++ b/frontend/src/components/medical/treatments/RelationshipComponents.jsx
@@ -1,0 +1,361 @@
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import {
+  ActionIcon,
+  Alert,
+  Box,
+  Button,
+  Group,
+  LoadingOverlay,
+  Modal,
+  Paper,
+  Stack,
+  Text,
+} from '@mantine/core';
+import {
+  IconCheck,
+  IconEdit,
+  IconInfoCircle,
+  IconPlus,
+  IconTrash,
+  IconX,
+} from '@tabler/icons-react';
+
+/**
+ * Container with loading overlay for relationship components.
+ */
+export function RelationshipContainer({ loading, children }) {
+  return (
+    <Box pos="relative">
+      <LoadingOverlay
+        visible={loading}
+        zIndex={1000}
+        overlayProps={{ radius: 'sm', blur: 2 }}
+      />
+      {children}
+    </Box>
+  );
+}
+
+RelationshipContainer.propTypes = {
+  loading: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+/**
+ * Dismissible error alert for relationship components.
+ */
+export function RelationshipErrorAlert({ error, onDismiss }) {
+  if (!error) return null;
+
+  return (
+    <Alert
+      icon={<IconInfoCircle size={16} />}
+      color="red"
+      variant="light"
+      onClose={onDismiss}
+      withCloseButton
+    >
+      {error}
+    </Alert>
+  );
+}
+
+RelationshipErrorAlert.propTypes = {
+  error: PropTypes.string,
+  onDismiss: PropTypes.func,
+};
+
+/**
+ * Empty state display when no relationships exist.
+ */
+export function RelationshipEmptyState({
+  message,
+  description,
+  isViewMode,
+}) {
+  return (
+    <Paper withBorder p="md" ta="center">
+      <Text c="dimmed">{message}</Text>
+      {!isViewMode && description && (
+        <Text size="xs" c="dimmed" mt="xs">
+          {description}
+        </Text>
+      )}
+    </Paper>
+  );
+}
+
+RelationshipEmptyState.propTypes = {
+  message: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  isViewMode: PropTypes.bool,
+};
+
+/**
+ * Footer section with available count and add button.
+ */
+export function RelationshipAddFooter({
+  availableCount,
+  entityName,
+  entityNamePlural,
+  buttonLabel,
+  onAdd,
+  loading,
+}) {
+  const { t } = useTranslation('common');
+  const plural = availableCount !== 1;
+  const displayName = plural ? (entityNamePlural || `${entityName}s`) : entityName;
+
+  return (
+    <Group justify="space-between" align="center">
+      <Text size="sm" c="dimmed">
+        {availableCount} {displayName} available to link
+      </Text>
+      <Button
+        variant="light"
+        leftSection={<IconPlus size={16} />}
+        onClick={onAdd}
+        disabled={loading || availableCount === 0}
+      >
+        {buttonLabel || t('buttons.link', 'Link')}
+      </Button>
+    </Group>
+  );
+}
+
+RelationshipAddFooter.propTypes = {
+  availableCount: PropTypes.number.isRequired,
+  entityName: PropTypes.string.isRequired,
+  entityNamePlural: PropTypes.string,
+  buttonLabel: PropTypes.string,
+  onAdd: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+};
+
+/**
+ * Edit/Delete action buttons for a relationship row.
+ */
+export function RelationshipRowActions({
+  isEditing,
+  onSave,
+  onCancel,
+  onEdit,
+  onDelete,
+  loading,
+}) {
+  if (isEditing) {
+    return (
+      <Group gap="xs">
+        <ActionIcon
+          variant="light"
+          color="green"
+          size="sm"
+          onClick={onSave}
+          disabled={loading}
+        >
+          <IconCheck size={14} />
+        </ActionIcon>
+        <ActionIcon
+          variant="light"
+          color="gray"
+          size="sm"
+          onClick={onCancel}
+        >
+          <IconX size={14} />
+        </ActionIcon>
+      </Group>
+    );
+  }
+
+  return (
+    <Group gap="xs">
+      <ActionIcon
+        variant="light"
+        color="blue"
+        size="sm"
+        onClick={onEdit}
+      >
+        <IconEdit size={14} />
+      </ActionIcon>
+      <ActionIcon
+        variant="light"
+        color="red"
+        size="sm"
+        onClick={onDelete}
+        disabled={loading}
+      >
+        <IconTrash size={14} />
+      </ActionIcon>
+    </Group>
+  );
+}
+
+RelationshipRowActions.propTypes = {
+  isEditing: PropTypes.bool,
+  onSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+};
+
+/**
+ * Standard modal for adding relationships.
+ */
+export function RelationshipAddModal({
+  opened,
+  onClose,
+  title,
+  children,
+}) {
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={title}
+      size="md"
+      centered
+      zIndex={3000}
+    >
+      <Stack gap="md">
+        {children}
+      </Stack>
+    </Modal>
+  );
+}
+
+RelationshipAddModal.propTypes = {
+  opened: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node,
+};
+
+/**
+ * Modal footer with cancel and submit buttons.
+ */
+export function RelationshipModalFooter({
+  onCancel,
+  onSubmit,
+  loading,
+  disabled,
+  submitLabel,
+}) {
+  const { t } = useTranslation('common');
+
+  return (
+    <Group justify="flex-end" gap="sm">
+      <Button variant="light" onClick={onCancel}>
+        {t('buttons.cancel', 'Cancel')}
+      </Button>
+      <Button
+        onClick={onSubmit}
+        loading={loading}
+        disabled={disabled}
+      >
+        {submitLabel}
+      </Button>
+    </Group>
+  );
+}
+
+RelationshipModalFooter.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  disabled: PropTypes.bool,
+  submitLabel: PropTypes.string.isRequired,
+};
+
+/**
+ * Wrapper for relationship row in the list.
+ */
+export function RelationshipRow({ children }) {
+  return (
+    <Paper withBorder p="md">
+      <Group justify="space-between" align="flex-start">
+        {children}
+      </Group>
+    </Paper>
+  );
+}
+
+RelationshipRow.propTypes = {
+  children: PropTypes.node,
+};
+
+/**
+ * Formats a date string for display with readable format (e.g., "Jan 15, 2025").
+ */
+export function formatDateDisplay(dateString) {
+  if (!dateString) return '';
+  try {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return dateString;
+  }
+}
+
+/**
+ * Gets display label from options array.
+ */
+export function getOptionLabel(value, options) {
+  if (!value) return value;
+  const option = options.find(opt => opt.value === value);
+  return option ? option.label : value;
+}
+
+/**
+ * Filters available options by removing already linked items.
+ */
+export function filterAvailableOptions(allOptions, linkedItems, idField) {
+  if (!Array.isArray(allOptions)) return [];
+  if (!Array.isArray(linkedItems)) return allOptions;
+  const linkedIdStrings = linkedItems.map(rel => rel[idField]?.toString());
+  return allOptions.filter(option => !linkedIdStrings.includes(option.value));
+}
+
+/**
+ * Creates options array for MultiSelect from entity list.
+ */
+export function createSelectOptions(entities, labelFn) {
+  if (!Array.isArray(entities)) return [];
+  return entities.map(entity => ({
+    value: entity.id.toString(),
+    label: labelFn(entity),
+  }));
+}
+
+/**
+ * Creates options array sorted by date (most recent first).
+ * @param {Array} entities - List of entities with date field
+ * @param {Function} labelFn - Function to create label from entity
+ * @param {string} dateField - Name of the date field to sort by
+ * @returns {Array} Sorted options array
+ */
+export function createDateSortedOptions(entities, labelFn, dateField) {
+  if (!Array.isArray(entities)) return [];
+
+  // Sort by date (most recent first), items without dates go to the end
+  const sorted = [...entities].sort((a, b) => {
+    const dateA = a[dateField] ? new Date(a[dateField]) : null;
+    const dateB = b[dateField] ? new Date(b[dateField]) : null;
+
+    if (!dateA && !dateB) return 0;
+    if (!dateA) return 1;
+    if (!dateB) return -1;
+
+    return dateB - dateA; // Most recent first
+  });
+
+  return sorted.map(entity => ({
+    value: entity.id.toString(),
+    label: labelFn(entity),
+  }));
+}

--- a/frontend/src/components/medical/treatments/TreatmentCard.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentCard.jsx
@@ -50,14 +50,34 @@ const TreatmentCard = ({
     }
   };
 
+  // Treatment category labels mapping
+  const TREATMENT_CATEGORY_LABELS = {
+    medication_therapy: 'Medication Therapy',
+    physical_therapy: 'Physical Therapy',
+    surgery_procedure: 'Surgery / Procedure',
+    lifestyle_dietary: 'Lifestyle / Dietary',
+    monitoring: 'Monitoring / Observation',
+    mental_health: 'Mental Health / Counseling',
+    rehabilitation: 'Rehabilitation',
+    alternative: 'Alternative / Complementary',
+    combination: 'Combination Therapy',
+    other: 'Other',
+  };
+
+  // Get display label for treatment type (supports both predefined and custom values)
+  const getTreatmentTypeLabel = (type) => {
+    if (!type) return null;
+    return TREATMENT_CATEGORY_LABELS[type] || type;
+  };
+
   try {
     // Generate badges based on treatment properties
     const badges = [];
-    
+
     if (treatment.treatment_type) {
-      badges.push({ 
-        label: treatment.treatment_type, 
-        color: 'blue' 
+      badges.push({
+        label: getTreatmentTypeLabel(treatment.treatment_type),
+        color: 'blue'
       });
     }
 
@@ -145,7 +165,7 @@ const TreatmentCard = ({
     return (
       <BaseMedicalCard
         title={titleContent}
-        subtitle={tCommon('treatments.card.subtitle', 'Medical Treatment')}
+        subtitle={treatment.treatment_type ? getTreatmentTypeLabel(treatment.treatment_type) : null}
         badges={badges.filter(badge => !badge.clickable)} // Only include non-clickable badges
         fields={fields}
         notes={treatment.notes}

--- a/frontend/src/components/medical/treatments/TreatmentEncounterRelationships.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentEncounterRelationships.jsx
@@ -1,0 +1,305 @@
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import {
+  Badge,
+  Group,
+  MultiSelect,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { IconStethoscope } from '@tabler/icons-react';
+import { useTreatmentRelationships } from '../../../hooks/useTreatmentRelationships';
+import {
+  RelationshipContainer,
+  RelationshipErrorAlert,
+  RelationshipEmptyState,
+  RelationshipAddFooter,
+  RelationshipRowActions,
+  RelationshipAddModal,
+  RelationshipModalFooter,
+  RelationshipRow,
+  createDateSortedOptions,
+  filterAvailableOptions,
+  formatDateDisplay,
+  getOptionLabel,
+} from './RelationshipComponents';
+
+const VISIT_LABEL_OPTIONS = [
+  { value: 'initial', label: 'Initial Visit' },
+  { value: 'follow_up', label: 'Follow-up' },
+  { value: 'review', label: 'Review' },
+  { value: 'final', label: 'Final Visit' },
+  { value: 'other', label: 'Other' },
+];
+
+const INITIAL_RELATIONSHIP_STATE = {
+  encounter_ids: [],
+  visit_label: '',
+  visit_sequence: '',
+  relevance_note: '',
+};
+
+const EDIT_FIELDS = ['visit_label', 'visit_sequence', 'relevance_note'];
+
+function buildSinglePayload(newRelationship) {
+  return {
+    encounter_id: parseInt(newRelationship.encounter_ids[0]),
+    visit_label: newRelationship.visit_label || null,
+    visit_sequence: newRelationship.visit_sequence ? parseInt(newRelationship.visit_sequence) : null,
+    relevance_note: newRelationship.relevance_note || null,
+  };
+}
+
+function buildBulkPayload(newRelationship) {
+  return [
+    newRelationship.encounter_ids.map(id => parseInt(id)),
+    newRelationship.relevance_note || null,
+  ];
+}
+
+function formatEncounterLabel(encounter) {
+  const date = formatDateDisplay(encounter.date);
+  const type = encounter.visit_type || 'Visit';
+  let label = `${date} - ${type}`;
+  if (encounter.reason) {
+    label += ` (${encounter.reason})`;
+  }
+  return label;
+}
+
+function TreatmentEncounterRelationships({
+  treatmentId,
+  encounters,
+  isViewMode = false,
+  onRelationshipsChange,
+  onEntityClick,
+}) {
+  const { t } = useTranslation('common');
+  // Ensure encounters is always an array
+  const safeEncounters = Array.isArray(encounters) ? encounters : [];
+
+  const {
+    relationships,
+    loading,
+    showAddModal,
+    editingRelationship,
+    newRelationship,
+    error,
+    handleAddRelationship,
+    handleEditRelationship,
+    handleDeleteRelationship,
+    resetAndCloseModal,
+    openAddModal,
+    startEditing,
+    cancelEditing,
+    updateNewRelationship,
+    updateEditingRelationship,
+    clearError,
+  } = useTreatmentRelationships({
+    type: 'encounter',
+    treatmentId,
+    initialState: INITIAL_RELATIONSHIP_STATE,
+    onRelationshipsChange,
+    buildSinglePayload,
+    buildBulkPayload,
+  });
+
+  const getEncounterById = (encounterId) => {
+    return safeEncounters.find(e => e.id === encounterId);
+  };
+
+  const encounterOptions = createDateSortedOptions(safeEncounters, formatEncounterLabel, 'date');
+  const availableOptions = filterAvailableOptions(encounterOptions, relationships, 'encounter_id');
+  const selectedCount = newRelationship.encounter_ids.length;
+
+  return (
+    <RelationshipContainer loading={loading}>
+      <Stack gap="md">
+        <RelationshipErrorAlert error={error} onDismiss={clearError} />
+
+        {relationships.length > 0 ? (
+          <Stack gap="sm">
+            {relationships.map(relationship => {
+              const encounter = relationship.encounter || getEncounterById(relationship.encounter_id);
+              const isEditing = editingRelationship?.id === relationship.id;
+
+              return (
+                <RelationshipRow key={relationship.id}>
+                  <Stack gap="xs" style={{ flex: 1 }}>
+                    <Group gap="sm" wrap="wrap">
+                      <Badge
+                        variant="light"
+                        color="blue"
+                        leftSection={<IconStethoscope size={12} />}
+                        style={isViewMode && onEntityClick ? { cursor: 'pointer' } : undefined}
+                        onClick={isViewMode && onEntityClick ? () => onEntityClick(relationship.encounter_id) : undefined}
+                      >
+                        {formatDateDisplay(encounter?.date)} - {encounter?.visit_type || 'Visit'}
+                      </Badge>
+                      {relationship.visit_label && (
+                        <Badge variant="outline" size="sm" color="cyan">
+                          {getOptionLabel(relationship.visit_label, VISIT_LABEL_OPTIONS)}
+                        </Badge>
+                      )}
+                      {relationship.visit_sequence && (
+                        <Badge variant="outline" size="sm" color="grape">
+                          Visit #{relationship.visit_sequence}
+                        </Badge>
+                      )}
+                    </Group>
+
+                    {encounter?.reason && (
+                      <Text size="sm" c="dimmed">
+                        <strong>Reason:</strong> {encounter.reason}
+                      </Text>
+                    )}
+
+                    {!isViewMode && isEditing ? (
+                      <Stack gap="xs">
+                        <Select
+                          size="xs"
+                          placeholder="Visit label"
+                          data={VISIT_LABEL_OPTIONS}
+                          value={editingRelationship?.visit_label || ''}
+                          onChange={(value) => updateEditingRelationship('visit_label', value)}
+                          clearable
+                          comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                        />
+                        <TextInput
+                          size="xs"
+                          placeholder="Visit sequence number"
+                          type="number"
+                          value={editingRelationship?.visit_sequence || ''}
+                          onChange={(e) => updateEditingRelationship('visit_sequence', e.target.value)}
+                        />
+                        <Textarea
+                          size="xs"
+                          placeholder="Relevance note"
+                          value={editingRelationship?.relevance_note || ''}
+                          onChange={(e) => updateEditingRelationship('relevance_note', e.target.value)}
+                          autosize
+                          minRows={2}
+                        />
+                      </Stack>
+                    ) : (
+                      relationship.relevance_note && (
+                        <Text size="sm" c="dimmed" fs="italic">
+                          {relationship.relevance_note}
+                        </Text>
+                      )
+                    )}
+                  </Stack>
+
+                  {!isViewMode && (
+                    <RelationshipRowActions
+                      isEditing={isEditing}
+                      onSave={() => handleEditRelationship(relationship.id, {
+                        visit_label: editingRelationship?.visit_label || null,
+                        visit_sequence: editingRelationship?.visit_sequence
+                          ? parseInt(editingRelationship.visit_sequence)
+                          : null,
+                        relevance_note: editingRelationship?.relevance_note || null,
+                      })}
+                      onCancel={cancelEditing}
+                      onEdit={() => startEditing(relationship, EDIT_FIELDS)}
+                      onDelete={() => handleDeleteRelationship(relationship.id)}
+                      loading={loading}
+                    />
+                  )}
+                </RelationshipRow>
+              );
+            })}
+          </Stack>
+        ) : (
+          <RelationshipEmptyState
+            message={t('labels.noEncountersLinked', 'No visits linked to this treatment')}
+            description="Link visits to track appointments related to this treatment plan."
+            isViewMode={isViewMode}
+          />
+        )}
+
+        {!isViewMode && (
+          <RelationshipAddFooter
+            availableCount={availableOptions.length}
+            entityName="visit"
+            buttonLabel={t('buttons.linkVisit', 'Link Visit')}
+            onAdd={openAddModal}
+            loading={loading}
+          />
+        )}
+
+        <RelationshipAddModal
+          opened={showAddModal}
+          onClose={resetAndCloseModal}
+          title="Link Visits to Treatment"
+        >
+          <MultiSelect
+            label="Select Visits"
+            placeholder="Choose visits to link"
+            data={availableOptions}
+            value={newRelationship.encounter_ids}
+            onChange={(values) => updateNewRelationship('encounter_ids', values)}
+            searchable
+            clearable
+            required
+            comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+          />
+
+          {selectedCount === 1 && (
+            <>
+              <Select
+                label="Visit Label (Optional)"
+                placeholder="Select visit type"
+                data={VISIT_LABEL_OPTIONS}
+                value={newRelationship.visit_label}
+                onChange={(value) => updateNewRelationship('visit_label', value || '')}
+                clearable
+                comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                description="Categorize this visit in the treatment plan"
+              />
+
+              <TextInput
+                label="Visit Sequence (Optional)"
+                placeholder="e.g., 1, 2, 3..."
+                type="number"
+                value={newRelationship.visit_sequence}
+                onChange={(e) => updateNewRelationship('visit_sequence', e.target.value)}
+                description="Order of this visit in the treatment plan"
+              />
+            </>
+          )}
+
+          <Textarea
+            label="Relevance Note (Optional)"
+            placeholder="Describe how this visit relates to the treatment"
+            value={newRelationship.relevance_note}
+            onChange={(e) => updateNewRelationship('relevance_note', e.target.value)}
+            autosize
+            minRows={2}
+          />
+
+          <RelationshipModalFooter
+            onCancel={resetAndCloseModal}
+            onSubmit={handleAddRelationship}
+            loading={loading}
+            disabled={selectedCount === 0}
+            submitLabel={selectedCount > 1 ? `Link ${selectedCount} Visits` : 'Link Visit'}
+          />
+        </RelationshipAddModal>
+      </Stack>
+    </RelationshipContainer>
+  );
+}
+
+TreatmentEncounterRelationships.propTypes = {
+  treatmentId: PropTypes.number,
+  encounters: PropTypes.array,
+  isViewMode: PropTypes.bool,
+  onRelationshipsChange: PropTypes.func,
+  onEntityClick: PropTypes.func,
+};
+
+export default TreatmentEncounterRelationships;

--- a/frontend/src/components/medical/treatments/TreatmentEquipmentRelationships.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentEquipmentRelationships.jsx
@@ -1,0 +1,812 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import {
+  Badge,
+  Button,
+  Group,
+  MultiSelect,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  Paper,
+  ActionIcon,
+  Alert,
+  Modal,
+  LoadingOverlay,
+  Box,
+  Tabs,
+  Divider,
+} from '@mantine/core';
+import { DateInput } from '@mantine/dates';
+import {
+  IconDeviceDesktop,
+  IconPlus,
+  IconTrash,
+  IconEdit,
+  IconCheck,
+  IconX,
+  IconInfoCircle,
+} from '@tabler/icons-react';
+import { apiService } from '../../../services/api';
+import logger from '../../../services/logger';
+import { parseDateInput, formatDateInputChange } from '../../../utils/dateUtils';
+import {
+  EQUIPMENT_TYPE_OPTIONS,
+  EQUIPMENT_STATUS_OPTIONS,
+  getEquipmentTypeLabel,
+  getEquipmentStatusColor,
+  formatEquipmentLabel,
+} from '../../../constants/equipmentConstants';
+
+const INITIAL_RELATIONSHIP_STATE = {
+  equipment_ids: [],
+  usage_frequency: '',
+  specific_settings: '',
+  relevance_note: '',
+};
+
+const INITIAL_NEW_EQUIPMENT_STATE = {
+  equipment_name: '',
+  equipment_type: '',
+  manufacturer: '',
+  model_number: '',
+  serial_number: '',
+  prescribed_date: null,
+  usage_instructions: '',
+  status: 'active',
+  supplier: '',
+  notes: '',
+};
+
+const EDIT_FIELDS = ['usage_frequency', 'specific_settings', 'relevance_note'];
+
+function TreatmentEquipmentRelationships({
+  treatmentId,
+  patientId,
+  equipment,
+  practitioners,
+  isViewMode = false,
+  onRelationshipsChange,
+  onEquipmentCreated,
+  onEntityClick,
+}) {
+  // Ensure equipment is always an array
+  const safeEquipment = Array.isArray(equipment) ? equipment : [];
+  const safePractitioners = Array.isArray(practitioners) ? practitioners : [];
+  const { t } = useTranslation('common');
+  const { t: tErrors } = useTranslation('errors');
+
+  const [relationships, setRelationships] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [editingRelationship, setEditingRelationship] = useState(null);
+  const [newRelationship, setNewRelationship] = useState(INITIAL_RELATIONSHIP_STATE);
+  const [error, setError] = useState(null);
+
+  // For inline equipment creation
+  const [addMode, setAddMode] = useState('existing'); // 'existing' or 'new'
+  const [newEquipment, setNewEquipment] = useState(INITIAL_NEW_EQUIPMENT_STATE);
+  const [creatingEquipment, setCreatingEquipment] = useState(false);
+
+  // Ref to track callback without causing re-renders
+  const onRelationshipsChangeRef = useRef(onRelationshipsChange);
+  useEffect(() => {
+    onRelationshipsChangeRef.current = onRelationshipsChange;
+  }, [onRelationshipsChange]);
+
+  const resetAndCloseModal = useCallback(() => {
+    setShowAddModal(false);
+    setNewRelationship(INITIAL_RELATIONSHIP_STATE);
+    setNewEquipment(INITIAL_NEW_EQUIPMENT_STATE);
+    setAddMode('existing');
+    setError(null);
+  }, []);
+
+  // Fetch relationships
+  const fetchRelationships = useCallback(async (signal) => {
+    if (!treatmentId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await apiService.getTreatmentEquipment(treatmentId, signal);
+
+      if (signal?.aborted) return;
+
+      setRelationships(data || []);
+      if (onRelationshipsChangeRef.current) {
+        onRelationshipsChangeRef.current(data || []);
+      }
+    } catch (err) {
+      if (err.name === 'AbortError' || signal?.aborted) return;
+
+      logger.error('treatment_equipment_fetch_error', {
+        treatmentId,
+        error: err.message,
+        component: 'TreatmentEquipmentRelationships',
+      });
+      setError(err.message || 'Failed to load equipment relationships');
+    } finally {
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
+    }
+  }, [treatmentId]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchRelationships(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
+  }, [fetchRelationships]);
+
+  // Create new equipment and link it
+  const handleCreateAndLinkEquipment = async () => {
+    if (!newEquipment.equipment_name?.trim() || !newEquipment.equipment_type) {
+      setError(tErrors('form.equipmentFieldsRequired', 'Equipment name and type are required'));
+      return;
+    }
+
+    if (!patientId) {
+      setError('Patient information is required to create equipment');
+      return;
+    }
+
+    setCreatingEquipment(true);
+    setError(null);
+
+    let createdEquipment = null;
+
+    try {
+      // Create the equipment first - include patient_id
+      const equipmentData = {
+        ...newEquipment,
+        patient_id: patientId,
+        prescribed_date: newEquipment.prescribed_date
+          ? formatDateInputChange(newEquipment.prescribed_date)
+          : null,
+      };
+
+      createdEquipment = await apiService.createMedicalEquipment(equipmentData);
+
+      // Now link it to the treatment
+      await apiService.linkTreatmentEquipment(treatmentId, {
+        equipment_id: createdEquipment.id,
+        usage_frequency: newRelationship.usage_frequency || null,
+        specific_settings: newRelationship.specific_settings || null,
+        relevance_note: newRelationship.relevance_note || null,
+      });
+
+      // Notify parent that equipment was created (so it can refresh its list)
+      if (onEquipmentCreated) {
+        onEquipmentCreated(createdEquipment);
+      }
+
+      await fetchRelationships();
+      resetAndCloseModal();
+    } catch (err) {
+      // If equipment was created but linking failed, clean up orphaned equipment
+      if (createdEquipment?.id) {
+        try {
+          await apiService.deleteMedicalEquipment(createdEquipment.id);
+          logger.info('treatment_equipment_orphan_cleanup', {
+            treatmentId,
+            equipmentId: createdEquipment.id,
+            component: 'TreatmentEquipmentRelationships',
+          });
+        } catch (cleanupErr) {
+          logger.error('treatment_equipment_orphan_cleanup_failed', {
+            treatmentId,
+            equipmentId: createdEquipment.id,
+            error: cleanupErr.message,
+            component: 'TreatmentEquipmentRelationships',
+          });
+        }
+      }
+
+      logger.error('treatment_equipment_create_link_error', {
+        treatmentId,
+        error: err.message,
+        component: 'TreatmentEquipmentRelationships',
+      });
+      setError(err.response?.data?.detail || err.message || 'Failed to create and link equipment');
+    } finally {
+      setCreatingEquipment(false);
+    }
+  };
+
+  // Link existing equipment
+  const handleAddRelationship = async () => {
+    if (addMode === 'new') {
+      return handleCreateAndLinkEquipment();
+    }
+
+    if (!newRelationship.equipment_ids || newRelationship.equipment_ids.length === 0) {
+      setError(tErrors('form.equipmentNotSelected', 'Please select at least one equipment'));
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      if (newRelationship.equipment_ids.length > 1) {
+        await apiService.linkTreatmentEquipmentBulk(
+          treatmentId,
+          newRelationship.equipment_ids.map(id => parseInt(id)),
+          newRelationship.relevance_note || null
+        );
+      } else {
+        await apiService.linkTreatmentEquipment(treatmentId, {
+          equipment_id: parseInt(newRelationship.equipment_ids[0]),
+          usage_frequency: newRelationship.usage_frequency || null,
+          specific_settings: newRelationship.specific_settings || null,
+          relevance_note: newRelationship.relevance_note || null,
+        });
+      }
+
+      await fetchRelationships();
+      resetAndCloseModal();
+    } catch (err) {
+      logger.error('treatment_equipment_add_error', {
+        treatmentId,
+        error: err.message,
+        component: 'TreatmentEquipmentRelationships',
+      });
+      setError(err.response?.data?.detail || err.message || 'Failed to add equipment relationship');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEditRelationship = async (relationshipId, updates) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await apiService.updateTreatmentEquipment(treatmentId, relationshipId, updates);
+      await fetchRelationships();
+      setEditingRelationship(null);
+    } catch (err) {
+      logger.error('treatment_equipment_update_error', {
+        treatmentId,
+        relationshipId,
+        error: err.message,
+        component: 'TreatmentEquipmentRelationships',
+      });
+      setError(err.response?.data?.detail || err.message || 'Failed to update equipment relationship');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteRelationship = async (relationshipId) => {
+    if (!window.confirm(t('messages.confirmRemoveEquipmentRelationship', 'Are you sure you want to remove this equipment link?'))) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await apiService.unlinkTreatmentEquipment(treatmentId, relationshipId);
+      await fetchRelationships();
+    } catch (err) {
+      logger.error('treatment_equipment_delete_error', {
+        treatmentId,
+        relationshipId,
+        error: err.message,
+        component: 'TreatmentEquipmentRelationships',
+      });
+      setError(err.response?.data?.detail || err.message || 'Failed to delete equipment relationship');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getEquipmentById = (equipmentId) => {
+    return safeEquipment.find(e => e.id === equipmentId);
+  };
+
+  const startEditing = (relationship) => {
+    setEditingRelationship({
+      id: relationship.id,
+      usage_frequency: relationship.usage_frequency || '',
+      specific_settings: relationship.specific_settings || '',
+      relevance_note: relationship.relevance_note || '',
+    });
+  };
+
+  // Prepare equipment options
+  const equipmentOptions = safeEquipment.map(eq => ({
+    value: eq.id.toString(),
+    label: formatEquipmentLabel(eq),
+  }));
+
+  const linkedEquipmentIds = relationships.map(rel => rel.equipment_id.toString());
+  const availableOptions = equipmentOptions.filter(
+    option => !linkedEquipmentIds.includes(option.value)
+  );
+
+  const selectedCount = newRelationship.equipment_ids.length;
+
+  return (
+    <Box pos="relative">
+      <LoadingOverlay visible={loading || creatingEquipment} zIndex={1000} overlayProps={{ radius: "sm", blur: 2 }} />
+
+      <Stack gap="md">
+        {error && (
+          <Alert
+            icon={<IconInfoCircle size={16} />}
+            color="red"
+            variant="light"
+            onClose={() => setError(null)}
+            withCloseButton
+          >
+            {error}
+          </Alert>
+        )}
+
+        {/* Existing Relationships */}
+        {relationships.length > 0 ? (
+          <Stack gap="sm">
+            {relationships.map(relationship => {
+              const eq = relationship.equipment || getEquipmentById(relationship.equipment_id);
+              const isEditing = editingRelationship?.id === relationship.id;
+              const typeLabel = getEquipmentTypeLabel(eq?.equipment_type);
+
+              return (
+                <Paper key={relationship.id} withBorder p="md">
+                  <Group justify="space-between" align="flex-start">
+                    <Stack gap="xs" style={{ flex: 1 }}>
+                      <Group gap="sm" wrap="wrap">
+                        <Badge
+                          variant="light"
+                          color="orange"
+                          leftSection={<IconDeviceDesktop size={12} />}
+                          style={isViewMode && onEntityClick && relationship.equipment_id ? { cursor: 'pointer' } : undefined}
+                          onClick={isViewMode && onEntityClick && relationship.equipment_id ? () => onEntityClick(relationship.equipment_id) : undefined}
+                        >
+                          {eq?.equipment_name || `Equipment ID: ${relationship.equipment_id}`}
+                        </Badge>
+                        {typeLabel && (
+                          <Badge variant="outline" size="sm" color="blue">
+                            {typeLabel}
+                          </Badge>
+                        )}
+                        {eq?.status && (
+                          <Badge variant="outline" size="sm" color={getEquipmentStatusColor(eq.status)}>
+                            {eq.status}
+                          </Badge>
+                        )}
+                        {relationship.usage_frequency && (
+                          <Badge variant="outline" size="sm" color="grape">
+                            {relationship.usage_frequency}
+                          </Badge>
+                        )}
+                      </Group>
+
+                      {eq?.manufacturer && (
+                        <Text size="sm" c="dimmed">
+                          <strong>Manufacturer:</strong> {eq.manufacturer}
+                          {eq.model_number && ` | Model: ${eq.model_number}`}
+                        </Text>
+                      )}
+
+                      {relationship.specific_settings && (
+                        <Text size="sm" c="dimmed">
+                          <strong>Settings:</strong> {relationship.specific_settings}
+                        </Text>
+                      )}
+
+                      {!isViewMode && isEditing ? (
+                        <Stack gap="xs">
+                          <TextInput
+                            size="xs"
+                            placeholder="Usage frequency (e.g., Nightly, As needed)"
+                            value={editingRelationship?.usage_frequency || ''}
+                            onChange={(e) => setEditingRelationship(prev => ({
+                              ...prev,
+                              usage_frequency: e.target.value,
+                            }))}
+                          />
+                          <TextInput
+                            size="xs"
+                            placeholder="Specific settings (e.g., Pressure: 10 cmH2O)"
+                            value={editingRelationship?.specific_settings || ''}
+                            onChange={(e) => setEditingRelationship(prev => ({
+                              ...prev,
+                              specific_settings: e.target.value,
+                            }))}
+                          />
+                          <Textarea
+                            size="xs"
+                            placeholder="Relevance note"
+                            value={editingRelationship?.relevance_note || ''}
+                            onChange={(e) => setEditingRelationship(prev => ({
+                              ...prev,
+                              relevance_note: e.target.value,
+                            }))}
+                            autosize
+                            minRows={2}
+                          />
+                        </Stack>
+                      ) : (
+                        relationship.relevance_note && (
+                          <Text size="sm" c="dimmed" fs="italic">
+                            {relationship.relevance_note}
+                          </Text>
+                        )
+                      )}
+                    </Stack>
+
+                    {!isViewMode && (
+                      <Group gap="xs">
+                        {isEditing ? (
+                          <>
+                            <ActionIcon
+                              variant="light"
+                              color="green"
+                              size="sm"
+                              onClick={() => handleEditRelationship(relationship.id, {
+                                usage_frequency: editingRelationship?.usage_frequency || null,
+                                specific_settings: editingRelationship?.specific_settings || null,
+                                relevance_note: editingRelationship?.relevance_note || null,
+                              })}
+                              disabled={loading}
+                            >
+                              <IconCheck size={14} />
+                            </ActionIcon>
+                            <ActionIcon
+                              variant="light"
+                              color="gray"
+                              size="sm"
+                              onClick={() => setEditingRelationship(null)}
+                            >
+                              <IconX size={14} />
+                            </ActionIcon>
+                          </>
+                        ) : (
+                          <>
+                            <ActionIcon
+                              variant="light"
+                              color="blue"
+                              size="sm"
+                              onClick={() => startEditing(relationship)}
+                            >
+                              <IconEdit size={14} />
+                            </ActionIcon>
+                            <ActionIcon
+                              variant="light"
+                              color="red"
+                              size="sm"
+                              onClick={() => handleDeleteRelationship(relationship.id)}
+                              disabled={loading}
+                            >
+                              <IconTrash size={14} />
+                            </ActionIcon>
+                          </>
+                        )}
+                      </Group>
+                    )}
+                  </Group>
+                </Paper>
+              );
+            })}
+          </Stack>
+        ) : (
+          <Paper withBorder p="md" ta="center">
+            <Text c="dimmed">{t('labels.noEquipmentLinked', 'No equipment linked to this treatment')}</Text>
+            {!isViewMode && (
+              <Text size="xs" c="dimmed" mt="xs">
+                Link medical equipment like CPAP machines, inhalers, or monitors.
+              </Text>
+            )}
+          </Paper>
+        )}
+
+        {/* Add Button */}
+        {!isViewMode && (
+          <Group justify="space-between" align="center">
+            <Text size="sm" c="dimmed">
+              {availableOptions.length} equipment item{availableOptions.length !== 1 ? 's' : ''} available to link
+            </Text>
+            <Button
+              variant="light"
+              leftSection={<IconPlus size={16} />}
+              onClick={() => setShowAddModal(true)}
+              disabled={loading}
+            >
+              {t('buttons.linkEquipment', 'Link Equipment')}
+            </Button>
+          </Group>
+        )}
+
+        {/* Add Modal with Tabs for Existing/New Equipment */}
+        <Modal
+          opened={showAddModal}
+          onClose={resetAndCloseModal}
+          title="Link Equipment to Treatment"
+          size="lg"
+          centered
+          zIndex={3000}
+        >
+          <Stack gap="md">
+            {error && (
+              <Alert
+                icon={<IconInfoCircle size={16} />}
+                color="red"
+                variant="light"
+                onClose={() => setError(null)}
+                withCloseButton
+              >
+                {error}
+              </Alert>
+            )}
+
+            <Tabs value={addMode} onChange={setAddMode}>
+              <Tabs.List>
+                <Tabs.Tab value="existing">Link Existing</Tabs.Tab>
+                <Tabs.Tab value="new">Create New</Tabs.Tab>
+              </Tabs.List>
+
+              {/* Existing Equipment Tab */}
+              <Tabs.Panel value="existing" pt="md">
+                <Stack gap="md">
+                  {availableOptions.length > 0 ? (
+                    <>
+                      <MultiSelect
+                        label="Select Equipment"
+                        placeholder="Choose equipment to link"
+                        data={availableOptions}
+                        value={newRelationship.equipment_ids}
+                        onChange={(values) => setNewRelationship(prev => ({
+                          ...prev,
+                          equipment_ids: values,
+                        }))}
+                        searchable
+                        clearable
+                        required
+                        comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                      />
+
+                      {selectedCount === 1 && (
+                        <>
+                          <TextInput
+                            label="Usage Frequency (Optional)"
+                            placeholder="e.g., Nightly, As needed, 3x daily"
+                            value={newRelationship.usage_frequency}
+                            onChange={(e) => setNewRelationship(prev => ({
+                              ...prev,
+                              usage_frequency: e.target.value,
+                            }))}
+                            description="How often this equipment is used for this treatment"
+                          />
+
+                          <TextInput
+                            label="Specific Settings (Optional)"
+                            placeholder="e.g., Pressure: 10 cmH2O, Flow: 2L/min"
+                            value={newRelationship.specific_settings}
+                            onChange={(e) => setNewRelationship(prev => ({
+                              ...prev,
+                              specific_settings: e.target.value,
+                            }))}
+                            description="Treatment-specific equipment settings"
+                          />
+                        </>
+                      )}
+
+                      <Textarea
+                        label="Relevance Note (Optional)"
+                        placeholder="Describe how this equipment relates to the treatment"
+                        value={newRelationship.relevance_note}
+                        onChange={(e) => setNewRelationship(prev => ({
+                          ...prev,
+                          relevance_note: e.target.value,
+                        }))}
+                        autosize
+                        minRows={2}
+                      />
+                    </>
+                  ) : (
+                    <Alert color="blue" variant="light">
+                      No equipment available to link. Use the "Create New" tab to add equipment.
+                    </Alert>
+                  )}
+                </Stack>
+              </Tabs.Panel>
+
+              {/* Create New Equipment Tab */}
+              <Tabs.Panel value="new" pt="md">
+                <Stack gap="md">
+                  <Text size="sm" c="dimmed">
+                    Create new equipment and automatically link it to this treatment.
+                  </Text>
+
+                  <Divider label="Equipment Details" labelPosition="center" />
+
+                  <TextInput
+                    label="Equipment Name"
+                    placeholder="e.g., ResMed AirSense 11"
+                    value={newEquipment.equipment_name}
+                    onChange={(e) => setNewEquipment(prev => ({
+                      ...prev,
+                      equipment_name: e.target.value,
+                    }))}
+                    required
+                  />
+
+                  <Select
+                    label="Equipment Type"
+                    placeholder="Select type"
+                    data={EQUIPMENT_TYPE_OPTIONS}
+                    value={newEquipment.equipment_type}
+                    onChange={(value) => setNewEquipment(prev => ({
+                      ...prev,
+                      equipment_type: value || '',
+                    }))}
+                    searchable
+                    required
+                    comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                  />
+
+                  <Group grow>
+                    <TextInput
+                      label="Manufacturer"
+                      placeholder="e.g., ResMed, Philips"
+                      value={newEquipment.manufacturer}
+                      onChange={(e) => setNewEquipment(prev => ({
+                        ...prev,
+                        manufacturer: e.target.value,
+                      }))}
+                    />
+                    <TextInput
+                      label="Model Number"
+                      placeholder="e.g., AirSense 11"
+                      value={newEquipment.model_number}
+                      onChange={(e) => setNewEquipment(prev => ({
+                        ...prev,
+                        model_number: e.target.value,
+                      }))}
+                    />
+                  </Group>
+
+                  <Group grow>
+                    <TextInput
+                      label="Serial Number"
+                      placeholder="Equipment serial number"
+                      value={newEquipment.serial_number}
+                      onChange={(e) => setNewEquipment(prev => ({
+                        ...prev,
+                        serial_number: e.target.value,
+                      }))}
+                    />
+                    <DateInput
+                      label="Prescribed Date"
+                      placeholder="Select date"
+                      value={parseDateInput(newEquipment.prescribed_date)}
+                      onChange={(date) => setNewEquipment(prev => ({
+                        ...prev,
+                        prescribed_date: date,
+                      }))}
+                      clearable
+                      popoverProps={{ withinPortal: true, zIndex: 4000 }}
+                    />
+                  </Group>
+
+                  <Group grow>
+                    <Select
+                      label="Status"
+                      data={EQUIPMENT_STATUS_OPTIONS}
+                      value={newEquipment.status}
+                      onChange={(value) => setNewEquipment(prev => ({
+                        ...prev,
+                        status: value || 'active',
+                      }))}
+                      comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                    />
+                    <TextInput
+                      label="Supplier"
+                      placeholder="Equipment supplier"
+                      value={newEquipment.supplier}
+                      onChange={(e) => setNewEquipment(prev => ({
+                        ...prev,
+                        supplier: e.target.value,
+                      }))}
+                    />
+                  </Group>
+
+                  <Textarea
+                    label="Usage Instructions"
+                    placeholder="How to use this equipment"
+                    value={newEquipment.usage_instructions}
+                    onChange={(e) => setNewEquipment(prev => ({
+                      ...prev,
+                      usage_instructions: e.target.value,
+                    }))}
+                    autosize
+                    minRows={2}
+                  />
+
+                  <Divider label="Link Settings" labelPosition="center" />
+
+                  <TextInput
+                    label="Usage Frequency (Optional)"
+                    placeholder="e.g., Nightly, As needed"
+                    value={newRelationship.usage_frequency}
+                    onChange={(e) => setNewRelationship(prev => ({
+                      ...prev,
+                      usage_frequency: e.target.value,
+                    }))}
+                  />
+
+                  <TextInput
+                    label="Specific Settings (Optional)"
+                    placeholder="e.g., Pressure: 10 cmH2O"
+                    value={newRelationship.specific_settings}
+                    onChange={(e) => setNewRelationship(prev => ({
+                      ...prev,
+                      specific_settings: e.target.value,
+                    }))}
+                  />
+
+                  <Textarea
+                    label="Relevance Note (Optional)"
+                    placeholder="How this equipment relates to the treatment"
+                    value={newRelationship.relevance_note}
+                    onChange={(e) => setNewRelationship(prev => ({
+                      ...prev,
+                      relevance_note: e.target.value,
+                    }))}
+                    autosize
+                    minRows={2}
+                  />
+                </Stack>
+              </Tabs.Panel>
+            </Tabs>
+
+            <Group justify="flex-end" gap="sm" mt="md">
+              <Button variant="light" onClick={resetAndCloseModal}>
+                {t('buttons.cancel', 'Cancel')}
+              </Button>
+              <Button
+                onClick={handleAddRelationship}
+                loading={loading || creatingEquipment}
+                disabled={
+                  addMode === 'existing'
+                    ? selectedCount === 0
+                    : !newEquipment.equipment_name?.trim() || !newEquipment.equipment_type
+                }
+              >
+                {addMode === 'new'
+                  ? 'Create & Link Equipment'
+                  : selectedCount > 1
+                    ? `Link ${selectedCount} Equipment`
+                    : 'Link Equipment'}
+              </Button>
+            </Group>
+          </Stack>
+        </Modal>
+      </Stack>
+    </Box>
+  );
+}
+
+TreatmentEquipmentRelationships.propTypes = {
+  treatmentId: PropTypes.number,
+  patientId: PropTypes.number,
+  equipment: PropTypes.array,
+  practitioners: PropTypes.array,
+  isViewMode: PropTypes.bool,
+  onRelationshipsChange: PropTypes.func,
+  onEquipmentCreated: PropTypes.func,
+  onEntityClick: PropTypes.func,
+};
+
+export default TreatmentEquipmentRelationships;

--- a/frontend/src/components/medical/treatments/TreatmentLabResultRelationships.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentLabResultRelationships.jsx
@@ -1,0 +1,316 @@
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import {
+  Badge,
+  Group,
+  MultiSelect,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { IconTestPipe } from '@tabler/icons-react';
+import { useTreatmentRelationships } from '../../../hooks/useTreatmentRelationships';
+import {
+  RelationshipContainer,
+  RelationshipErrorAlert,
+  RelationshipEmptyState,
+  RelationshipAddFooter,
+  RelationshipRowActions,
+  RelationshipAddModal,
+  RelationshipModalFooter,
+  RelationshipRow,
+  createDateSortedOptions,
+  filterAvailableOptions,
+  formatDateDisplay,
+  getOptionLabel,
+} from './RelationshipComponents';
+
+const PURPOSE_OPTIONS = [
+  { value: 'baseline', label: 'Baseline' },
+  { value: 'monitoring', label: 'Monitoring' },
+  { value: 'outcome', label: 'Outcome' },
+  { value: 'safety', label: 'Safety' },
+  { value: 'other', label: 'Other' },
+];
+
+const PURPOSE_COLORS = {
+  baseline: 'blue',
+  monitoring: 'cyan',
+  outcome: 'green',
+  safety: 'orange',
+};
+
+const INITIAL_RELATIONSHIP_STATE = {
+  lab_result_ids: [],
+  purpose: '',
+  expected_frequency: '',
+  relevance_note: '',
+};
+
+const EDIT_FIELDS = ['purpose', 'expected_frequency', 'relevance_note'];
+
+function buildSinglePayload(newRelationship) {
+  return {
+    lab_result_id: parseInt(newRelationship.lab_result_ids[0]),
+    purpose: newRelationship.purpose || null,
+    expected_frequency: newRelationship.expected_frequency || null,
+    relevance_note: newRelationship.relevance_note || null,
+  };
+}
+
+function buildBulkPayload(newRelationship) {
+  return [
+    newRelationship.lab_result_ids.map(id => parseInt(id)),
+    newRelationship.purpose || null,
+    newRelationship.relevance_note || null,
+  ];
+}
+
+function formatLabResultLabel(labResult) {
+  // Put date first for easier scanning in dropdowns
+  // Use completed_date if available, fall back to ordered_date
+  const dateValue = labResult.completed_date || labResult.ordered_date;
+  const date = dateValue ? formatDateDisplay(dateValue) : null;
+  let label = date ? `${date} - ${labResult.test_name}` : labResult.test_name;
+  if (labResult.labs_result) {
+    label += ` (${labResult.labs_result})`;
+  }
+  return label;
+}
+
+function getPurposeColor(purpose) {
+  return PURPOSE_COLORS[purpose] || 'gray';
+}
+
+function TreatmentLabResultRelationships({
+  treatmentId,
+  labResults,
+  isViewMode = false,
+  onRelationshipsChange,
+  onEntityClick,
+}) {
+  const { t } = useTranslation('common');
+  // Ensure labResults is always an array
+  const safeLabResults = Array.isArray(labResults) ? labResults : [];
+
+  const {
+    relationships,
+    loading,
+    showAddModal,
+    editingRelationship,
+    newRelationship,
+    error,
+    handleAddRelationship,
+    handleEditRelationship,
+    handleDeleteRelationship,
+    resetAndCloseModal,
+    openAddModal,
+    startEditing,
+    cancelEditing,
+    updateNewRelationship,
+    updateEditingRelationship,
+    clearError,
+  } = useTreatmentRelationships({
+    type: 'labResult',
+    treatmentId,
+    initialState: INITIAL_RELATIONSHIP_STATE,
+    onRelationshipsChange,
+    buildSinglePayload,
+    buildBulkPayload,
+  });
+
+  const getLabResultById = (labResultId) => {
+    return safeLabResults.find(lab => lab.id === labResultId);
+  };
+
+  const labResultOptions = createDateSortedOptions(safeLabResults, formatLabResultLabel, 'completed_date');
+  const availableOptions = filterAvailableOptions(labResultOptions, relationships, 'lab_result_id');
+  const selectedCount = newRelationship.lab_result_ids.length;
+
+  return (
+    <RelationshipContainer loading={loading}>
+      <Stack gap="md">
+        <RelationshipErrorAlert error={error} onDismiss={clearError} />
+
+        {relationships.length > 0 ? (
+          <Stack gap="sm">
+            {relationships.map(relationship => {
+              const labResult = relationship.lab_result || getLabResultById(relationship.lab_result_id);
+              const isEditing = editingRelationship?.id === relationship.id;
+
+              return (
+                <RelationshipRow key={relationship.id}>
+                  <Stack gap="xs" style={{ flex: 1 }}>
+                    <Group gap="sm" wrap="wrap">
+                      <Badge
+                        variant="light"
+                        color="violet"
+                        leftSection={<IconTestPipe size={12} />}
+                        style={isViewMode && onEntityClick ? { cursor: 'pointer' } : undefined}
+                        onClick={isViewMode && onEntityClick ? () => onEntityClick(relationship.lab_result_id) : undefined}
+                      >
+                        {labResult?.test_name || `Lab Result ID: ${relationship.lab_result_id}`}
+                      </Badge>
+                      {relationship.purpose && (
+                        <Badge variant="outline" size="sm" color={getPurposeColor(relationship.purpose)}>
+                          {getOptionLabel(relationship.purpose, PURPOSE_OPTIONS)}
+                        </Badge>
+                      )}
+                      {relationship.expected_frequency && (
+                        <Badge variant="outline" size="sm" color="grape">
+                          {relationship.expected_frequency}
+                        </Badge>
+                      )}
+                    </Group>
+
+                    {(labResult?.completed_date || labResult?.ordered_date) && (
+                      <Text size="sm" c="dimmed">
+                        <strong>Date:</strong> {formatDateDisplay(labResult.completed_date || labResult.ordered_date)}
+                        {labResult?.labs_result && ` | Result: ${labResult.labs_result}`}
+                      </Text>
+                    )}
+
+                    {!isViewMode && isEditing ? (
+                      <Stack gap="xs">
+                        <Select
+                          size="xs"
+                          placeholder="Purpose"
+                          data={PURPOSE_OPTIONS}
+                          value={editingRelationship?.purpose || ''}
+                          onChange={(value) => updateEditingRelationship('purpose', value)}
+                          clearable
+                          comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                        />
+                        <TextInput
+                          size="xs"
+                          placeholder="Expected frequency (e.g., Monthly)"
+                          value={editingRelationship?.expected_frequency || ''}
+                          onChange={(e) => updateEditingRelationship('expected_frequency', e.target.value)}
+                        />
+                        <Textarea
+                          size="xs"
+                          placeholder="Relevance note"
+                          value={editingRelationship?.relevance_note || ''}
+                          onChange={(e) => updateEditingRelationship('relevance_note', e.target.value)}
+                          autosize
+                          minRows={2}
+                        />
+                      </Stack>
+                    ) : (
+                      relationship.relevance_note && (
+                        <Text size="sm" c="dimmed" fs="italic">
+                          {relationship.relevance_note}
+                        </Text>
+                      )
+                    )}
+                  </Stack>
+
+                  {!isViewMode && (
+                    <RelationshipRowActions
+                      isEditing={isEditing}
+                      onSave={() => handleEditRelationship(relationship.id, {
+                        purpose: editingRelationship?.purpose || null,
+                        expected_frequency: editingRelationship?.expected_frequency || null,
+                        relevance_note: editingRelationship?.relevance_note || null,
+                      })}
+                      onCancel={cancelEditing}
+                      onEdit={() => startEditing(relationship, EDIT_FIELDS)}
+                      onDelete={() => handleDeleteRelationship(relationship.id)}
+                      loading={loading}
+                    />
+                  )}
+                </RelationshipRow>
+              );
+            })}
+          </Stack>
+        ) : (
+          <RelationshipEmptyState
+            message={t('labels.noLabResultsLinked', 'No lab results linked to this treatment')}
+            description="Link lab results to track baseline, monitoring, and outcome tests."
+            isViewMode={isViewMode}
+          />
+        )}
+
+        {!isViewMode && (
+          <RelationshipAddFooter
+            availableCount={availableOptions.length}
+            entityName="lab result"
+            buttonLabel={t('buttons.linkLabResult', 'Link Lab Result')}
+            onAdd={openAddModal}
+            loading={loading}
+          />
+        )}
+
+        <RelationshipAddModal
+          opened={showAddModal}
+          onClose={resetAndCloseModal}
+          title="Link Lab Results to Treatment"
+        >
+          <MultiSelect
+            label="Select Lab Results"
+            placeholder="Choose lab results to link"
+            data={availableOptions}
+            value={newRelationship.lab_result_ids}
+            onChange={(values) => updateNewRelationship('lab_result_ids', values)}
+            searchable
+            clearable
+            required
+            comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+          />
+
+          {selectedCount === 1 && (
+            <>
+              <Select
+                label="Purpose (Optional)"
+                placeholder="Select purpose"
+                data={PURPOSE_OPTIONS}
+                value={newRelationship.purpose}
+                onChange={(value) => updateNewRelationship('purpose', value || '')}
+                clearable
+                comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                description="Why this lab is part of the treatment plan"
+              />
+
+              <TextInput
+                label="Expected Frequency (Optional)"
+                placeholder="e.g., Monthly, Weekly, As needed"
+                value={newRelationship.expected_frequency}
+                onChange={(e) => updateNewRelationship('expected_frequency', e.target.value)}
+                description="How often this test should be done"
+              />
+            </>
+          )}
+
+          <Textarea
+            label="Relevance Note (Optional)"
+            placeholder="Describe how this lab result relates to the treatment"
+            value={newRelationship.relevance_note}
+            onChange={(e) => updateNewRelationship('relevance_note', e.target.value)}
+            autosize
+            minRows={2}
+          />
+
+          <RelationshipModalFooter
+            onCancel={resetAndCloseModal}
+            onSubmit={handleAddRelationship}
+            loading={loading}
+            disabled={selectedCount === 0}
+            submitLabel={selectedCount > 1 ? `Link ${selectedCount} Lab Results` : 'Link Lab Result'}
+          />
+        </RelationshipAddModal>
+      </Stack>
+    </RelationshipContainer>
+  );
+}
+
+TreatmentLabResultRelationships.propTypes = {
+  treatmentId: PropTypes.number,
+  labResults: PropTypes.array,
+  isViewMode: PropTypes.bool,
+  onRelationshipsChange: PropTypes.func,
+  onEntityClick: PropTypes.func,
+};
+
+export default TreatmentLabResultRelationships;

--- a/frontend/src/components/medical/treatments/TreatmentMedicationRelationships.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentMedicationRelationships.jsx
@@ -1,0 +1,305 @@
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import {
+  Badge,
+  Group,
+  MultiSelect,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { IconPill } from '@tabler/icons-react';
+import { useTreatmentRelationships } from '../../../hooks/useTreatmentRelationships';
+import {
+  RelationshipContainer,
+  RelationshipErrorAlert,
+  RelationshipEmptyState,
+  RelationshipAddFooter,
+  RelationshipRowActions,
+  RelationshipAddModal,
+  RelationshipModalFooter,
+  RelationshipRow,
+  createSelectOptions,
+  filterAvailableOptions,
+} from './RelationshipComponents';
+
+const INITIAL_RELATIONSHIP_STATE = {
+  medication_ids: [],
+  specific_dosage: '',
+  specific_frequency: '',
+  specific_duration: '',
+  timing_instructions: '',
+  relevance_note: '',
+};
+
+const EDIT_FIELDS = ['specific_dosage', 'specific_frequency', 'relevance_note'];
+
+function buildSinglePayload(newRelationship) {
+  return {
+    medication_id: parseInt(newRelationship.medication_ids[0]),
+    specific_dosage: newRelationship.specific_dosage || null,
+    specific_frequency: newRelationship.specific_frequency || null,
+    specific_duration: newRelationship.specific_duration || null,
+    timing_instructions: newRelationship.timing_instructions || null,
+    relevance_note: newRelationship.relevance_note || null,
+  };
+}
+
+function buildBulkPayload(newRelationship) {
+  return [
+    newRelationship.medication_ids.map(id => parseInt(id)),
+    newRelationship.relevance_note || null,
+  ];
+}
+
+function formatMedicationLabel(medication) {
+  let label = medication.medication_name;
+  if (medication.dosage) {
+    label += ` (${medication.dosage})`;
+  }
+  if (medication.status) {
+    label += ` - ${medication.status}`;
+  }
+  return label;
+}
+
+function TreatmentMedicationRelationships({
+  treatmentId,
+  medications,
+  isViewMode = false,
+  onRelationshipsChange,
+  onEntityClick,
+}) {
+  const { t } = useTranslation('common');
+  // Ensure medications is always an array
+  const safeMedications = Array.isArray(medications) ? medications : [];
+
+  const {
+    relationships,
+    loading,
+    showAddModal,
+    editingRelationship,
+    newRelationship,
+    error,
+    handleAddRelationship,
+    handleEditRelationship,
+    handleDeleteRelationship,
+    resetAndCloseModal,
+    openAddModal,
+    startEditing,
+    cancelEditing,
+    updateNewRelationship,
+    updateEditingRelationship,
+    clearError,
+  } = useTreatmentRelationships({
+    type: 'medication',
+    treatmentId,
+    initialState: INITIAL_RELATIONSHIP_STATE,
+    onRelationshipsChange,
+    buildSinglePayload,
+    buildBulkPayload,
+  });
+
+  const getMedicationById = (medicationId) => {
+    return safeMedications.find(m => m.id === medicationId);
+  };
+
+  const medicationOptions = createSelectOptions(safeMedications, formatMedicationLabel);
+  const availableOptions = filterAvailableOptions(medicationOptions, relationships, 'medication_id');
+  const selectedCount = newRelationship.medication_ids.length;
+
+  return (
+    <RelationshipContainer loading={loading}>
+      <Stack gap="md">
+        <RelationshipErrorAlert error={error} onDismiss={clearError} />
+
+        {relationships.length > 0 ? (
+          <Stack gap="sm">
+            {relationships.map(relationship => {
+              const medication = relationship.medication || getMedicationById(relationship.medication_id);
+              const isEditing = editingRelationship?.id === relationship.id;
+
+              return (
+                <RelationshipRow key={relationship.id}>
+                  <Stack gap="xs" style={{ flex: 1 }}>
+                    <Group gap="sm" wrap="wrap">
+                      <Badge
+                        variant="light"
+                        color="teal"
+                        leftSection={<IconPill size={12} />}
+                        style={isViewMode && onEntityClick ? { cursor: 'pointer' } : undefined}
+                        onClick={isViewMode && onEntityClick ? () => onEntityClick(relationship.medication_id) : undefined}
+                      >
+                        {medication?.medication_name || `Medication ID: ${relationship.medication_id}`}
+                      </Badge>
+                      {(relationship.specific_dosage || medication?.dosage) && (
+                        <Badge variant="outline" size="sm">
+                          {relationship.specific_dosage || medication?.dosage}
+                        </Badge>
+                      )}
+                      {(relationship.specific_frequency || medication?.frequency) && (
+                        <Badge variant="outline" size="sm" color="cyan">
+                          {relationship.specific_frequency || medication?.frequency}
+                        </Badge>
+                      )}
+                      {relationship.specific_duration && (
+                        <Badge variant="outline" size="sm" color="grape">
+                          {relationship.specific_duration}
+                        </Badge>
+                      )}
+                      {medication?.status && (
+                        <Badge variant="outline" size="sm" color="green">
+                          {medication.status}
+                        </Badge>
+                      )}
+                    </Group>
+
+                    {relationship.timing_instructions && (
+                      <Text size="sm" c="dimmed">
+                        <strong>Timing:</strong> {relationship.timing_instructions}
+                      </Text>
+                    )}
+
+                    {!isViewMode && isEditing ? (
+                      <Stack gap="xs">
+                        <TextInput
+                          size="xs"
+                          placeholder="Specific dosage for this treatment"
+                          value={editingRelationship?.specific_dosage || ''}
+                          onChange={(e) => updateEditingRelationship('specific_dosage', e.target.value)}
+                        />
+                        <TextInput
+                          size="xs"
+                          placeholder="Specific frequency"
+                          value={editingRelationship?.specific_frequency || ''}
+                          onChange={(e) => updateEditingRelationship('specific_frequency', e.target.value)}
+                        />
+                        <Textarea
+                          size="xs"
+                          placeholder="Relevance note"
+                          value={editingRelationship?.relevance_note || ''}
+                          onChange={(e) => updateEditingRelationship('relevance_note', e.target.value)}
+                          autosize
+                          minRows={2}
+                        />
+                      </Stack>
+                    ) : (
+                      relationship.relevance_note && (
+                        <Text size="sm" c="dimmed" fs="italic">
+                          {relationship.relevance_note}
+                        </Text>
+                      )
+                    )}
+                  </Stack>
+
+                  {!isViewMode && (
+                    <RelationshipRowActions
+                      isEditing={isEditing}
+                      onSave={() => handleEditRelationship(relationship.id, {
+                        specific_dosage: editingRelationship?.specific_dosage || null,
+                        specific_frequency: editingRelationship?.specific_frequency || null,
+                        relevance_note: editingRelationship?.relevance_note || null,
+                      })}
+                      onCancel={cancelEditing}
+                      onEdit={() => startEditing(relationship, EDIT_FIELDS)}
+                      onDelete={() => handleDeleteRelationship(relationship.id)}
+                      loading={loading}
+                    />
+                  )}
+                </RelationshipRow>
+              );
+            })}
+          </Stack>
+        ) : (
+          <RelationshipEmptyState
+            message={t('labels.noMedicationsLinked', 'No medications linked to this treatment')}
+            description="Link medications to track what is prescribed for this treatment plan."
+            isViewMode={isViewMode}
+          />
+        )}
+
+        {!isViewMode && (
+          <RelationshipAddFooter
+            availableCount={availableOptions.length}
+            entityName="medication"
+            buttonLabel={t('buttons.linkMedication', 'Link Medication')}
+            onAdd={openAddModal}
+            loading={loading}
+          />
+        )}
+
+        <RelationshipAddModal
+          opened={showAddModal}
+          onClose={resetAndCloseModal}
+          title="Link Medications to Treatment"
+        >
+          <MultiSelect
+            label="Select Medications"
+            placeholder="Choose medications to link"
+            data={availableOptions}
+            value={newRelationship.medication_ids}
+            onChange={(values) => updateNewRelationship('medication_ids', values)}
+            searchable
+            clearable
+            required
+            comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+          />
+
+          {selectedCount === 1 && (
+            <>
+              <TextInput
+                label="Specific Dosage (Optional)"
+                placeholder="e.g., 400mg 3x daily with meals"
+                value={newRelationship.specific_dosage}
+                onChange={(e) => updateNewRelationship('specific_dosage', e.target.value)}
+                description="Override the medication's default dosage for this treatment"
+              />
+
+              <TextInput
+                label="Duration (Optional)"
+                placeholder="e.g., 2 weeks, Until symptoms resolve"
+                value={newRelationship.specific_duration}
+                onChange={(e) => updateNewRelationship('specific_duration', e.target.value)}
+              />
+
+              <TextInput
+                label="Timing Instructions (Optional)"
+                placeholder="e.g., Take 30 min before PT session"
+                value={newRelationship.timing_instructions}
+                onChange={(e) => updateNewRelationship('timing_instructions', e.target.value)}
+              />
+            </>
+          )}
+
+          <Textarea
+            label="Relevance Note (Optional)"
+            placeholder="Describe how this medication relates to the treatment"
+            value={newRelationship.relevance_note}
+            onChange={(e) => updateNewRelationship('relevance_note', e.target.value)}
+            autosize
+            minRows={2}
+          />
+
+          <RelationshipModalFooter
+            onCancel={resetAndCloseModal}
+            onSubmit={handleAddRelationship}
+            loading={loading}
+            disabled={selectedCount === 0}
+            submitLabel={selectedCount > 1 ? `Link ${selectedCount} Medications` : 'Link Medication'}
+          />
+        </RelationshipAddModal>
+      </Stack>
+    </RelationshipContainer>
+  );
+}
+
+TreatmentMedicationRelationships.propTypes = {
+  treatmentId: PropTypes.number,
+  medications: PropTypes.array,
+  isViewMode: PropTypes.bool,
+  onRelationshipsChange: PropTypes.func,
+  onEntityClick: PropTypes.func,
+};
+
+export default TreatmentMedicationRelationships;

--- a/frontend/src/components/medical/treatments/TreatmentPlanSetup.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentPlanSetup.jsx
@@ -1,0 +1,599 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Tabs,
+  Badge,
+  Stack,
+  Box,
+  MultiSelect,
+  Select,
+  Paper,
+  Text,
+  TextInput,
+  Textarea,
+  LoadingOverlay,
+  Group,
+  Collapse,
+  UnstyledButton,
+} from '@mantine/core';
+import {
+  IconPill,
+  IconStethoscope,
+  IconTestPipe,
+  IconDeviceDesktop,
+  IconChevronDown,
+  IconChevronRight,
+} from '@tabler/icons-react';
+import { apiService } from '../../../services/api';
+import logger from '../../../services/logger';
+import {
+  createDateSortedOptions,
+  formatDateDisplay,
+} from './RelationshipComponents';
+
+// Options for select fields
+const VISIT_LABEL_OPTIONS = [
+  { value: 'initial', label: 'Initial Visit' },
+  { value: 'follow_up', label: 'Follow-up' },
+  { value: 'review', label: 'Review' },
+  { value: 'final', label: 'Final Visit' },
+  { value: 'other', label: 'Other' },
+];
+
+const PURPOSE_OPTIONS = [
+  { value: 'baseline', label: 'Baseline' },
+  { value: 'monitoring', label: 'Monitoring' },
+  { value: 'outcome', label: 'Outcome' },
+  { value: 'safety', label: 'Safety' },
+  { value: 'other', label: 'Other' },
+];
+
+/**
+ * Collapsible item card for showing/editing relationship details
+ */
+const ItemDetailsCard = ({ label, color, icon: Icon, children, defaultOpen = false }) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <Paper withBorder p="xs">
+      <UnstyledButton onClick={() => setIsOpen(!isOpen)} style={{ width: '100%' }}>
+        <Group justify="space-between">
+          <Group gap="xs">
+            <Badge size="sm" variant="light" color={color} leftSection={<Icon size={12} />}>
+              {label}
+            </Badge>
+          </Group>
+          {isOpen ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
+        </Group>
+      </UnstyledButton>
+      <Collapse in={isOpen}>
+        <Stack gap="xs" mt="xs">
+          {children}
+        </Stack>
+      </Collapse>
+    </Paper>
+  );
+};
+
+ItemDetailsCard.propTypes = {
+  label: PropTypes.string.isRequired,
+  color: PropTypes.string.isRequired,
+  icon: PropTypes.elementType.isRequired,
+  children: PropTypes.node.isRequired,
+  defaultOpen: PropTypes.bool,
+};
+
+/**
+ * Treatment Plan Setup for creation mode.
+ * Allows selecting relationships before the treatment exists.
+ * Selections are stored locally and passed to parent for bulk creation after treatment is created.
+ */
+const TreatmentPlanSetup = ({
+  pendingRelationships,
+  onRelationshipsChange,
+}) => {
+  const [activeTab, setActiveTab] = useState('medications');
+  const [loading, setLoading] = useState(true);
+
+  // Available entities for selection
+  const [medications, setMedications] = useState([]);
+  const [encounters, setEncounters] = useState([]);
+  const [labResults, setLabResults] = useState([]);
+  const [equipment, setEquipment] = useState([]);
+
+  const isMountedRef = useRef(true);
+
+  // Fetch available entities
+  const fetchEntities = useCallback(async (signal) => {
+    setLoading(true);
+    try {
+      const [medsData, encountersData, labsData, equipmentData] = await Promise.all([
+        apiService.getMedications(signal).catch(() => []),
+        apiService.getEncounters(signal).catch(() => []),
+        apiService.getLabResults(signal).catch(() => []),
+        apiService.getMedicalEquipment(signal).catch(() => []),
+      ]);
+
+      if (!signal?.aborted && isMountedRef.current) {
+        setMedications(Array.isArray(medsData) ? medsData : []);
+        setEncounters(Array.isArray(encountersData) ? encountersData : []);
+        setLabResults(Array.isArray(labsData) ? labsData : []);
+        setEquipment(Array.isArray(equipmentData) ? equipmentData : []);
+        setLoading(false);
+      }
+    } catch (err) {
+      if (err.name !== 'AbortError' && isMountedRef.current) {
+        logger.error('treatment_plan_setup_fetch_error', { error: err.message });
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    const controller = new AbortController();
+    fetchEntities(controller.signal);
+
+    return () => {
+      isMountedRef.current = false;
+      controller.abort();
+    };
+  }, [fetchEntities]);
+
+  // Format functions for select options
+  const formatMedicationLabel = (med) => {
+    let label = med.medication_name;
+    if (med.dosage) label += ` (${med.dosage})`;
+    if (med.status) label += ` - ${med.status}`;
+    return label;
+  };
+
+  const formatEncounterLabel = (enc) => {
+    const date = formatDateDisplay(enc.date);
+    const type = enc.visit_type || 'Visit';
+    let label = `${date} - ${type}`;
+    if (enc.reason) label += ` (${enc.reason})`;
+    return label;
+  };
+
+  const formatLabResultLabel = (lab) => {
+    const dateValue = lab.completed_date || lab.ordered_date;
+    const date = dateValue ? formatDateDisplay(dateValue) : null;
+    let label = date ? `${date} - ${lab.test_name}` : lab.test_name;
+    if (lab.labs_result) label += ` (${lab.labs_result})`;
+    return label;
+  };
+
+  const formatEquipmentLabel = (eq) => {
+    let label = eq.equipment_name;
+    if (eq.equipment_type) label += ` (${eq.equipment_type})`;
+    if (eq.status) label += ` - ${eq.status}`;
+    return label;
+  };
+
+  // Create options for MultiSelect
+  const medicationOptions = medications.map(m => ({
+    value: m.id.toString(),
+    label: formatMedicationLabel(m),
+  }));
+
+  const encounterOptions = createDateSortedOptions(encounters, formatEncounterLabel, 'date');
+  const labResultOptions = createDateSortedOptions(labResults, formatLabResultLabel, 'completed_date');
+
+  const equipmentOptions = equipment.map(e => ({
+    value: e.id.toString(),
+    label: formatEquipmentLabel(e),
+  }));
+
+  // Get selected IDs from pending relationships
+  const getSelectedIds = (type) => {
+    const items = pendingRelationships[type] || [];
+    return items.map(item => typeof item === 'object' ? item.id : item);
+  };
+
+  // Get metadata for a specific item
+  const getItemMetadata = (type, itemId) => {
+    const items = pendingRelationships[type] || [];
+    const item = items.find(i => (typeof i === 'object' ? i.id : i) === itemId);
+    return typeof item === 'object' ? item : { id: itemId };
+  };
+
+  // Get label for a specific item by ID
+  const getItemLabel = (type, itemId) => {
+    const options = {
+      medications: medicationOptions,
+      encounters: encounterOptions,
+      labResults: labResultOptions,
+      equipment: equipmentOptions,
+    };
+    const option = options[type]?.find(o => o.value === itemId);
+    return option?.label || itemId;
+  };
+
+  // Handle selection change - preserve metadata for existing selections
+  const handleSelectionChange = (type, values) => {
+    const existingItems = pendingRelationships[type] || [];
+
+    // Create new items array, preserving metadata for items that were already selected
+    const newItems = values.map(id => {
+      const existing = existingItems.find(item =>
+        (typeof item === 'object' ? item.id : item) === id
+      );
+      return existing || { id };
+    });
+
+    onRelationshipsChange({
+      ...pendingRelationships,
+      [type]: newItems,
+    });
+  };
+
+  // Update metadata for a specific item
+  const updateItemMetadata = (type, itemId, field, value) => {
+    const items = pendingRelationships[type] || [];
+    const updatedItems = items.map(item => {
+      const id = typeof item === 'object' ? item.id : item;
+      if (id === itemId) {
+        return typeof item === 'object'
+          ? { ...item, [field]: value }
+          : { id, [field]: value };
+      }
+      return item;
+    });
+
+    onRelationshipsChange({
+      ...pendingRelationships,
+      [type]: updatedItems,
+    });
+  };
+
+  // Counts for badges
+  const medicationCount = (pendingRelationships.medications || []).length;
+  const encounterCount = (pendingRelationships.encounters || []).length;
+  const labResultCount = (pendingRelationships.labResults || []).length;
+  const equipmentCount = (pendingRelationships.equipment || []).length;
+
+  // Get selected IDs for rendering
+  const selectedMedIds = getSelectedIds('medications');
+  const selectedEncIds = getSelectedIds('encounters');
+  const selectedLabIds = getSelectedIds('labResults');
+  const selectedEquipIds = getSelectedIds('equipment');
+
+  return (
+    <Box pos="relative">
+      <LoadingOverlay visible={loading} zIndex={1000} overlayProps={{ radius: 'sm', blur: 2 }} />
+
+      <Stack gap="md">
+        <Tabs value={activeTab} onChange={setActiveTab}>
+          <Tabs.List>
+            <Tabs.Tab
+              value="medications"
+              leftSection={<IconPill size={16} />}
+              rightSection={medicationCount > 0 ? (
+                <Badge size="sm" variant="filled" color="teal" circle>
+                  {medicationCount}
+                </Badge>
+              ) : null}
+            >
+              Medications
+            </Tabs.Tab>
+            <Tabs.Tab
+              value="encounters"
+              leftSection={<IconStethoscope size={16} />}
+              rightSection={encounterCount > 0 ? (
+                <Badge size="sm" variant="filled" color="blue" circle>
+                  {encounterCount}
+                </Badge>
+              ) : null}
+            >
+              Visits
+            </Tabs.Tab>
+            <Tabs.Tab
+              value="labs"
+              leftSection={<IconTestPipe size={16} />}
+              rightSection={labResultCount > 0 ? (
+                <Badge size="sm" variant="filled" color="violet" circle>
+                  {labResultCount}
+                </Badge>
+              ) : null}
+            >
+              Labs
+            </Tabs.Tab>
+            <Tabs.Tab
+              value="equipment"
+              leftSection={<IconDeviceDesktop size={16} />}
+              rightSection={equipmentCount > 0 ? (
+                <Badge size="sm" variant="filled" color="orange" circle>
+                  {equipmentCount}
+                </Badge>
+              ) : null}
+            >
+              Equipment
+            </Tabs.Tab>
+          </Tabs.List>
+
+          <Box mt="md">
+            {/* Medications Tab */}
+            <Tabs.Panel value="medications">
+              <Stack gap="md">
+                <MultiSelect
+                  label="Medications to Link"
+                  placeholder={medicationOptions.length > 0 ? "Select medications..." : "No medications available"}
+                  data={medicationOptions}
+                  value={selectedMedIds}
+                  onChange={(values) => handleSelectionChange('medications', values)}
+                  searchable
+                  clearable
+                  disabled={medicationOptions.length === 0}
+                  comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                />
+
+                {/* Show detail fields for each selected medication */}
+                {selectedMedIds.length > 0 && (
+                  <Stack gap="xs">
+                    <Text size="xs" c="dimmed">Click to expand and add details (optional)</Text>
+                    {selectedMedIds.map((medId) => {
+                      const metadata = getItemMetadata('medications', medId);
+                      return (
+                        <ItemDetailsCard
+                          key={medId}
+                          label={getItemLabel('medications', medId)}
+                          color="teal"
+                          icon={IconPill}
+                        >
+                          <TextInput
+                            size="xs"
+                            placeholder="Specific dosage (e.g., 400mg 3x daily)"
+                            value={metadata.specific_dosage || ''}
+                            onChange={(e) => updateItemMetadata('medications', medId, 'specific_dosage', e.target.value)}
+                          />
+                          <TextInput
+                            size="xs"
+                            placeholder="Frequency (e.g., Every 8 hours)"
+                            value={metadata.specific_frequency || ''}
+                            onChange={(e) => updateItemMetadata('medications', medId, 'specific_frequency', e.target.value)}
+                          />
+                          <TextInput
+                            size="xs"
+                            placeholder="Duration (e.g., 2 weeks)"
+                            value={metadata.specific_duration || ''}
+                            onChange={(e) => updateItemMetadata('medications', medId, 'specific_duration', e.target.value)}
+                          />
+                          <TextInput
+                            size="xs"
+                            placeholder="Timing instructions"
+                            value={metadata.timing_instructions || ''}
+                            onChange={(e) => updateItemMetadata('medications', medId, 'timing_instructions', e.target.value)}
+                          />
+                          <Textarea
+                            size="xs"
+                            placeholder="Relevance note"
+                            value={metadata.relevance_note || ''}
+                            onChange={(e) => updateItemMetadata('medications', medId, 'relevance_note', e.target.value)}
+                            autosize
+                            minRows={1}
+                          />
+                        </ItemDetailsCard>
+                      );
+                    })}
+                  </Stack>
+                )}
+
+                {medicationOptions.length === 0 && !loading && (
+                  <Text size="sm" c="dimmed" ta="center">
+                    No medications found. Create medications first to link them here.
+                  </Text>
+                )}
+              </Stack>
+            </Tabs.Panel>
+
+            {/* Visits Tab */}
+            <Tabs.Panel value="encounters">
+              <Stack gap="md">
+                <MultiSelect
+                  label="Visits to Link"
+                  placeholder={encounterOptions.length > 0 ? "Select visits..." : "No visits available"}
+                  data={encounterOptions}
+                  value={selectedEncIds}
+                  onChange={(values) => handleSelectionChange('encounters', values)}
+                  searchable
+                  clearable
+                  disabled={encounterOptions.length === 0}
+                  comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                />
+
+                {/* Show detail fields for each selected visit */}
+                {selectedEncIds.length > 0 && (
+                  <Stack gap="xs">
+                    <Text size="xs" c="dimmed">Click to expand and add details (optional)</Text>
+                    {selectedEncIds.map((encId) => {
+                      const metadata = getItemMetadata('encounters', encId);
+                      return (
+                        <ItemDetailsCard
+                          key={encId}
+                          label={getItemLabel('encounters', encId)}
+                          color="blue"
+                          icon={IconStethoscope}
+                        >
+                          <Select
+                            size="xs"
+                            placeholder="Visit label"
+                            data={VISIT_LABEL_OPTIONS}
+                            value={metadata.visit_label || ''}
+                            onChange={(value) => updateItemMetadata('encounters', encId, 'visit_label', value || '')}
+                            clearable
+                            comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                          />
+                          <TextInput
+                            size="xs"
+                            placeholder="Visit sequence (1, 2, 3...)"
+                            type="number"
+                            value={metadata.visit_sequence || ''}
+                            onChange={(e) => updateItemMetadata('encounters', encId, 'visit_sequence', e.target.value)}
+                          />
+                          <Textarea
+                            size="xs"
+                            placeholder="Relevance note"
+                            value={metadata.relevance_note || ''}
+                            onChange={(e) => updateItemMetadata('encounters', encId, 'relevance_note', e.target.value)}
+                            autosize
+                            minRows={1}
+                          />
+                        </ItemDetailsCard>
+                      );
+                    })}
+                  </Stack>
+                )}
+
+                {encounterOptions.length === 0 && !loading && (
+                  <Text size="sm" c="dimmed" ta="center">
+                    No visits found. Create visits first to link them here.
+                  </Text>
+                )}
+              </Stack>
+            </Tabs.Panel>
+
+            {/* Labs Tab */}
+            <Tabs.Panel value="labs">
+              <Stack gap="md">
+                <MultiSelect
+                  label="Lab Results to Link"
+                  placeholder={labResultOptions.length > 0 ? "Select lab results..." : "No lab results available"}
+                  data={labResultOptions}
+                  value={selectedLabIds}
+                  onChange={(values) => handleSelectionChange('labResults', values)}
+                  searchable
+                  clearable
+                  disabled={labResultOptions.length === 0}
+                  comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                />
+
+                {/* Show detail fields for each selected lab */}
+                {selectedLabIds.length > 0 && (
+                  <Stack gap="xs">
+                    <Text size="xs" c="dimmed">Click to expand and add details (optional)</Text>
+                    {selectedLabIds.map((labId) => {
+                      const metadata = getItemMetadata('labResults', labId);
+                      return (
+                        <ItemDetailsCard
+                          key={labId}
+                          label={getItemLabel('labResults', labId)}
+                          color="violet"
+                          icon={IconTestPipe}
+                        >
+                          <Select
+                            size="xs"
+                            placeholder="Purpose"
+                            data={PURPOSE_OPTIONS}
+                            value={metadata.purpose || ''}
+                            onChange={(value) => updateItemMetadata('labResults', labId, 'purpose', value || '')}
+                            clearable
+                            comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                          />
+                          <TextInput
+                            size="xs"
+                            placeholder="Expected frequency (e.g., Monthly)"
+                            value={metadata.expected_frequency || ''}
+                            onChange={(e) => updateItemMetadata('labResults', labId, 'expected_frequency', e.target.value)}
+                          />
+                          <Textarea
+                            size="xs"
+                            placeholder="Relevance note"
+                            value={metadata.relevance_note || ''}
+                            onChange={(e) => updateItemMetadata('labResults', labId, 'relevance_note', e.target.value)}
+                            autosize
+                            minRows={1}
+                          />
+                        </ItemDetailsCard>
+                      );
+                    })}
+                  </Stack>
+                )}
+
+                {labResultOptions.length === 0 && !loading && (
+                  <Text size="sm" c="dimmed" ta="center">
+                    No lab results found. Create lab results first to link them here.
+                  </Text>
+                )}
+              </Stack>
+            </Tabs.Panel>
+
+            {/* Equipment Tab */}
+            <Tabs.Panel value="equipment">
+              <Stack gap="md">
+                <MultiSelect
+                  label="Equipment to Link"
+                  placeholder={equipmentOptions.length > 0 ? "Select equipment..." : "No equipment available"}
+                  data={equipmentOptions}
+                  value={selectedEquipIds}
+                  onChange={(values) => handleSelectionChange('equipment', values)}
+                  searchable
+                  clearable
+                  disabled={equipmentOptions.length === 0}
+                  comboboxProps={{ withinPortal: true, zIndex: 4000 }}
+                />
+
+                {/* Show detail fields for each selected equipment */}
+                {selectedEquipIds.length > 0 && (
+                  <Stack gap="xs">
+                    <Text size="xs" c="dimmed">Click to expand and add details (optional)</Text>
+                    {selectedEquipIds.map((equipId) => {
+                      const metadata = getItemMetadata('equipment', equipId);
+                      return (
+                        <ItemDetailsCard
+                          key={equipId}
+                          label={getItemLabel('equipment', equipId)}
+                          color="orange"
+                          icon={IconDeviceDesktop}
+                        >
+                          <TextInput
+                            size="xs"
+                            placeholder="Usage frequency (e.g., Nightly)"
+                            value={metadata.usage_frequency || ''}
+                            onChange={(e) => updateItemMetadata('equipment', equipId, 'usage_frequency', e.target.value)}
+                          />
+                          <TextInput
+                            size="xs"
+                            placeholder="Specific settings (e.g., Pressure: 10 cmH2O)"
+                            value={metadata.specific_settings || ''}
+                            onChange={(e) => updateItemMetadata('equipment', equipId, 'specific_settings', e.target.value)}
+                          />
+                          <Textarea
+                            size="xs"
+                            placeholder="Relevance note"
+                            value={metadata.relevance_note || ''}
+                            onChange={(e) => updateItemMetadata('equipment', equipId, 'relevance_note', e.target.value)}
+                            autosize
+                            minRows={1}
+                          />
+                        </ItemDetailsCard>
+                      );
+                    })}
+                  </Stack>
+                )}
+
+                {equipmentOptions.length === 0 && !loading && (
+                  <Text size="sm" c="dimmed" ta="center">
+                    No equipment found. Equipment can be added after creating the treatment.
+                  </Text>
+                )}
+              </Stack>
+            </Tabs.Panel>
+          </Box>
+        </Tabs>
+      </Stack>
+    </Box>
+  );
+};
+
+TreatmentPlanSetup.propTypes = {
+  pendingRelationships: PropTypes.shape({
+    medications: PropTypes.array,
+    encounters: PropTypes.array,
+    labResults: PropTypes.array,
+    equipment: PropTypes.array,
+  }).isRequired,
+  onRelationshipsChange: PropTypes.func.isRequired,
+};
+
+export default TreatmentPlanSetup;

--- a/frontend/src/components/medical/treatments/TreatmentRelationshipsManager.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentRelationshipsManager.jsx
@@ -1,0 +1,322 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import {
+  Tabs,
+  Badge,
+  Stack,
+  Box,
+} from '@mantine/core';
+import {
+  IconPill,
+  IconStethoscope,
+  IconTestPipe,
+  IconDeviceDesktop,
+} from '@tabler/icons-react';
+import { apiService } from '../../../services/api';
+import logger from '../../../services/logger';
+import TreatmentMedicationRelationships from './TreatmentMedicationRelationships';
+import TreatmentEncounterRelationships from './TreatmentEncounterRelationships';
+import TreatmentLabResultRelationships from './TreatmentLabResultRelationships';
+import TreatmentEquipmentRelationships from './TreatmentEquipmentRelationships';
+
+/**
+ * Manages treatment relationships (medications, visits, labs, equipment).
+ * This component displays the relationship tabs directly - mode control is handled by the parent.
+ */
+const TreatmentRelationshipsManager = ({
+  treatmentId,
+  patientId,
+  isViewMode = false,
+  onCountsChange,
+  onMedicationClick,
+  onEncounterClick,
+  onLabResultClick,
+  onEquipmentClick,
+}) => {
+  const { t } = useTranslation('common');
+  const [activeTab, setActiveTab] = useState('medications');
+
+  // Relationship counts for badges
+  const [medicationCount, setMedicationCount] = useState(0);
+  const [encounterCount, setEncounterCount] = useState(0);
+  const [labResultCount, setLabResultCount] = useState(0);
+  const [equipmentCount, setEquipmentCount] = useState(0);
+
+  // Data for selectors
+  const [medications, setMedications] = useState([]);
+  const [encounters, setEncounters] = useState([]);
+  const [labResults, setLabResults] = useState([]);
+  const [equipment, setEquipment] = useState([]);
+
+  // Track if component is mounted to prevent state updates after unmount
+  const isMountedRef = useRef(true);
+
+  // Fetch available entities for linking with abort signal
+  const fetchAvailableEntities = useCallback(async (signal) => {
+    if (!treatmentId) return;
+
+    try {
+      // Fetch all in parallel with abort signal
+      const [medsData, encountersData, labsData, equipmentData] = await Promise.all([
+        apiService.getMedications(signal).catch((err) => {
+          if (err.name !== 'AbortError') {
+            logger.error('Failed to fetch medications', { error: err.message });
+          }
+          return [];
+        }),
+        apiService.getEncounters(signal).catch((err) => {
+          if (err.name !== 'AbortError') {
+            logger.error('Failed to fetch encounters', { error: err.message });
+          }
+          return [];
+        }),
+        apiService.getLabResults(signal).catch((err) => {
+          if (err.name !== 'AbortError') {
+            logger.error('Failed to fetch lab results', { error: err.message });
+          }
+          return [];
+        }),
+        apiService.getMedicalEquipment(signal).catch((err) => {
+          if (err.name !== 'AbortError') {
+            logger.error('Failed to fetch equipment', { error: err.message });
+          }
+          return [];
+        }),
+      ]);
+
+      // Only update state if not aborted - ensure arrays
+      if (!signal?.aborted && isMountedRef.current) {
+        setMedications(Array.isArray(medsData) ? medsData : []);
+        setEncounters(Array.isArray(encountersData) ? encountersData : []);
+        setLabResults(Array.isArray(labsData) ? labsData : []);
+        setEquipment(Array.isArray(equipmentData) ? equipmentData : []);
+      }
+    } catch (err) {
+      if (err.name !== 'AbortError' && isMountedRef.current) {
+        logger.error('treatment_relationships_fetch_entities_error', {
+          treatmentId,
+          error: err.message,
+          component: 'TreatmentRelationshipsManager',
+        });
+      }
+    }
+  }, [treatmentId]);
+
+  // Fetch relationship counts with abort signal
+  const fetchCounts = useCallback(async (signal) => {
+    if (!treatmentId) return;
+
+    try {
+      const [meds, encs, labs, equip] = await Promise.all([
+        apiService.getTreatmentMedications(treatmentId, signal).catch((err) => {
+          if (err.name !== 'AbortError') {
+            logger.error('Failed to fetch treatment medications', { error: err.message });
+          }
+          return [];
+        }),
+        apiService.getTreatmentEncounters(treatmentId, signal).catch((err) => {
+          if (err.name !== 'AbortError') {
+            logger.error('Failed to fetch treatment encounters', { error: err.message });
+          }
+          return [];
+        }),
+        apiService.getTreatmentLabResults(treatmentId, signal).catch((err) => {
+          if (err.name !== 'AbortError') {
+            logger.error('Failed to fetch treatment lab results', { error: err.message });
+          }
+          return [];
+        }),
+        apiService.getTreatmentEquipment(treatmentId, signal).catch((err) => {
+          if (err.name !== 'AbortError') {
+            logger.error('Failed to fetch treatment equipment', { error: err.message });
+          }
+          return [];
+        }),
+      ]);
+
+      // Only update state if not aborted - ensure arrays before getting length
+      if (!signal?.aborted && isMountedRef.current) {
+        setMedicationCount(Array.isArray(meds) ? meds.length : 0);
+        setEncounterCount(Array.isArray(encs) ? encs.length : 0);
+        setLabResultCount(Array.isArray(labs) ? labs.length : 0);
+        setEquipmentCount(Array.isArray(equip) ? equip.length : 0);
+      }
+    } catch (err) {
+      if (err.name !== 'AbortError' && isMountedRef.current) {
+        logger.error('treatment_relationships_fetch_counts_error', {
+          treatmentId,
+          error: err.message,
+          component: 'TreatmentRelationshipsManager',
+        });
+      }
+    }
+  }, [treatmentId]);
+
+  // Effect with proper cleanup using AbortController
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    if (treatmentId) {
+      const controller = new AbortController();
+
+      fetchAvailableEntities(controller.signal);
+      fetchCounts(controller.signal);
+
+      return () => {
+        controller.abort();
+      };
+    }
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, [treatmentId, fetchAvailableEntities, fetchCounts]);
+
+  // Memoized callbacks to prevent infinite re-renders in child components
+  const handleMedicationCountChange = useCallback((rels) => {
+    setMedicationCount(rels?.length || 0);
+  }, []);
+
+  const handleEncounterCountChange = useCallback((rels) => {
+    setEncounterCount(rels?.length || 0);
+  }, []);
+
+  const handleLabResultCountChange = useCallback((rels) => {
+    setLabResultCount(rels?.length || 0);
+  }, []);
+
+  const handleEquipmentCountChange = useCallback((rels) => {
+    setEquipmentCount(rels?.length || 0);
+  }, []);
+
+  // When new equipment is created inline, refresh the equipment list
+  const handleEquipmentCreated = useCallback((newEquip) => {
+    setEquipment(prev => [...prev, newEquip]);
+  }, []);
+
+  // Report total counts to parent when they change
+  useEffect(() => {
+    if (onCountsChange) {
+      const total = medicationCount + encounterCount + labResultCount + equipmentCount;
+      onCountsChange(total);
+    }
+  }, [medicationCount, encounterCount, labResultCount, equipmentCount, onCountsChange]);
+
+  if (!treatmentId) {
+    return null;
+  }
+
+  return (
+    <Stack gap="md">
+      {/* Relationship Tabs */}
+      <Box>
+        <Tabs value={activeTab} onChange={setActiveTab}>
+          <Tabs.List>
+            <Tabs.Tab
+              value="medications"
+              leftSection={<IconPill size={16} />}
+              rightSection={medicationCount > 0 ? (
+                <Badge size="sm" variant="filled" color="teal" circle>
+                  {medicationCount}
+                </Badge>
+              ) : null}
+            >
+              Medications
+            </Tabs.Tab>
+            <Tabs.Tab
+              value="encounters"
+              leftSection={<IconStethoscope size={16} />}
+              rightSection={encounterCount > 0 ? (
+                <Badge size="sm" variant="filled" color="blue" circle>
+                  {encounterCount}
+                </Badge>
+              ) : null}
+            >
+              Visits
+            </Tabs.Tab>
+            <Tabs.Tab
+              value="labs"
+              leftSection={<IconTestPipe size={16} />}
+              rightSection={labResultCount > 0 ? (
+                <Badge size="sm" variant="filled" color="violet" circle>
+                  {labResultCount}
+                </Badge>
+              ) : null}
+            >
+              Labs
+            </Tabs.Tab>
+            <Tabs.Tab
+              value="equipment"
+              leftSection={<IconDeviceDesktop size={16} />}
+              rightSection={equipmentCount > 0 ? (
+                <Badge size="sm" variant="filled" color="orange" circle>
+                  {equipmentCount}
+                </Badge>
+              ) : null}
+            >
+              Equipment
+            </Tabs.Tab>
+          </Tabs.List>
+
+          <Box mt="md">
+            <Tabs.Panel value="medications">
+              <TreatmentMedicationRelationships
+                treatmentId={treatmentId}
+                medications={medications}
+                isViewMode={isViewMode}
+                onRelationshipsChange={handleMedicationCountChange}
+                onEntityClick={onMedicationClick}
+              />
+            </Tabs.Panel>
+
+            <Tabs.Panel value="encounters">
+              <TreatmentEncounterRelationships
+                treatmentId={treatmentId}
+                encounters={encounters}
+                isViewMode={isViewMode}
+                onRelationshipsChange={handleEncounterCountChange}
+                onEntityClick={onEncounterClick}
+              />
+            </Tabs.Panel>
+
+            <Tabs.Panel value="labs">
+              <TreatmentLabResultRelationships
+                treatmentId={treatmentId}
+                labResults={labResults}
+                isViewMode={isViewMode}
+                onRelationshipsChange={handleLabResultCountChange}
+                onEntityClick={onLabResultClick}
+              />
+            </Tabs.Panel>
+
+            <Tabs.Panel value="equipment">
+              <TreatmentEquipmentRelationships
+                treatmentId={treatmentId}
+                patientId={patientId}
+                equipment={equipment}
+                isViewMode={isViewMode}
+                onRelationshipsChange={handleEquipmentCountChange}
+                onEquipmentCreated={handleEquipmentCreated}
+                onEntityClick={onEquipmentClick}
+              />
+            </Tabs.Panel>
+          </Box>
+        </Tabs>
+      </Box>
+    </Stack>
+  );
+};
+
+TreatmentRelationshipsManager.propTypes = {
+  treatmentId: PropTypes.number,
+  patientId: PropTypes.number,
+  isViewMode: PropTypes.bool,
+  onCountsChange: PropTypes.func,
+  onMedicationClick: PropTypes.func,
+  onEncounterClick: PropTypes.func,
+  onLabResultClick: PropTypes.func,
+  onEquipmentClick: PropTypes.func,
+};
+
+export default TreatmentRelationshipsManager;

--- a/frontend/src/components/medical/treatments/TreatmentViewModal.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentViewModal.jsx
@@ -18,11 +18,13 @@ import {
   IconNotes,
   IconFileText,
   IconEdit,
+  IconLink,
 } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import StatusBadge from '../StatusBadge';
 import { useDateFormat } from '../../../hooks/useDateFormat';
 import DocumentManagerWithProgress from '../../shared/DocumentManagerWithProgress';
+import TreatmentRelationshipsManager from './TreatmentRelationshipsManager';
 
 const TreatmentViewModal = ({
   isOpen,
@@ -32,6 +34,10 @@ const TreatmentViewModal = ({
   conditions = [],
   practitioners = [],
   onConditionClick,
+  onMedicationClick,
+  onEncounterClick,
+  onLabResultClick,
+  onEquipmentClick,
   onError,
 }) => {
   const { t } = useTranslation('common');
@@ -76,6 +82,26 @@ const TreatmentViewModal = ({
     }
   };
 
+  // Treatment category labels mapping
+  const TREATMENT_CATEGORY_LABELS = {
+    medication_therapy: 'Medication Therapy',
+    physical_therapy: 'Physical Therapy',
+    surgery_procedure: 'Surgery / Procedure',
+    lifestyle_dietary: 'Lifestyle / Dietary',
+    monitoring: 'Monitoring / Observation',
+    mental_health: 'Mental Health / Counseling',
+    rehabilitation: 'Rehabilitation',
+    alternative: 'Alternative / Complementary',
+    combination: 'Combination Therapy',
+    other: 'Other',
+  };
+
+  // Get display label for treatment type (supports both predefined and custom values)
+  const getTreatmentTypeLabel = (type) => {
+    if (!type) return null;
+    return TREATMENT_CATEGORY_LABELS[type] || type; // Return mapped label or raw value for custom entries
+  };
+
   return (
     <Modal
       opened={isOpen}
@@ -94,7 +120,7 @@ const TreatmentViewModal = ({
               <Group gap="xs">
                 {treatment.treatment_type && (
                   <Badge variant="light" color="blue" size="sm">
-                    {treatment.treatment_type}
+                    {getTreatmentTypeLabel(treatment.treatment_type)}
                   </Badge>
                 )}
                 <StatusBadge status={treatment.status} />
@@ -122,6 +148,9 @@ const TreatmentViewModal = ({
           <Tabs.Tab value="documents" leftSection={<IconFileText size={16} />}>
             {t('treatments.viewModal.tabs.documents', 'Documents')}
           </Tabs.Tab>
+          <Tabs.Tab value="relationships" leftSection={<IconLink size={16} />}>
+            {t('treatments.viewModal.tabs.relationships', 'Relationships')}
+          </Tabs.Tab>
         </Tabs.List>
 
         {/* Overview Tab */}
@@ -137,9 +166,9 @@ const TreatmentViewModal = ({
                     <Text size="sm">{treatment.treatment_name}</Text>
                   </Stack>
                   <Stack gap="xs">
-                    <Text fw={500} size="sm" c="dimmed">{t('treatments.viewModal.treatmentType', 'Treatment Type')}</Text>
+                    <Text fw={500} size="sm" c="dimmed">{t('treatments.viewModal.treatmentType', 'Treatment Category')}</Text>
                     <Text size="sm" c={treatment.treatment_type ? 'inherit' : 'dimmed'}>
-                      {treatment.treatment_type || t('treatments.viewModal.notSpecified', 'Not specified')}
+                      {getTreatmentTypeLabel(treatment.treatment_type) || t('treatments.viewModal.notSpecified', 'Not specified')}
                     </Text>
                   </Stack>
                   <Stack gap="xs">
@@ -328,6 +357,20 @@ const TreatmentViewModal = ({
               entityType="treatment"
               entityId={treatment.id}
               onError={onError}
+            />
+          </Box>
+        </Tabs.Panel>
+
+        {/* Relationships Tab */}
+        <Tabs.Panel value="relationships">
+          <Box mt="md">
+            <TreatmentRelationshipsManager
+              treatmentId={treatment.id}
+              isViewMode={true}
+              onMedicationClick={onMedicationClick}
+              onEncounterClick={onEncounterClick}
+              onLabResultClick={onLabResultClick}
+              onEquipmentClick={onEquipmentClick}
             />
           </Box>
         </Tabs.Panel>

--- a/frontend/src/config/navigation.config.js
+++ b/frontend/src/config/navigation.config.js
@@ -156,6 +156,13 @@ export const NAVIGATION_SECTIONS = {
         id: 'insurance',
       },
       {
+        nameKey: 'sidebarNav.items.medicalEquipment',
+        name: 'Medical Equipment',
+        path: buildEntityUrl(ENTITY_TYPES.MEDICAL_EQUIPMENT),
+        icon: '🩺',
+        id: 'medical-equipment',
+      },
+      {
         nameKey: 'sidebarNav.items.emergencyContacts',
         name: 'Emergency Contacts',
         path: buildEntityUrl(ENTITY_TYPES.EMERGENCY_CONTACT),

--- a/frontend/src/constants/equipmentConstants.js
+++ b/frontend/src/constants/equipmentConstants.js
@@ -1,0 +1,99 @@
+/**
+ * Equipment Constants
+ *
+ * Shared constants for medical equipment across the application.
+ * This centralizes equipment type labels, status options, and related utilities.
+ */
+
+/**
+ * Equipment type options for form select fields
+ * Used in: EquipmentFormWrapper, TreatmentEquipmentRelationships
+ */
+export const EQUIPMENT_TYPE_OPTIONS = [
+  { value: 'cpap', label: 'CPAP Machine' },
+  { value: 'bipap', label: 'BiPAP Machine' },
+  { value: 'nebulizer', label: 'Nebulizer' },
+  { value: 'inhaler', label: 'Inhaler' },
+  { value: 'blood_pressure_monitor', label: 'Blood Pressure Monitor' },
+  { value: 'glucose_monitor', label: 'Glucose Monitor' },
+  { value: 'pulse_oximeter', label: 'Pulse Oximeter' },
+  { value: 'wheelchair', label: 'Wheelchair' },
+  { value: 'walker', label: 'Walker' },
+  { value: 'cane', label: 'Cane' },
+  { value: 'crutches', label: 'Crutches' },
+  { value: 'oxygen_concentrator', label: 'Oxygen Concentrator' },
+  { value: 'oxygen_tank', label: 'Oxygen Tank' },
+  { value: 'hearing_aid', label: 'Hearing Aid' },
+  { value: 'insulin_pump', label: 'Insulin Pump' },
+  { value: 'continuous_glucose_monitor', label: 'Continuous Glucose Monitor' },
+  { value: 'tens_unit', label: 'TENS Unit' },
+  { value: 'brace', label: 'Brace' },
+  { value: 'prosthetic', label: 'Prosthetic' },
+  { value: 'other', label: 'Other' },
+];
+
+/**
+ * Equipment type labels lookup map
+ * Used for displaying equipment type labels from type values
+ */
+export const EQUIPMENT_TYPE_LABELS = Object.fromEntries(
+  EQUIPMENT_TYPE_OPTIONS.map(option => [option.value, option.label])
+);
+
+/**
+ * Equipment status options for form select fields
+ */
+export const EQUIPMENT_STATUS_OPTIONS = [
+  { value: 'active', label: 'Active' },
+  { value: 'inactive', label: 'Inactive' },
+  { value: 'replaced', label: 'Replaced' },
+  { value: 'returned', label: 'Returned' },
+  { value: 'lost', label: 'Lost' },
+];
+
+/**
+ * Status color mapping for badges
+ */
+const STATUS_COLORS = {
+  active: 'green',
+  inactive: 'gray',
+  replaced: 'blue',
+  returned: 'orange',
+  lost: 'red',
+};
+
+/**
+ * Get the display label for an equipment type
+ * @param {string} type - The equipment type value
+ * @returns {string|null} The display label or the raw value for custom types
+ */
+export function getEquipmentTypeLabel(type) {
+  if (!type) return null;
+  return EQUIPMENT_TYPE_LABELS[type] || type;
+}
+
+/**
+ * Get the color for an equipment status badge
+ * @param {string} status - The equipment status
+ * @returns {string} The color name for Mantine Badge
+ */
+export function getEquipmentStatusColor(status) {
+  return STATUS_COLORS[status] || 'gray';
+}
+
+/**
+ * Format an equipment item for display in select options
+ * @param {Object} equipment - The equipment object
+ * @returns {string} Formatted label string
+ */
+export function formatEquipmentLabel(equipment) {
+  let label = equipment.equipment_name;
+  const typeLabel = getEquipmentTypeLabel(equipment.equipment_type);
+  if (typeLabel) {
+    label += ` (${typeLabel})`;
+  }
+  if (equipment.status && equipment.status !== 'active') {
+    label += ` - ${equipment.status}`;
+  }
+  return label;
+}

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -38,3 +38,6 @@ export { useEntityFileCounts } from './useEntityFileCounts';
 
 // View modal navigation hooks
 export { useViewModalNavigation } from './useViewModalNavigation';
+
+// Treatment relationship management hooks
+export { useTreatmentRelationships } from './useTreatmentRelationships';

--- a/frontend/src/hooks/useTreatmentRelationships.js
+++ b/frontend/src/hooks/useTreatmentRelationships.js
@@ -1,0 +1,285 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { apiService } from '../services/api';
+import logger from '../services/logger';
+
+/**
+ * Configuration for different relationship types.
+ * Each type defines its API methods and entity-specific settings.
+ */
+const RELATIONSHIP_CONFIGS = {
+  medication: {
+    entityName: 'medication',
+    entityIdField: 'medication_id',
+    idsField: 'medication_ids',
+    fetchMethod: 'getTreatmentMedications',
+    linkMethod: 'linkTreatmentMedication',
+    linkBulkMethod: 'linkTreatmentMedicationsBulk',
+    updateMethod: 'updateTreatmentMedication',
+    unlinkMethod: 'unlinkTreatmentMedication',
+    logPrefix: 'treatment_medication',
+    componentName: 'TreatmentMedicationRelationships',
+  },
+  encounter: {
+    entityName: 'encounter',
+    entityIdField: 'encounter_id',
+    idsField: 'encounter_ids',
+    fetchMethod: 'getTreatmentEncounters',
+    linkMethod: 'linkTreatmentEncounter',
+    linkBulkMethod: 'linkTreatmentEncountersBulk',
+    updateMethod: 'updateTreatmentEncounter',
+    unlinkMethod: 'unlinkTreatmentEncounter',
+    logPrefix: 'treatment_encounter',
+    componentName: 'TreatmentEncounterRelationships',
+  },
+  labResult: {
+    entityName: 'lab result',
+    entityIdField: 'lab_result_id',
+    idsField: 'lab_result_ids',
+    fetchMethod: 'getTreatmentLabResults',
+    linkMethod: 'linkTreatmentLabResult',
+    linkBulkMethod: 'linkTreatmentLabResultsBulk',
+    updateMethod: 'updateTreatmentLabResult',
+    unlinkMethod: 'unlinkTreatmentLabResult',
+    logPrefix: 'treatment_lab_result',
+    componentName: 'TreatmentLabResultRelationships',
+  },
+};
+
+/**
+ * Custom hook for managing treatment relationships with medications, encounters, or lab results.
+ * Extracts common CRUD logic shared across all relationship components.
+ *
+ * @param {Object} options - Hook configuration options
+ * @param {string} options.type - Relationship type ('medication', 'encounter', or 'labResult')
+ * @param {number} options.treatmentId - The treatment ID to manage relationships for
+ * @param {Object} options.initialState - Initial state for new relationship form
+ * @param {Function} options.onRelationshipsChange - Callback when relationships change
+ * @param {Function} options.buildSinglePayload - Function to build payload for single link
+ * @param {Function} options.buildBulkPayload - Function to build payload for bulk link
+ * @returns {Object} State and handlers for managing relationships
+ */
+export function useTreatmentRelationships({
+  type,
+  treatmentId,
+  initialState,
+  onRelationshipsChange,
+  buildSinglePayload,
+  buildBulkPayload,
+}) {
+  const { t } = useTranslation('common');
+  const { t: tErrors } = useTranslation('errors');
+
+  const config = RELATIONSHIP_CONFIGS[type];
+  if (!config) {
+    throw new Error(`Unknown relationship type: ${type}`);
+  }
+
+  const [relationships, setRelationships] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [editingRelationship, setEditingRelationship] = useState(null);
+  const [newRelationship, setNewRelationship] = useState(initialState);
+  const [error, setError] = useState(null);
+
+  // Use ref for callback to avoid infinite re-renders when parent passes inline function
+  const onRelationshipsChangeRef = useRef(onRelationshipsChange);
+  useEffect(() => {
+    onRelationshipsChangeRef.current = onRelationshipsChange;
+  }, [onRelationshipsChange]);
+
+  const resetAndCloseModal = useCallback(() => {
+    setShowAddModal(false);
+    setNewRelationship(initialState);
+    setError(null);
+  }, [initialState]);
+
+  const fetchRelationships = useCallback(async (signal) => {
+    if (!treatmentId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await apiService[config.fetchMethod](treatmentId, signal);
+
+      // Check if aborted before updating state
+      if (signal?.aborted) return;
+
+      setRelationships(data || []);
+      if (onRelationshipsChangeRef.current) {
+        onRelationshipsChangeRef.current(data || []);
+      }
+    } catch (err) {
+      // Don't update state or log if request was aborted
+      if (err.name === 'AbortError' || signal?.aborted) return;
+
+      logger.error(`${config.logPrefix}_fetch_error`, {
+        treatmentId,
+        error: err.message,
+        component: config.componentName,
+      });
+      setError(err.message || `Failed to load ${config.entityName} relationships`);
+    } finally {
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
+    }
+  }, [treatmentId, config]);
+
+  // Effect with proper cleanup using AbortController
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchRelationships(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
+  }, [fetchRelationships]);
+
+  const handleAddRelationship = useCallback(async () => {
+    const ids = newRelationship[config.idsField];
+    if (!ids || ids.length === 0) {
+      setError(tErrors(`form.${config.entityName.replace(' ', '')}NotSelected`, `Please select at least one ${config.entityName}`));
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      if (ids.length > 1 && buildBulkPayload) {
+        const bulkPayload = buildBulkPayload(newRelationship);
+        await apiService[config.linkBulkMethod](treatmentId, ...bulkPayload);
+      } else {
+        const singlePayload = buildSinglePayload(newRelationship);
+        await apiService[config.linkMethod](treatmentId, singlePayload);
+      }
+
+      await fetchRelationships();
+      resetAndCloseModal();
+    } catch (err) {
+      logger.error(`${config.logPrefix}_add_error`, {
+        treatmentId,
+        error: err.message,
+        component: config.componentName,
+      });
+      setError(err.response?.data?.detail || err.message || `Failed to add ${config.entityName} relationship`);
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    newRelationship,
+    config,
+    treatmentId,
+    buildSinglePayload,
+    buildBulkPayload,
+    fetchRelationships,
+    resetAndCloseModal,
+    tErrors,
+  ]);
+
+  const handleEditRelationship = useCallback(async (relationshipId, updates) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await apiService[config.updateMethod](treatmentId, relationshipId, updates);
+      await fetchRelationships();
+      setEditingRelationship(null);
+    } catch (err) {
+      logger.error(`${config.logPrefix}_update_error`, {
+        treatmentId,
+        relationshipId,
+        error: err.message,
+        component: config.componentName,
+      });
+      setError(err.response?.data?.detail || err.message || `Failed to update ${config.entityName} relationship`);
+    } finally {
+      setLoading(false);
+    }
+  }, [treatmentId, fetchRelationships, config]);
+
+  const handleDeleteRelationship = useCallback(async (relationshipId, confirmMessage) => {
+    const defaultMessage = t(
+      `messages.confirmRemove${type.charAt(0).toUpperCase() + type.slice(1)}Relationship`,
+      `Are you sure you want to remove this ${config.entityName} link?`
+    );
+
+    if (!window.confirm(confirmMessage || defaultMessage)) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await apiService[config.unlinkMethod](treatmentId, relationshipId);
+      await fetchRelationships();
+    } catch (err) {
+      logger.error(`${config.logPrefix}_delete_error`, {
+        treatmentId,
+        relationshipId,
+        error: err.message,
+        component: config.componentName,
+      });
+      setError(err.response?.data?.detail || err.message || `Failed to delete ${config.entityName} relationship`);
+    } finally {
+      setLoading(false);
+    }
+  }, [treatmentId, fetchRelationships, config, type, t]);
+
+  const updateNewRelationship = useCallback((field, value) => {
+    setNewRelationship(prev => ({ ...prev, [field]: value }));
+  }, []);
+
+  const updateEditingRelationship = useCallback((field, value) => {
+    setEditingRelationship(prev => prev ? { ...prev, [field]: value } : null);
+  }, []);
+
+  const startEditing = useCallback((relationship, editFields) => {
+    const editState = { id: relationship.id };
+    for (const field of editFields) {
+      editState[field] = relationship[field] || '';
+    }
+    setEditingRelationship(editState);
+  }, []);
+
+  const cancelEditing = useCallback(() => {
+    setEditingRelationship(null);
+  }, []);
+
+  const openAddModal = useCallback(() => {
+    setShowAddModal(true);
+  }, []);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return {
+    // State
+    relationships,
+    loading,
+    showAddModal,
+    editingRelationship,
+    newRelationship,
+    error,
+    config,
+
+    // Actions
+    fetchRelationships,
+    handleAddRelationship,
+    handleEditRelationship,
+    handleDeleteRelationship,
+    resetAndCloseModal,
+    openAddModal,
+    startEditing,
+    cancelEditing,
+    updateNewRelationship,
+    updateEditingRelationship,
+    clearError,
+  };
+}
+
+export default useTreatmentRelationships;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -54,6 +54,7 @@ import {
   IconUsers,
   IconShield,
   IconBandage,
+  IconDeviceDesktop,
 } from '@tabler/icons-react';
 import { PageHeader } from '../components';
 import { PatientSelector } from '../components/medical';
@@ -448,6 +449,12 @@ const Dashboard = () => {
       icon: IconBuilding,
       color: 'green',
       link: '/pharmacies',
+    },
+    {
+      title: t('dashboard.modules.medicalEquipment', 'Medical Equipment'),
+      icon: IconDeviceDesktop,
+      color: 'orange',
+      link: '/medical-equipment',
     },
   ];
 

--- a/frontend/src/pages/medical/MedicalEquipment.jsx
+++ b/frontend/src/pages/medical/MedicalEquipment.jsx
@@ -1,0 +1,350 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useMedicalData } from '../../hooks/useMedicalData';
+import { useViewModalNavigation } from '../../hooks/useViewModalNavigation';
+import { apiService } from '../../services/api';
+import { usePatientWithStaticData } from '../../hooks/useGlobalData';
+import { PageHeader } from '../../components';
+import { withResponsive } from '../../hoc/withResponsive';
+import logger from '../../services/logger';
+import MedicalPageFilters from '../../components/shared/MedicalPageFilters';
+import MedicalPageActions from '../../components/shared/MedicalPageActions';
+import EmptyState from '../../components/shared/EmptyState';
+import MedicalPageLoading from '../../components/shared/MedicalPageLoading';
+import AnimatedCardGrid from '../../components/shared/AnimatedCardGrid';
+import MedicalPageAlerts from '../../components/shared/MedicalPageAlerts';
+import EquipmentCard from '../../components/medical/equipment/EquipmentCard';
+import EquipmentViewModal from '../../components/medical/equipment/EquipmentViewModal';
+import EquipmentFormWrapper from '../../components/medical/equipment/EquipmentFormWrapper';
+import {
+  EQUIPMENT_TYPE_OPTIONS,
+  EQUIPMENT_STATUS_OPTIONS,
+} from '../../constants/equipmentConstants';
+import {
+  Button,
+  Stack,
+  Container,
+} from '@mantine/core';
+
+const EMPTY_FORM_DATA = {
+  equipment_name: '',
+  equipment_type: '',
+  manufacturer: '',
+  model_number: '',
+  serial_number: '',
+  prescribed_date: '',
+  last_service_date: '',
+  next_service_date: '',
+  usage_instructions: '',
+  status: 'active',
+  supplier: '',
+  notes: '',
+  practitioner_id: '',
+  tags: [],
+};
+
+// Simple filter/search configuration for equipment
+const equipmentConfig = {
+  searchFields: ['equipment_name', 'manufacturer', 'model_number', 'serial_number', 'supplier'],
+  filterConfigs: [
+    {
+      field: 'status',
+      label: 'Status',
+      type: 'select',
+      options: EQUIPMENT_STATUS_OPTIONS,
+    },
+    {
+      field: 'equipment_type',
+      label: 'Type',
+      type: 'select',
+      options: EQUIPMENT_TYPE_OPTIONS,
+    },
+  ],
+};
+
+// Simple data management hook for filtering
+const useSimpleDataManagement = (data, config) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filters, setFilters] = useState({});
+
+  const filteredData = React.useMemo(() => {
+    let result = [...(data || [])];
+
+    // Apply search
+    if (searchTerm && config.searchFields) {
+      const lowerSearch = searchTerm.toLowerCase();
+      result = result.filter(item =>
+        config.searchFields.some(field => {
+          const value = item[field];
+          return value && String(value).toLowerCase().includes(lowerSearch);
+        })
+      );
+    }
+
+    // Apply filters
+    Object.entries(filters).forEach(([field, value]) => {
+      if (value) {
+        result = result.filter(item => item[field] === value);
+      }
+    });
+
+    return result;
+  }, [data, searchTerm, filters, config.searchFields]);
+
+  const hasActiveFilters = searchTerm || Object.values(filters).some(v => v);
+
+  return {
+    data: filteredData,
+    searchTerm,
+    setSearchTerm,
+    filters,
+    setFilters,
+    hasActiveFilters,
+    clearFilters: () => {
+      setSearchTerm('');
+      setFilters({});
+    },
+  };
+};
+
+const MedicalEquipment = () => {
+  const { t } = useTranslation('common');
+  const [viewMode, setViewMode] = useState('cards');
+
+  // Get practitioners data
+  const { practitioners: practitionersObject } = usePatientWithStaticData();
+  const practitioners = practitionersObject?.practitioners || [];
+
+  // Medical data management
+  const {
+    items: equipment,
+    currentPatient,
+    loading,
+    error,
+    successMessage,
+    createItem,
+    updateItem,
+    deleteItem,
+    refreshData,
+    clearError,
+    setError,
+  } = useMedicalData({
+    entityName: 'equipment',
+    apiMethodsConfig: {
+      getAll: signal => apiService.getMedicalEquipment(signal),
+      getByPatient: (patientId, signal) => apiService.getMedicalEquipment(signal), // Equipment is patient-scoped by backend
+      create: (data, signal) => apiService.createMedicalEquipment(data, signal),
+      update: (id, data, signal) => apiService.updateMedicalEquipment(id, data, signal),
+      delete: (id, signal) => apiService.deleteMedicalEquipment(id, signal),
+    },
+    requiresPatient: true,
+  });
+
+  // Data management for filtering
+  const dataManagement = useSimpleDataManagement(equipment, equipmentConfig);
+
+  // View modal navigation
+  const {
+    isOpen: showViewModal,
+    viewingItem: viewingEquipment,
+    openModal: handleViewEquipment,
+    closeModal: handleCloseViewModal,
+  } = useViewModalNavigation({
+    items: equipment,
+    loading,
+  });
+
+  // Form state
+  const [showModal, setShowModal] = useState(false);
+  const [editingEquipment, setEditingEquipment] = useState(null);
+  const [formData, setFormData] = useState(EMPTY_FORM_DATA);
+
+  const handleAddEquipment = () => {
+    setEditingEquipment(null);
+    setFormData(EMPTY_FORM_DATA);
+    setShowModal(true);
+  };
+
+  const handleEditEquipment = (equip) => {
+    setEditingEquipment(equip);
+    setFormData({
+      equipment_name: equip.equipment_name || '',
+      equipment_type: equip.equipment_type || '',
+      manufacturer: equip.manufacturer || '',
+      model_number: equip.model_number || '',
+      serial_number: equip.serial_number || '',
+      prescribed_date: equip.prescribed_date || '',
+      last_service_date: equip.last_service_date || '',
+      next_service_date: equip.next_service_date || '',
+      usage_instructions: equip.usage_instructions || '',
+      status: equip.status || 'active',
+      supplier: equip.supplier || '',
+      notes: equip.notes || '',
+      practitioner_id: equip.practitioner_id ? String(equip.practitioner_id) : '',
+      tags: equip.tags || [],
+    });
+    setShowModal(true);
+  };
+
+  const handleDeleteEquipment = async (equipmentId) => {
+    const success = await deleteItem(equipmentId);
+    if (success) {
+      await refreshData();
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!formData.equipment_name.trim()) {
+      setError('Equipment name is required');
+      return;
+    }
+
+    if (!formData.equipment_type) {
+      setError('Equipment type is required');
+      return;
+    }
+
+    if (!currentPatient?.id) {
+      setError('Patient information not available');
+      return;
+    }
+
+    const equipmentData = {
+      equipment_name: formData.equipment_name,
+      equipment_type: formData.equipment_type,
+      manufacturer: formData.manufacturer || null,
+      model_number: formData.model_number || null,
+      serial_number: formData.serial_number || null,
+      prescribed_date: formData.prescribed_date || null,
+      last_service_date: formData.last_service_date || null,
+      next_service_date: formData.next_service_date || null,
+      usage_instructions: formData.usage_instructions || null,
+      status: formData.status || 'active',
+      supplier: formData.supplier || null,
+      notes: formData.notes || null,
+      tags: formData.tags || [],
+      patient_id: currentPatient.id,
+      practitioner_id: formData.practitioner_id ? parseInt(formData.practitioner_id) : null,
+    };
+
+    let success;
+    if (editingEquipment) {
+      success = await updateItem(editingEquipment.id, equipmentData);
+    } else {
+      success = await createItem(equipmentData);
+    }
+
+    if (success) {
+      setShowModal(false);
+      await refreshData();
+    }
+  };
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const filteredEquipment = dataManagement.data;
+
+  if (loading) {
+    return (
+      <MedicalPageLoading
+        message={t('equipment.loading', 'Loading equipment...')}
+        hint={t('equipment.loadingHint', 'If this takes too long, please refresh the page')}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Container size="xl" py="md">
+        <PageHeader title={t('equipment.title', 'Medical Equipment')} icon="🩺" />
+
+        <Stack gap="lg">
+          <MedicalPageAlerts
+            error={error}
+            successMessage={successMessage}
+            onClearError={clearError}
+          />
+
+          <MedicalPageActions
+            primaryAction={{
+              label: t('equipment.addEquipment', '+ Add Equipment'),
+              onClick: handleAddEquipment,
+            }}
+            viewMode={viewMode}
+            onViewModeChange={setViewMode}
+            mb={0}
+          />
+
+          {/* Search and Filter */}
+          <MedicalPageFilters dataManagement={dataManagement} config={equipmentConfig} />
+
+          {filteredEquipment.length === 0 ? (
+            <EmptyState
+              emoji="🩺"
+              title={t('equipment.noEquipmentFound', 'No Equipment Found')}
+              hasActiveFilters={dataManagement.hasActiveFilters}
+              filteredMessage={t('equipment.tryAdjustingFilters', 'Try adjusting your search or filter criteria.')}
+              noDataMessage={t('equipment.startAdding', 'Start by adding your first piece of medical equipment.')}
+              actionButton={
+                <Button variant="filled" onClick={handleAddEquipment}>
+                  {t('equipment.addFirstEquipment', 'Add Your First Equipment')}
+                </Button>
+              }
+            />
+          ) : (
+            <AnimatedCardGrid
+              items={filteredEquipment}
+              columns={{ base: 12, sm: 6, lg: 4 }}
+              renderCard={(equip) => (
+                <EquipmentCard
+                  equipment={equip}
+                  onEdit={handleEditEquipment}
+                  onDelete={handleDeleteEquipment}
+                  onView={handleViewEquipment}
+                  onError={(error) => {
+                    logger.error('EquipmentCard error', {
+                      equipmentId: equip.id,
+                      error: error.message,
+                      page: 'MedicalEquipment',
+                    });
+                  }}
+                />
+              )}
+            />
+          )}
+        </Stack>
+      </Container>
+
+      <EquipmentFormWrapper
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        title={editingEquipment ? t('equipment.editEquipment', 'Edit Equipment') : t('equipment.addEquipment', 'Add Equipment')}
+        editingEquipment={editingEquipment}
+        formData={formData}
+        onInputChange={handleInputChange}
+        onSubmit={handleSubmit}
+        practitionersOptions={practitioners}
+        practitionersLoading={false}
+        isLoading={false}
+      />
+
+      <EquipmentViewModal
+        isOpen={showViewModal}
+        onClose={handleCloseViewModal}
+        equipment={viewingEquipment}
+        onEdit={handleEditEquipment}
+        practitioners={practitioners}
+      />
+    </>
+  );
+};
+
+export default withResponsive(MedicalEquipment, {
+  injectResponsive: true,
+  displayName: 'ResponsiveMedicalEquipment'
+});

--- a/frontend/src/pages/medical/Treatments.jsx
+++ b/frontend/src/pages/medical/Treatments.jsx
@@ -180,22 +180,13 @@ const Treatments = () => {
   const handleSubmit = async e => {
     e.preventDefault();
 
-    // Validation
+    // Validation - only treatment_name is required
     if (!formData.treatment_name.trim()) {
       setError('Treatment name is required');
       return;
     }
 
-    if (!formData.treatment_type.trim()) {
-      setError('Treatment type is required');
-      return;
-    }
-
-    if (!formData.start_date) {
-      setError('Start date is required');
-      return;
-    }
-
+    // Validate end date is after start date (only if both are provided)
     if (
       formData.end_date &&
       formData.start_date &&
@@ -212,8 +203,8 @@ const Treatments = () => {
 
     const treatmentData = {
       treatment_name: formData.treatment_name,
-      treatment_type: formData.treatment_type,
-      description: formData.description,
+      treatment_type: formData.treatment_type || null,
+      description: formData.description || null,
       start_date: formData.start_date || null,
       end_date: formData.end_date || null,
       status: formData.status,
@@ -267,13 +258,18 @@ const Treatments = () => {
     return practitioner;
   };
 
-  // Handler to navigate to condition page and open view modal
-  const handleConditionClick = conditionId => {
-    if (conditionId) {
-      // Navigate to conditions page with view parameter to auto-open the modal
-      navigate(`/conditions?view=${conditionId}`);
+  // Generic handler factory for navigating to entity pages with view modal
+  const createEntityClickHandler = (path) => (entityId) => {
+    if (entityId) {
+      navigate(`${path}?view=${entityId}`);
     }
   };
+
+  const handleConditionClick = createEntityClickHandler('/conditions');
+  const handleMedicationClick = createEntityClickHandler('/medications');
+  const handleEncounterClick = createEntityClickHandler('/visits');
+  const handleLabResultClick = createEntityClickHandler('/lab-results');
+  const handleEquipmentClick = createEntityClickHandler('/medical-equipment');
 
   // Get processed data from data management
   const filteredTreatments = dataManagement.data;
@@ -444,6 +440,10 @@ const Treatments = () => {
         conditions={conditions}
         practitioners={practitioners}
         onConditionClick={handleConditionClick}
+        onMedicationClick={handleMedicationClick}
+        onEncounterClick={handleEncounterClick}
+        onLabResultClick={handleLabResultClick}
+        onEquipmentClick={handleEquipmentClick}
         navigate={navigate}
       />
     </>

--- a/frontend/src/services/api/index.js
+++ b/frontend/src/services/api/index.js
@@ -23,6 +23,7 @@ const ENTITY_TO_API_PATH = {
   [ENTITY_TYPES.FAMILY_MEMBER]: 'family-members',
   [ENTITY_TYPES.SYMPTOM]: 'symptoms',
   [ENTITY_TYPES.INJURY]: 'injuries',
+  [ENTITY_TYPES.MEDICAL_EQUIPMENT]: 'medical-equipment',
 };
 
 // Streamlined API service with proper logging integration
@@ -1880,6 +1881,132 @@ class ApiService {
 
   deleteTreatment(treatmentId, signal) {
     return this.deleteEntity(ENTITY_TYPES.TREATMENT, treatmentId, signal);
+  }
+
+  // Treatment-Medication relationship methods
+  getTreatmentMedications(treatmentId, signal) {
+    return this.get(`/treatments/${treatmentId}/medications`, { signal });
+  }
+
+  linkTreatmentMedication(treatmentId, data, signal) {
+    return this.post(`/treatments/${treatmentId}/medications`, data, { signal });
+  }
+
+  linkTreatmentMedicationsBulk(treatmentId, medicationIds, relevanceNote = null, signal) {
+    return this.post(`/treatments/${treatmentId}/medications/bulk`, {
+      medication_ids: medicationIds,
+      relevance_note: relevanceNote,
+    }, { signal });
+  }
+
+  updateTreatmentMedication(treatmentId, relationshipId, data, signal) {
+    return this.put(`/treatments/${treatmentId}/medications/${relationshipId}`, data, { signal });
+  }
+
+  unlinkTreatmentMedication(treatmentId, relationshipId, signal) {
+    return this.delete(`/treatments/${treatmentId}/medications/${relationshipId}`, { signal });
+  }
+
+  // Treatment-Encounter relationship methods
+  getTreatmentEncounters(treatmentId, signal) {
+    return this.get(`/treatments/${treatmentId}/encounters`, { signal });
+  }
+
+  linkTreatmentEncounter(treatmentId, data, signal) {
+    return this.post(`/treatments/${treatmentId}/encounters`, data, { signal });
+  }
+
+  linkTreatmentEncountersBulk(treatmentId, encounterIds, relevanceNote = null, signal) {
+    return this.post(`/treatments/${treatmentId}/encounters/bulk`, {
+      encounter_ids: encounterIds,
+      relevance_note: relevanceNote,
+    }, { signal });
+  }
+
+  updateTreatmentEncounter(treatmentId, relationshipId, data, signal) {
+    return this.put(`/treatments/${treatmentId}/encounters/${relationshipId}`, data, { signal });
+  }
+
+  unlinkTreatmentEncounter(treatmentId, relationshipId, signal) {
+    return this.delete(`/treatments/${treatmentId}/encounters/${relationshipId}`, { signal });
+  }
+
+  // Treatment-LabResult relationship methods
+  getTreatmentLabResults(treatmentId, signal) {
+    return this.get(`/treatments/${treatmentId}/lab-results`, { signal });
+  }
+
+  linkTreatmentLabResult(treatmentId, data, signal) {
+    return this.post(`/treatments/${treatmentId}/lab-results`, data, { signal });
+  }
+
+  linkTreatmentLabResultsBulk(treatmentId, labResultIds, purpose = null, relevanceNote = null, signal) {
+    return this.post(`/treatments/${treatmentId}/lab-results/bulk`, {
+      lab_result_ids: labResultIds,
+      purpose: purpose,
+      relevance_note: relevanceNote,
+    }, { signal });
+  }
+
+  updateTreatmentLabResult(treatmentId, relationshipId, data, signal) {
+    return this.put(`/treatments/${treatmentId}/lab-results/${relationshipId}`, data, { signal });
+  }
+
+  unlinkTreatmentLabResult(treatmentId, relationshipId, signal) {
+    return this.delete(`/treatments/${treatmentId}/lab-results/${relationshipId}`, { signal });
+  }
+
+  // Treatment-Equipment relationship methods
+  getTreatmentEquipment(treatmentId, signal) {
+    return this.get(`/treatments/${treatmentId}/equipment`, { signal });
+  }
+
+  linkTreatmentEquipment(treatmentId, data, signal) {
+    return this.post(`/treatments/${treatmentId}/equipment`, data, { signal });
+  }
+
+  linkTreatmentEquipmentBulk(treatmentId, equipmentIds, relevanceNote = null, signal) {
+    return this.post(`/treatments/${treatmentId}/equipment/bulk`, {
+      equipment_ids: equipmentIds,
+      relevance_note: relevanceNote,
+    }, { signal });
+  }
+
+  updateTreatmentEquipment(treatmentId, relationshipId, data, signal) {
+    return this.put(`/treatments/${treatmentId}/equipment/${relationshipId}`, data, { signal });
+  }
+
+  unlinkTreatmentEquipment(treatmentId, relationshipId, signal) {
+    return this.delete(`/treatments/${treatmentId}/equipment/${relationshipId}`, { signal });
+  }
+
+  // Medical Equipment methods
+  getMedicalEquipment(signal) {
+    return this.get('/medical-equipment/', { signal });
+  }
+
+  getMedicalEquipmentById(equipmentId, signal) {
+    return this.get(`/medical-equipment/${equipmentId}`, { signal });
+  }
+
+  getActiveMedicalEquipment(signal) {
+    return this.get('/medical-equipment/active/', { signal });
+  }
+
+  getMedicalEquipmentNeedingService(signal) {
+    return this.get('/medical-equipment/needing-service/', { signal });
+  }
+
+  createMedicalEquipment(equipmentData, signal) {
+    return this.post('/medical-equipment/', equipmentData, { signal });
+  }
+
+  updateMedicalEquipment(equipmentId, equipmentData, signal) {
+    return this.put(`/medical-equipment/${equipmentId}`, equipmentData, { signal });
+  }
+
+  deleteMedicalEquipment(equipmentId, signal) {
+    return this.delete(`/medical-equipment/${equipmentId}`, { signal });
   }
 
   // Procedure methods

--- a/frontend/src/utils/entityNavigation.js
+++ b/frontend/src/utils/entityNavigation.js
@@ -31,6 +31,7 @@ const ENTITY_TO_ROUTE_MAP = {
   [ENTITY_TYPES.EMERGENCY_CONTACT]: '/emergency-contacts',
   [ENTITY_TYPES.PATIENT]: '/patients',
   [ENTITY_TYPES.FAMILY_MEMBER]: '/family-history',
+  [ENTITY_TYPES.MEDICAL_EQUIPMENT]: '/medical-equipment',
 };
 
 /**

--- a/frontend/src/utils/entityRelationships.js
+++ b/frontend/src/utils/entityRelationships.js
@@ -24,6 +24,7 @@ export const ENTITY_TYPES = {
   FAMILY_MEMBER: 'family_member',
   SYMPTOM: 'symptoms',
   INJURY: 'injury',
+  MEDICAL_EQUIPMENT: 'medical_equipment',
 };
 
 // Relationship types


### PR DESCRIPTION
This pull request introduces comprehensive support for managing medical equipment as part of a patient's treatment plan. It includes a new database table for medical equipment, several new relationship tables to link treatments with medications, encounters, lab results, and equipment, and a full set of CRUD API endpoints for medical equipment management. Additionally, the treatment model is updated to make some fields optional, and relevant relationships and logging are established throughout the backend.

**Database schema changes:**

- Added a new `medical_equipment` table to track equipment assigned to patients, including details like type, manufacturer, service dates, and status.
- Introduced several junction tables: `treatment_medications`, `treatment_encounters`, `treatment_lab_results`, and `treatment_equipment` to enable many-to-many relationships between treatments and other entities.
- Made the `treatment_type` and `start_date` fields in the `treatments` table optional (nullable).

**API and backend logic:**

- Implemented a new API router and endpoint set (`app/api/v1/endpoints/medical_equipment.py`) for CRUD operations, filtering, and querying medical equipment, including endpoints for active equipment and those needing service.
- Registered the new medical equipment API endpoints in the main API router. [[1]](diffhunk://#diff-968b39b3701201539408ecfce108b95fba055d08fbc6c6c8f0e0a8d612b16058R24) [[2]](diffhunk://#diff-968b39b3701201539408ecfce108b95fba055d08fbc6c6c8f0e0a8d612b16058R98)
- Added a dedicated CRUD module for medical equipment with patient filtering, type filtering, active status, and service-needs logic.

**Model and logging updates:**

- Added `medical_equipment` relationships to both `Patient` and `Practitioner` models, enabling ORM-level access to a patient's or practitioner's equipment. [[1]](diffhunk://#diff-6136b7719b4607d189578925ce8b2785a6304e57812f17d99ebbb90a11fe4867R241-R243) [[2]](diffhunk://#diff-6136b7719b4607d189578925ce8b2785a6304e57812f17d99ebbb90a11fe4867R288)
- Introduced a new `EntityType.MEDICAL_EQUIPMENT` constant for activity logging and auditing.

**Summary of most important changes:**

**Database and Schema:**
- Added `medical_equipment` table and several treatment relationship tables to support equipment tracking and complex treatment plans.
- Made `treatment_type` and `start_date` fields in `treatments` table optional.

**API and CRUD:**
- Implemented new CRUD and API endpoints for managing medical equipment, including filtering, detailed retrieval, and service status checks. [[1]](diffhunk://#diff-4f96815d813826d784fd1c2c9e4af4c4899c0f5622273e9744544eefc4594aa8R1-R250) [[2]](diffhunk://#diff-b489ce991803432bb6fd94f2b50f7c4f4cfa047d786173a29b8bb59ba7bbe808R1-R140)
- Registered the new endpoints with the main API router. [[1]](diffhunk://#diff-968b39b3701201539408ecfce108b95fba055d08fbc6c6c8f0e0a8d612b16058R24) [[2]](diffhunk://#diff-968b39b3701201539408ecfce108b95fba055d08fbc6c6c8f0e0a8d612b16058R98)

**Models and Logging:**
- Added ORM relationships for `medical_equipment` in `Patient` and `Practitioner` models. [[1]](diffhunk://#diff-6136b7719b4607d189578925ce8b2785a6304e57812f17d99ebbb90a11fe4867R241-R243) [[2]](diffhunk://#diff-6136b7719b4607d189578925ce8b2785a6304e57812f17d99ebbb90a11fe4867R288)
- Added `MEDICAL_EQUIPMENT` to the `EntityType` enum for logging purposes.