### PR TITLE
fix: resolve family condition lifecycle issues

### DIFF
--- a/app/api/v1/endpoints/family_member.py
+++ b/app/api/v1/endpoints/family_member.py
@@ -268,7 +268,9 @@ def update_family_condition(
             entity_name="Family Condition",
             request=request,
             current_user=current_user,
-            current_user_patient_id=current_user_patient_id,
+            # current_user_patient_id is intentionally omitted here because ownership 
+            # is verified via the parent FamilyMember object above.
+            # FamilyCondition objects do not have a direct patient_id link.
         )
 
 
@@ -311,5 +313,6 @@ def delete_family_condition(
             entity_name="Family Condition",
             request=request,
             current_user=current_user,
-            current_user_patient_id=current_user_patient_id,
+            # current_user_patient_id is intentionally omitted here because ownership 
+            # is verified via the parent FamilyMember object above.
         )

--- a/app/crud/activity_log.py
+++ b/app/crud/activity_log.py
@@ -399,7 +399,7 @@ class CRUDActivityLog(CRUDBase[ActivityLog, Dict[str, Any], Dict[str, Any]]):
             "user_id": user_id,
             "patient_id": patient_id,
             "entity_id": entity_id,
-            "metadata": metadata,
+            "event_metadata": metadata,
             "ip_address": ip_address,
             "user_agent": user_agent,
         }

--- a/app/models/activity_log.py
+++ b/app/models/activity_log.py
@@ -72,7 +72,7 @@ class ActivityLog(Base):
             "entity_type": self.entity_type,
             "entity_id": self.entity_id,
             "description": self.description,
-            "metadata": self.metadata,
+            "metadata": self.event_metadata,
             "timestamp": (
                 self.timestamp.isoformat() if self.timestamp is not None else None
             ),

--- a/app/schemas/family_history_sharing.py
+++ b/app/schemas/family_history_sharing.py
@@ -79,6 +79,7 @@ class FamilyConditionBase(BaseModel):
     status: Optional[str]
     condition_type: Optional[str]
     notes: Optional[str]
+    icd10_code: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/src/components/medical/family-history/FamilyHistoryViewModal.jsx
+++ b/frontend/src/components/medical/family-history/FamilyHistoryViewModal.jsx
@@ -330,6 +330,9 @@ const FamilyHistoryViewModal = ({
                         <Text fw={500} size="md">
                           {condition.condition_name}
                         </Text>
+                        {condition.status && (
+                          <StatusBadge status={condition.status} size="sm" />
+                        )}
                         {condition.severity && (
                           <Badge color={getSeverityColor(condition.severity)}>
                             {condition.severity}
@@ -399,6 +402,12 @@ const FamilyHistoryViewModal = ({
                     {condition.diagnosis_age && (
                       <Text size="sm" c="dimmed" mb="xs">
                         {t('familyHistory.card.diagnosedAtAge', 'Diagnosed at age {{age}}', { age: condition.diagnosis_age })}
+                      </Text>
+                    )}
+
+                    {condition.icd10_code && (
+                      <Text size="sm" c="dimmed" mb="xs">
+                        <strong>ICD-10:</strong> {condition.icd10_code}
                       </Text>
                     )}
 

--- a/frontend/src/components/medical/family-history/__tests__/FamilyHistoryViewModal.test.jsx
+++ b/frontend/src/components/medical/family-history/__tests__/FamilyHistoryViewModal.test.jsx
@@ -1,0 +1,62 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MantineProvider } from '@mantine/core';
+import FamilyHistoryViewModal from '../FamilyHistoryViewModal';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+const mockMember = {
+  id: 1,
+  name: 'John Doe',
+  relationship: 'father',
+  family_conditions: [
+    {
+      id: 10,
+      condition_name: 'Hypertension',
+      status: 'active',
+      icd10_code: 'I10',
+      severity: 'moderate',
+      condition_type: 'cardiovascular',
+      diagnosis_age: 45,
+      notes: 'Controlled with medication'
+    }
+  ]
+};
+
+const renderModal = (props = {}) => {
+  return render(
+    <MantineProvider>
+      <FamilyHistoryViewModal
+        isOpen={true}
+        onClose={vi.fn()}
+        member={mockMember}
+        onEdit={vi.fn()}
+        onAddCondition={vi.fn()}
+        onEditCondition={vi.fn()}
+        onDeleteCondition={vi.fn()}
+        {...props}
+      />
+    </MantineProvider>
+  );
+};
+
+describe('FamilyHistoryViewModal Display', () => {
+  it('renders status badge and ICD-10 code for conditions', () => {
+    renderModal();
+    
+    expect(screen.getByText('Hypertension')).toBeInTheDocument();
+    expect(screen.getByText(/Active/i)).toBeInTheDocument();
+    expect(screen.getByText(/ICD-10:/i)).toBeInTheDocument();
+    expect(screen.getByText('I10')).toBeInTheDocument();
+  });
+
+  it('renders "No medical conditions recorded" when member has no conditions', () => {
+    renderModal({ member: { ...mockMember, family_conditions: [] } });
+    expect(screen.getByText('familyHistory.card.noConditionsRecorded')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/medical/FamilyHistory.jsx
+++ b/frontend/src/pages/medical/FamilyHistory.jsx
@@ -284,6 +284,8 @@ const FamilyHistory = () => {
     condition_type: '',
     severity: '',
     diagnosis_age: '',
+    status: '',
+    icd10_code: '',
     notes: '',
   });
 
@@ -323,6 +325,8 @@ const FamilyHistory = () => {
       condition_type: '',
       severity: '',
       diagnosis_age: '',
+      status: '',
+      icd10_code: '',
       notes: '',
     });
     setEditingCondition(null);
@@ -449,6 +453,8 @@ const FamilyHistory = () => {
       condition_type: condition.condition_type || '',
       severity: condition.severity || '',
       diagnosis_age: condition.diagnosis_age || '',
+      status: condition.status || '',
+      icd10_code: condition.icd10_code || condition.icd10Code || '',
       notes: condition.notes || '',
     });
     setShowConditionModal(true);
@@ -527,6 +533,8 @@ const FamilyHistory = () => {
       condition_type: conditionFormData.condition_type || null,
       severity: conditionFormData.severity || null,
       diagnosis_age: conditionFormData.diagnosis_age || null,
+      status: conditionFormData.status || null,
+      icd10_code: conditionFormData.icd10_code || null,
       notes: conditionFormData.notes || null,
     };
 
@@ -592,6 +600,8 @@ const FamilyHistory = () => {
       condition_type: '',
       severity: '',
       diagnosis_age: '',
+      status: '',
+      icd10_code: '',
       notes: '',
     });
     setEditingCondition(null);
@@ -644,6 +654,8 @@ const FamilyHistory = () => {
         condition_type: condition.condition_type || '',
         severity: condition.severity || '',
         diagnosis_age: condition.diagnosis_age || '',
+        status: condition.status || '',
+        icd10_code: condition.icd10_code || condition.icd10Code || '',
         notes: condition.notes || '',
       });
       // Temporarily close view modal to prevent overlap
@@ -664,6 +676,8 @@ const FamilyHistory = () => {
       condition_type: '',
       severity: '',
       diagnosis_age: '',
+      status: '',
+      icd10_code: '',
       notes: '',
     });
     setEditingCondition(null);

--- a/tests/api/test_family_condition_persistence.py
+++ b/tests/api/test_family_condition_persistence.py
@@ -1,0 +1,47 @@
+import pytest
+from fastapi import status
+from app.models.models import FamilyCondition
+
+def test_family_condition_full_lifecycle(authenticated_client, db_session, test_patient):
+    fm_res = authenticated_client.post(
+        "/api/v1/family-members/",
+        json={"name": "Lifecycle Test Relative", "relationship": "brother", "patient_id": test_patient.id}
+    )
+    assert fm_res.status_code == 200
+    fm_id = fm_res.json()["id"]
+
+    cond_data = {
+        "condition_name": "Test Condition",
+        "status": "active",
+        "icd10_code": "E11.9",
+        "severity": "mild",
+        "condition_type": "diabetes"
+    }
+    create_res = authenticated_client.post(f"/api/v1/family-members/{fm_id}/conditions", json=cond_data)
+    assert create_res.status_code == 200
+    cond_id = create_res.json()["id"]
+    assert create_res.json()["icd10_code"] == "E11.9"
+    assert create_res.json()["status"] == "active"
+
+    update_data = {
+        "condition_name": "Updated Condition",
+        "status": "resolved",
+        "icd10_code": "Z00.0"
+    }
+    update_res = authenticated_client.put(
+        f"/api/v1/family-members/{fm_id}/conditions/{cond_id}",
+        json=update_data
+    )
+    assert update_res.status_code == 200
+    assert update_res.json()["status"] == "resolved"
+    assert update_res.json()["icd10_code"] == "Z00.0"
+    
+    db_condition = db_session.query(FamilyCondition).filter(FamilyCondition.id == cond_id).first()
+    assert db_condition.status == "resolved"
+    assert db_condition.icd10_code == "Z00.0"
+
+    delete_res = authenticated_client.delete(f"/api/v1/family-members/{fm_id}/conditions/{cond_id}")
+    assert delete_res.status_code == 200
+    
+    db_deleted = db_session.query(FamilyCondition).filter(FamilyCondition.id == cond_id).first()
+    assert db_deleted is None


### PR DESCRIPTION
Hello, this is my first PR for the repo, i recently started to use MediKeep and so far i'm liking a lot the app, but i encountered a error when updating the conditions of a family member, so i investigated and came to a functional solution, if there is some change needed or some files are needed to be removed you can guide me

## DESCRIPTION

This PR addresses issues that were causing errors when saving and updating family member conditions. Additionally, ICD-10 codes and status were not being properly reflected or updated by the frontend, leading to inconsistencies between the user interface and the backend data.

- **Summary of changes:**
  - Fixed 404 error when updating/deleting family conditions (removed redundant `patient_id` check).
  - Fixed ICD-10 code and Status persistence (adjusted frontend submission and backend schemas).
  - Fixed ActivityLog saving failure ([corrected column mapping: `metadata` → `event_metadata`](https://github.com/KiwiDev808/MediKeep/blob/a093d9d61e629bcf0235c808ed789585364e659a/app/crud/activity_log.py#L402)) as per [ActivtyLog model](https://github.com/KiwiDev808/MediKeep/blob/981e3cbed2cd0dac48c56e729334b5f1f4990f55/app/models/activity_log.py#L42-L44) .
  - Added Status and ICD-10 visualization to FamilyHistoryViewModal.

## SCREENSHOT

Error when trying to update a existing condition in a family member

<img width="1914" height="957" alt="Captura de tela de 2026-02-16 22-17-11" src="https://github.com/user-attachments/assets/b74128de-5987-42b2-b582-59e978f4b0fb" />
<img width="1914" height="960" alt="Captura de tela de 2026-02-16 22-17-02" src="https://github.com/user-attachments/assets/0c90f227-8dc4-4725-ad8d-e78a2048fa55" />
<img width="1919" height="962" alt="Captura de tela de 2026-02-16 22-16-51" src="https://github.com/user-attachments/assets/ea57aadd-7552-4ecb-a79b-e6dc11c4a2e6" />
<img width="1918" height="955" alt="Captura de tela de 2026-02-16 22-16-38" src="https://github.com/user-attachments/assets/6887ba44-e043-4b1a-a28e-c1964346be4d" />
<img width="1919" height="966" alt="Captura de tela de 2026-02-16 22-16-28" src="https://github.com/user-attachments/assets/f28856f2-7c12-4c9a-b70f-3217ba6d729d" />

New badges for family member condition status and ICD-10 type

<img width="600" height="213" alt="image" src="https://github.com/user-attachments/assets/3a64519c-792d-471c-9d34-49b949e4252b" />


## ISSUES

Issue #520 
