### PR TITLE
fix: add missing Center component to TagManagement page

### DIFF
--- a/frontend/src/pages/tools/TagManagement.jsx
+++ b/frontend/src/pages/tools/TagManagement.jsx
@@ -18,6 +18,7 @@ import {
   NumberInput,
   Tooltip,
   Progress,
+  Center,
 } from '@mantine/core';
 import MedicalPageLoading from '../../components/shared/MedicalPageLoading';
 import {


### PR DESCRIPTION
This pull request introduces a minor update to the UI components imported in `TagManagement.jsx`. The `Center` component from `@mantine/core` has been added to the import list. This change will allow for easier centering of elements in the UI where needed.

- Added the `Center` component to the imports from `@mantine/core` in `TagManagement.jsx` to enable centered layouts.