### PR TITLE
fix: added missing translation keys to vistits

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -66,6 +66,8 @@
     "endDate": "Enddatum",
     "duration": "Dauer",
     "notes": "Notizen",
+    "tags": "Tags",
+    "location": "Standort",
     "name": "Name",
     "date": "Datum",
     "time": "Zeit",
@@ -89,6 +91,13 @@
     "conditionsAvailableToLink": "{{count}} Erkrankungen zum Verknüpfen verfügbar",
     "linkedMedications": "Verknüpfte Medikamente",
     "visitWebsite": "Website besuchen ↗"
+  },
+  "fields": {
+    "tags": {
+      "label": "Tags",
+      "placeholder": "Tags hinzufügen, um diesen Eintrag zu organisieren",
+      "description": "Tags hinzufügen, um diesen Eintrag später zu finden"
+    }
   },
   "viewToggle": {
     "cards": "Karten",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -66,6 +66,8 @@
     "endDate": "End Date",
     "duration": "Duration",
     "notes": "Notes",
+    "tags": "Tags",
+    "location": "Location",
     "name": "Name",
     "date": "Date",
     "time": "Time",
@@ -87,6 +89,13 @@
     "conditionsAvailableToLink": "{{count}} conditions available to link",
     "linkedMedications": "Linked Medications",
     "visitWebsite": "Visit Website ↗"
+  },
+  "fields": {
+    "tags": {
+      "label": "Tags",
+      "placeholder": "Add tags to organize and find this record",
+      "description": "Add tags to help organize and search for this record later"
+    }
   },
   "viewToggle": {
     "cards": "Cards",

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -61,6 +61,8 @@
     "endDate": "Fecha de fin",
     "duration": "Duración",
     "notes": "Notas",
+    "tags": "Etiquetas",
+    "location": "Ubicación",
     "name": "Nombre",
     "date": "Fecha",
     "time": "Hora",
@@ -72,6 +74,13 @@
     "account": "Cuenta",
     "help": "Ayuda",
     "support": "Soporte"
+  },
+  "fields": {
+    "tags": {
+      "label": "Etiquetas",
+      "placeholder": "Agregar etiquetas para organizar este registro",
+      "description": "Agregar etiquetas para encontrar este registro más tarde"
+    }
   },
   "viewToggle": {
     "cards": "Tarjetas",

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -65,6 +65,8 @@
     "endDate": "Datee de fin",
     "duration": "Durée",
     "notes": "Notes",
+    "tags": "Tags",
+    "location": "Lieu",
     "name": "Nom",
     "date": "Date",
     "time": "Heure",
@@ -86,6 +88,13 @@
     "conditionsAvailableToLink": "{{count}} conditions pouvant être connectées",
     "linkedMedications": "Médicaments connectés",
     "visitWebsite": "Visiter le site web ↗"
+  },
+  "fields": {
+    "tags": {
+      "label": "Tags",
+      "placeholder": "Ajouter des tags pour organiser cet enregistrement",
+      "description": "Ajouter des tags pour retrouver cet enregistrement plus tard"
+    }
   },
   "viewToggle": {
     "cards": "Cartes",
@@ -110,7 +119,7 @@
         "bloodGlucoseMin": "Le taux de glucose dans le sang doit valoir au moins 20 mg/dL",
         "bloodGlucoseMax": "Le taux de glucose dans le sang ne peut pas dépasser 800 mg/dL",
         "a1cMin": "A1C doit valoir au moins 0 %",
-        "a1cMax": "A1C ne peut dépasser 20 %"
+        "a1cMax": "A1C ne peut dépasser 20 %",
         "dateInFuture": "La date ne peut se situer dans le futur",
         "timeInFuture": "L'heure sélectionnée ne peut se situer dans le futur"
       }

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -65,6 +65,8 @@
     "endDate": "Data di fine",
     "duration": "Durata",
     "notes": "Note",
+    "tags": "Tag",
+    "location": "Posizione",
     "name": "Nome",
     "date": "Data",
     "time": "Ora",
@@ -86,6 +88,13 @@
     "conditionsAvailableToLink": "{{count}} condizioni disponibili da collegare",
     "linkedMedications": "Farmaci collegati",
     "visitWebsite": "Visita il sito ↗"
+  },
+  "fields": {
+    "tags": {
+      "label": "Tag",
+      "placeholder": "Aggiungi tag per organizzare questo record",
+      "description": "Aggiungi tag per trovare questo record più tardi"
+    }
   },
   "viewToggle": {
     "cards": "Schede",

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -65,6 +65,8 @@
     "endDate": "Data de Término",
     "duration": "Duração",
     "notes": "Notas",
+    "tags": "Tags",
+    "location": "Local",
     "name": "Nome",
     "date": "Data",
     "time": "Hora",
@@ -86,6 +88,13 @@
     "conditionsAvailableToLink": "{{count}} condições disponíveis para vincular",
     "linkedMedications": "Medicações Vinculadas",
     "visitWebsite": "Visitar Site ↗"
+  },
+  "fields": {
+    "tags": {
+      "label": "Tags",
+      "placeholder": "Adicionar tags para organizar este registro",
+      "description": "Adicionar tags para encontrar este registro mais tarde"
+    }
   },
   "viewToggle": {
     "cards": "Cards",

--- a/frontend/src/components/medical/MantineVisitForm.jsx
+++ b/frontend/src/components/medical/MantineVisitForm.jsx
@@ -46,7 +46,9 @@ const MantineVisitForm = ({
   statusMessage,
   children,
 }) => {
-  const { t } = useTranslation('common');
+  // Translation hooks - medical for field translations, common for UI elements
+  const { t } = useTranslation('medical');
+  const { t: tCommon } = useTranslation('common');
 
   // Tab state management
   const [activeTab, setActiveTab] = useState('info');
@@ -240,7 +242,7 @@ const MantineVisitForm = ({
         }
       }}
     >
-      <FormLoadingOverlay visible={isSubmitting || isLoading} message={t('visits.form.savingVisit', 'Saving visit...')} />
+      <FormLoadingOverlay visible={isSubmitting || isLoading} message={tCommon('visits.form.savingVisit', 'Saving visit...')} />
 
       <form onSubmit={handleSubmit}>
         <Stack gap="lg">
@@ -248,18 +250,18 @@ const MantineVisitForm = ({
           <Tabs value={activeTab} onChange={setActiveTab}>
             <Tabs.List>
               <Tabs.Tab value="info" leftSection={<IconInfoCircle size={16} />}>
-                {t('visits.form.tabs.visitInfo', 'Visit Info')}
+                {tCommon('visits.form.tabs.visitInfo', 'Visit Info')}
               </Tabs.Tab>
               <Tabs.Tab value="clinical" leftSection={<IconStethoscope size={16} />}>
-                {t('visits.form.tabs.clinical', 'Clinical')}
+                {tCommon('visits.form.tabs.clinical', 'Clinical')}
               </Tabs.Tab>
               {editingVisit && (
                 <Tabs.Tab value="documents" leftSection={<IconFileText size={16} />}>
-                  {t('visits.form.tabs.documents', 'Documents')}
+                  {tCommon('visits.form.tabs.documents', 'Documents')}
                 </Tabs.Tab>
               )}
               <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
-                {t('visits.form.tabs.notes', 'Notes')}
+                {tCommon('visits.form.tabs.notes', 'Notes')}
               </Tabs.Tab>
             </Tabs.List>
 
@@ -290,7 +292,7 @@ const MantineVisitForm = ({
               <Tabs.Panel value="documents">
                 <Box mt="md">
                   <Stack gap="md">
-                    <Title order={4}>{t('visits.viewModal.attachedDocuments', 'Attached Documents')}</Title>
+                    <Title order={4}>{tCommon('visits.viewModal.attachedDocuments', 'Attached Documents')}</Title>
                     <DocumentManagerWithProgress
                       entityType="visit"
                       entityId={editingVisit.id}
@@ -319,10 +321,10 @@ const MantineVisitForm = ({
           {/* Action Buttons */}
           <Group justify="flex-end" mt="md">
             <Button variant="outline" onClick={onClose} disabled={isSubmitting || isLoading}>
-              {t('buttons.cancel', 'Cancel')}
+              {tCommon('buttons.cancel', 'Cancel')}
             </Button>
             <Button type="submit" disabled={isSubmitting || isLoading}>
-              {editingVisit ? t('visits.form.updateVisit', 'Update Visit') : t('visits.form.addVisit', 'Add Visit')}
+              {editingVisit ? tCommon('visits.form.updateVisit', 'Update Visit') : tCommon('visits.form.addVisit', 'Add Visit')}
             </Button>
           </Group>
         </Stack>


### PR DESCRIPTION
- Introduced new "tags" and "location" fields in the localization JSON files for German, English, Spanish, French, Italian, and Portuguese.
- Added corresponding labels, placeholders, and descriptions for the tags field to enhance user experience in organizing and finding records.