### PR TITLE
refactor: shuffle practitioner contact info be more visually consistent 

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -1958,11 +1958,10 @@
     "viewModal": {
       "title": "Details der medizinischen Fachkraft",
       "subtitle": "Medizinische Fachkraft",
-      "practiceInfo": "PRAXISINFORMATIONEN",
+      "practitionerContact": "ARZTKONTAKT",
       "practice": "Praxis",
       "specialty": "Fachgebiet",
       "phone": "Telefon",
-      "contactRating": "KONTAKT & BEWERTUNG",
       "website": "Webseite",
       "visitWebsite": "Webseite besuchen",
       "rating": "Bewertung",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1707,12 +1707,11 @@
     "viewModal": {
       "title": "Practitioner Details",
       "subtitle": "Healthcare Practitioner",
-      "practiceInfo": "PRACTICE INFORMATION",
+      "practitionerContact": "PRACTITIONER CONTACT",
       "practice": "Practice",
       "specialty": "Specialty",
       "phone": "Phone",
       "email": "Email",
-      "contactRating": "CONTACT & RATING",
       "website": "Website",
       "visitWebsite": "Visit Website",
       "rating": "Rating",

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -1867,12 +1867,11 @@
     },
     "title": "Profesionales de salud",
     "viewModal": {
-      "contactRating": "CONTACTO Y VALORACIÓN",
       "editButton": "Editar profesional",
       "email": "Correo electrónico",
       "phone": "Teléfono",
       "practice": "Consultorio",
-      "practiceInfo": "INFORMACIÓN DEL CONSULTORIO",
+      "practitionerContact": "CONTACTO DEL PROFESIONAL",
       "rating": "Valoración",
       "specialty": "Especialidad",
       "subtitle": "Profesional de salud",

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -1707,12 +1707,11 @@
     "viewModal": {
       "title": "Détails du médecin",
       "subtitle": "Médecin",
-      "practiceInfo": "INFORMATIONS DU CABINET",
+      "practitionerContact": "CONTACT DU PRATICIEN",
       "practice": "Cabinet",
       "specialty": "Spécialité",
       "phone": "Téléphone",
       "email": "Email",
-      "contactRating": "CONTACT & AVIS",
       "website": "Site web",
       "visitWebsite": "Visiter le site web",
       "rating": "Avis",

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -1707,11 +1707,10 @@
     "viewModal": {
       "title": "Dettagli professionista",
       "subtitle": "Professionista sanitario",
-      "practiceInfo": "INFORMAZIONI SULLA STRUTTURA",
+      "practitionerContact": "CONTATTO DEL PROFESSIONISTA",
       "practice": "Struttura",
       "specialty": "Specialità",
       "phone": "Telefono",
-      "contactRating": "CONTATTI E VALUTAZIONE",
       "website": "Sito web",
       "visitWebsite": "Visita il sito web",
       "rating": "Valutazione",

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -1707,11 +1707,10 @@
     "viewModal": {
       "title": "Detalhes do Profissional",
       "subtitle": "Profissional de Saúde",
-      "practiceInfo": "INFORMAÇÕES DA PRÁTICA",
+      "practitionerContact": "CONTATO DO PROFISSIONAL",
       "practice": "Prática",
       "specialty": "Especialidade",
       "phone": "Telefone",
-      "contactRating": "CONTATO & AVALIAÇÃO",
       "website": "Website",
       "visitWebsite": "Visitar Website",
       "rating": "Avaliação",

--- a/frontend/src/components/medical/practitioners/PractitionerViewModal.jsx
+++ b/frontend/src/components/medical/practitioners/PractitionerViewModal.jsx
@@ -88,15 +88,6 @@ const PractitionerViewModal = ({
 
   const notSpecified = t('common.labels.notSpecified', 'Not specified');
 
-  const hasPracticeContactInfo = practiceDetails && (
-    practiceDetails.phone_number ||
-    practiceDetails.fax_number ||
-    practiceDetails.website ||
-    practiceDetails.patient_portal_url ||
-    practiceDetails.notes ||
-    (practiceDetails.locations && practiceDetails.locations.length > 0)
-  );
-
   return (
     <Modal
       opened={isOpen}
@@ -143,14 +134,14 @@ const PractitionerViewModal = ({
           </Group>
         </Paper>
 
-        <Grid>
-          <Grid.Col span={{ base: 12, sm: 6 }}>
-            <Card withBorder p="md" h="100%">
-              <Stack gap="sm">
-                <Text fw={600} size="sm" c="dimmed">
-                  {t('practitioners.viewModal.practiceInfo', 'PRACTICE INFORMATION')}
-                </Text>
-                <Divider />
+        <Card withBorder p="md">
+          <Stack gap="sm">
+            <Text fw={600} size="sm" c="dimmed">
+              {t('practitioners.viewModal.practitionerContact', 'PRACTITIONER CONTACT')}
+            </Text>
+            <Divider />
+            <Grid>
+              <Grid.Col span={{ base: 12, sm: 6 }}>
                 <Group>
                   <Text size="sm" fw={500} w={80}>
                     {t('practitioners.viewModal.practice', 'Practice')}:
@@ -162,6 +153,8 @@ const PractitionerViewModal = ({
                     {practitioner.practice_name || practitioner.practice || notSpecified}
                   </Text>
                 </Group>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 6 }}>
                 <Group>
                   <Text size="sm" fw={500} w={80}>
                     {t('practitioners.viewModal.specialty', 'Specialty')}:
@@ -173,6 +166,8 @@ const PractitionerViewModal = ({
                     {practitioner.specialty || notSpecified}
                   </Text>
                 </Group>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 6 }}>
                 <Group>
                   <Text size="sm" fw={500} w={80}>
                     {t('practitioners.viewModal.phone', 'Phone')}:
@@ -184,6 +179,8 @@ const PractitionerViewModal = ({
                     {practitioner.phone_number || notSpecified}
                   </Text>
                 </Group>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 6 }}>
                 <Group>
                   <Text size="sm" fw={500} w={80}>
                     {t('practitioners.viewModal.email', 'Email')}:
@@ -205,17 +202,8 @@ const PractitionerViewModal = ({
                     )}
                   </Text>
                 </Group>
-              </Stack>
-            </Card>
-          </Grid.Col>
-
-          <Grid.Col span={{ base: 12, sm: 6 }}>
-            <Card withBorder p="md" h="100%">
-              <Stack gap="sm">
-                <Text fw={600} size="sm" c="dimmed">
-                  {t('practitioners.viewModal.contactRating', 'CONTACT & RATING')}
-                </Text>
-                <Divider />
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 6 }}>
                 <Group>
                   <Text size="sm" fw={500} w={80}>
                     {t('practitioners.viewModal.website', 'Website')}:
@@ -239,6 +227,8 @@ const PractitionerViewModal = ({
                     )}
                   </Text>
                 </Group>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 6 }}>
                 <Group>
                   <Text size="sm" fw={500} w={80}>
                     {t('practitioners.viewModal.rating', 'Rating')}:
@@ -269,10 +259,10 @@ const PractitionerViewModal = ({
                     )}
                   </Text>
                 </Group>
-              </Stack>
-            </Card>
-          </Grid.Col>
-        </Grid>
+              </Grid.Col>
+            </Grid>
+          </Stack>
+        </Card>
 
         {/* Practice Details Section */}
         {practitioner.practice_id && (
@@ -375,16 +365,14 @@ const PractitionerViewModal = ({
                   </Grid>
 
                   {/* Notes */}
-                  {practiceDetails.notes && (
-                    <div>
-                      <Text size="sm" fw={500} mb={4}>
-                        {t('practitioners.viewModal.practiceNotes', 'Notes')}:
-                      </Text>
-                      <Text size="sm" c="dimmed" style={{ whiteSpace: 'pre-wrap' }}>
-                        {practiceDetails.notes}
-                      </Text>
-                    </div>
-                  )}
+                  <Group>
+                    <Text size="sm" fw={500} w={100}>
+                      {t('practitioners.viewModal.practiceNotes', 'Notes')}:
+                    </Text>
+                    <Text size="sm" c={practiceDetails.notes ? 'inherit' : 'dimmed'} style={{ whiteSpace: 'pre-wrap' }}>
+                      {practiceDetails.notes || notSpecified}
+                    </Text>
+                  </Group>
 
                   {/* Locations */}
                   {practiceDetails.locations && practiceDetails.locations.length > 0 && (
@@ -404,11 +392,6 @@ const PractitionerViewModal = ({
                     </div>
                   )}
 
-                  {!hasPracticeContactInfo && (
-                    <Text size="sm" c="dimmed" fs="italic">
-                      {notSpecified}
-                    </Text>
-                  )}
                 </Stack>
               ) : (
                 <Text size="sm" c="dimmed" fs="italic">


### PR DESCRIPTION
This pull request updates the practitioner view modal to improve clarity and consistency in both the UI layout and translations. The modal now consolidates practitioner contact information into a single section, removes redundant labels, and refines how missing information is displayed. Translations across all supported languages have been updated to match these changes.

**UI and Layout Improvements:**

* Combined practitioner contact and rating information into a single `Card` section, simplifying the layout and removing the previously split sections for practice info and contact/rating. (`frontend/src/components/medical/practitioners/PractitionerViewModal.jsx`, [[1]](diffhunk://#diff-0f81ce6cd9acf983509d98a25131cf0b7f969eef1c8f4ec93c4a60ecf985bb48L146-R144) [[2]](diffhunk://#diff-0f81ce6cd9acf983509d98a25131cf0b7f969eef1c8f4ec93c4a60ecf985bb48L208-L218) [[3]](diffhunk://#diff-0f81ce6cd9acf983509d98a25131cf0b7f969eef1c8f4ec93c4a60ecf985bb48L272-R265)
* Improved display of notes in the practice details section: notes are shown using a `Group`, and if missing, "Not specified" is displayed in a dimmed style. (`frontend/src/components/medical/practitioners/PractitionerViewModal.jsx`, [frontend/src/components/medical/practitioners/PractitionerViewModal.jsxL378-R375](diffhunk://#diff-0f81ce6cd9acf983509d98a25131cf0b7f969eef1c8f4ec93c4a60ecf985bb48L378-R375))
* Removed fallback for missing practice contact info, relying on individual fields to show "Not specified" instead. (`frontend/src/components/medical/practitioners/PractitionerViewModal.jsx`, [frontend/src/components/medical/practitioners/PractitionerViewModal.jsxL407-L411](diffhunk://#diff-0f81ce6cd9acf983509d98a25131cf0b7f969eef1c8f4ec93c4a60ecf985bb48L407-L411))

**Translation and Label Updates:**

* Replaced the label `practiceInfo` with `practitionerContact` and removed the `contactRating` label in all supported languages for consistency. (`frontend/public/locales/en/common.json`, [[1]](diffhunk://#diff-33c499047fc22cc766f0d8b1be2a6103ce9c582c107b84d8219031120f04bd7aL1710-L1715); `frontend/public/locales/de/common.json`, [[2]](diffhunk://#diff-2e67589bc551d2f12ba1499b32925674c0611ff673460af46437902cab5f058eL1961-L1965); `frontend/public/locales/es/common.json`, [[3]](diffhunk://#diff-13c52b69dfe950d320432dae53ccb8a566a5d4d69ac5a7ba54f4a909a3bb4e6fL1870-R1874); `frontend/public/locales/fr/common.json`, [[4]](diffhunk://#diff-285d4745ded42255660eafafa54fc7490496e86f0ed40a9d9ea2f6687b8b32d6L1710-L1715); `frontend/public/locales/it/common.json`, [[5]](diffhunk://#diff-7f4d6bada4d4e07a00f12836e045c0d3337f22b8b4cee8a62ec4d4d807f084a5L1710-L1714); `frontend/public/locales/pt/common.json`, [[6]](diffhunk://#diff-176f05b6abedc9e7880d4ed22413ca5c6b41f830a638582cd3eaffecf4ebcf4cL1710-L1714)

**Code Cleanup:**

* Removed the unused `hasPracticeContactInfo` variable from the modal component. (`frontend/src/components/medical/practitioners/PractitionerViewModal.jsx`, [frontend/src/components/medical/practitioners/PractitionerViewModal.jsxL91-L99](diffhunk://#diff-0f81ce6cd9acf983509d98a25131cf0b7f969eef1c8f4ec93c4a60ecf985bb48L91-L99))