### PR TITLE
fix: normalize empty values in VitalsForm submission handling

### DIFF
--- a/frontend/src/components/medical/VitalsForm.jsx
+++ b/frontend/src/components/medical/VitalsForm.jsx
@@ -631,14 +631,16 @@ const VitalsForm = ({
         notes: formData.notes || null,
       };
 
-      // Remove empty/null values
+      // Edit: normalize empties to null so the backend clears DB columns.
+      // Create: strip empties so only provided fields are sent.
       Object.keys(processedData).forEach(key => {
-        if (
-          processedData[key] === '' ||
-          processedData[key] === null ||
-          processedData[key] === undefined
-        ) {
-          delete processedData[key];
+        const value = processedData[key];
+        if (value == null || value === '') {
+          if (isEdit) {
+            processedData[key] = null;
+          } else {
+            delete processedData[key];
+          }
         }
       });
 


### PR DESCRIPTION
- Updated the VitalsForm component to handle empty values differently based on the edit state. In edit mode, empty strings are normalized to null, allowing the backend to clear corresponding database columns. In create mode, empty values are removed from the submission data, ensuring only provided fields are sent to the backend.