### PR TITLE
feat: add action buttons to ResponsiveTable component

### DIFF
--- a/frontend/src/__tests__/responsive/ResponsiveTable.test.jsx
+++ b/frontend/src/__tests__/responsive/ResponsiveTable.test.jsx
@@ -831,6 +831,58 @@ describe('ResponsiveTable Component Tests', () => {
       expect(screen.queryAllByRole('button', { name: /edit/i })).toHaveLength(0);
       expect(screen.queryAllByRole('button', { name: /delete/i })).toHaveLength(0);
     });
+
+    it('renders action buttons in mobile card view', () => {
+      useResponsive.mockReturnValue({
+        breakpoint: 'xs',
+        deviceType: 'mobile',
+        isMobile: true,
+        isTablet: false,
+        isDesktop: false,
+        width: 375,
+        height: 667,
+      });
+
+      renderResponsive(<ResponsiveTable {...actionProps} />, {
+        viewport: TEST_VIEWPORTS.mobile,
+      });
+
+      const viewButtons = screen.getAllByRole('button', { name: /view/i });
+      const editButtons = screen.getAllByRole('button', { name: /edit/i });
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+
+      expect(viewButtons).toHaveLength(sampleMedicationData.length);
+      expect(editButtons).toHaveLength(sampleMedicationData.length);
+      expect(deleteButtons).toHaveLength(sampleMedicationData.length);
+    });
+
+    it('mobile action button click does not trigger row click', async () => {
+      const user = userEvent.setup();
+      const mockRowClick = vi.fn();
+
+      useResponsive.mockReturnValue({
+        breakpoint: 'xs',
+        deviceType: 'mobile',
+        isMobile: true,
+        isTablet: false,
+        isDesktop: false,
+        width: 375,
+        height: 667,
+      });
+
+      renderResponsive(
+        <ResponsiveTable {...actionProps} onRowClick={mockRowClick} />,
+        { viewport: TEST_VIEWPORTS.mobile }
+      );
+
+      const viewButtons = screen.getAllByRole('button', { name: /view/i });
+      await user.click(viewButtons[0]);
+
+      await waitFor(() => {
+        expect(actionProps.onView).toHaveBeenCalled();
+        expect(mockRowClick).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('Sort Persistence (persistKey)', () => {

--- a/frontend/src/components/adapters/ResponsiveTable.jsx
+++ b/frontend/src/components/adapters/ResponsiveTable.jsx
@@ -345,7 +345,7 @@ export const ResponsiveTable = memo(({
             <IconEdit size={iconSize} />
           </ActionIcon>
         )}
-        {onDelete && (
+        {onDelete && row.id != null && (
           <ActionIcon
             variant="subtle"
             color="red"

--- a/frontend/src/pages/medical/FamilyHistory.jsx
+++ b/frontend/src/pages/medical/FamilyHistory.jsx
@@ -1218,7 +1218,7 @@ const FamilyHistory = () => {
                 patientData={currentPatient}
                 tableName={t('familyHistory.sharedTableName', 'Shared Family History')}
                 onView={row => handleViewFamilyMember({ id: row.familyMemberId })}
-                onEdit={row => {
+                onEdit={_row => {
                   notifications.show({
                     title: t('familyHistory.notifications.cannotEdit', 'Cannot Edit'),
                     message: t('familyHistory.notifications.cannotEditShared', 'You cannot edit shared family history records'),


### PR DESCRIPTION
This pull request adds support for action buttons (View, Edit, Delete) to the `ResponsiveTable` component, allowing row-level actions and improving accessibility and internationalization. It also introduces comprehensive tests for these new features and updates the usage of `onDelete` in the `FamilyHistory` page to match the new API.

**ResponsiveTable Component Enhancements:**

* Added `onView`, `onEdit`, and `onDelete` props to `ResponsiveTable`, enabling action buttons for each row. The table now conditionally renders an "Actions" column and buttons based on provided callbacks, with proper accessibility and internationalization support using `react-i18next`. [[1]](diffhunk://#diff-bfa60e5e708a7ff3b308bca1ce8d0f4fdae7180bcc476ffd7aa63ac28d8fae0eR76-R78) [[2]](diffhunk://#diff-bfa60e5e708a7ff3b308bca1ce8d0f4fdae7180bcc476ffd7aa63ac28d8fae0eR119-R120) [[3]](diffhunk://#diff-bfa60e5e708a7ff3b308bca1ce8d0f4fdae7180bcc476ffd7aa63ac28d8fae0eR313-R362) [[4]](diffhunk://#diff-bfa60e5e708a7ff3b308bca1ce8d0f4fdae7180bcc476ffd7aa63ac28d8fae0eR409-R419)
* Updated header, row, card, loading, and accessibility logic to include the Actions column and action buttons when callbacks are present. [[1]](diffhunk://#diff-bfa60e5e708a7ff3b308bca1ce8d0f4fdae7180bcc476ffd7aa63ac28d8fae0eR472-R482) [[2]](diffhunk://#diff-bfa60e5e708a7ff3b308bca1ce8d0f4fdae7180bcc476ffd7aa63ac28d8fae0eR547-R559) [[3]](diffhunk://#diff-bfa60e5e708a7ff3b308bca1ce8d0f4fdae7180bcc476ffd7aa63ac28d8fae0eR588-R592) [[4]](diffhunk://#diff-bfa60e5e708a7ff3b308bca1ce8d0f4fdae7180bcc476ffd7aa63ac28d8fae0eR603-R613) [[5]](diffhunk://#diff-bfa60e5e708a7ff3b308bca1ce8d0f4fdae7180bcc476ffd7aa63ac28d8fae0eL583-R669)
* Imported new icons (`IconEye`, `IconEdit`, `IconTrash`) for action buttons.

**Testing Improvements:**

* Added a new test suite for Action Buttons in `ResponsiveTable.test.jsx`, covering rendering, callback invocation, and interaction behavior.

**FamilyHistory Page Updates:**

* Refactored the `onDelete` handler in `FamilyHistory.jsx` to accept a row ID instead of a row object, aligning with the new `ResponsiveTable` API.
* Updated the shared record deletion handler to match the new signature.