### PR TITLE
fix: update tags field type in SymptomUpdate schema from string to list of strings

### DIFF
--- a/app/schemas/symptom.py
+++ b/app/schemas/symptom.py
@@ -104,7 +104,7 @@ class SymptomUpdate(BaseModel):
     is_chronic: Optional[bool] = None
     typical_triggers: Optional[List[str]] = None
     general_notes: Optional[str] = None
-    tags: Optional[str] = None
+    tags: Optional[List[str]] = None
 
     @field_validator("symptom_name")
     @classmethod


### PR DESCRIPTION
This pull request makes a small but important change to the `SymptomUpdate` schema. The `tags` field has been updated to accept a list of strings instead of a single string, allowing for multiple tags to be associated with a symptom.

* Changed the type of the `tags` field in the `SymptomUpdate` model from `Optional[str]` to `Optional[List[str]]` in `app/schemas/symptom.py` to support multiple tags.