### PR TITLE
refactor: move get_db() to database.py, use explicit .env path

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,4 +1,4 @@
-from typing import Generator, Optional, NamedTuple
+from typing import Optional, NamedTuple
 
 from fastapi import Depends, Query, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -6,7 +6,7 @@ from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.core.database.database import SessionLocal
+from app.core.database.database import get_db, SessionLocal
 from app.core.logging.config import get_logger, log_security_event
 from app.core.http.error_handling import (
     MedicalRecordsAPIException,
@@ -36,20 +36,6 @@ class TokenValidationResult(NamedTuple):
     """Result of JWT token validation containing decoded payload and username."""
     payload: dict
     username: str
-
-
-def get_db() -> Generator:
-    """
-    Get database session.
-
-    Creates a database session for each request and closes it when done.
-    This is the standard FastAPI database dependency pattern.
-    """
-    try:
-        db = SessionLocal()
-        yield db
-    finally:
-        db.close()
 
 
 def _validate_and_decode_token(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -10,7 +10,9 @@ from dotenv import load_dotenv
 from app.core.secrets import get_secret
 
 # Load environment variables from .env file
-load_dotenv()
+# Use explicit path so this works regardless of working directory
+_env_path = Path(__file__).parents[2] / ".env"
+load_dotenv(dotenv_path=_env_path)
 
 
 def _get_windows_path_helper(path_type: str):


### PR DESCRIPTION
## Summary

- Remove duplicate `get_db()` from `app/api/deps.py`; it already exists in `app/core/database/database.py`, so `deps.py` now re-exports it from there instead of defining it locally.
- Use an explicit path when calling `load_dotenv()` in `app/core/config.py` so config loading works correctly regardless of the process working directory (e.g. when running tests from a subdirectory).

These changes were originally bundled into the Medication↔Condition linkage PR (#529) but are unrelated to that feature and were requested to be split out by the reviewer.

## Test plan

- [x] Existing backend tests pass (`pytest`)
- [x] Application starts correctly and can connect to the database
- [x] Config loads correctly when the process is started from different working directories
