### PR TITLE
fix: add dataKey to YAxis in TestComponentTrendChart for improved chart rendering

### DIFF
--- a/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
@@ -94,6 +94,7 @@ const QualitativeChart: React.FC<{ trendData: TrendResponse }> = ({ trendData })
               allowDuplicatedCategory={false}
             />
             <YAxis
+              dataKey="value"
               type="number"
               domain={[-0.5, 1.5]}
               ticks={[0, 1]}


### PR DESCRIPTION
This pull request makes a small change to the `QualitativeChart` component in `TestComponentTrendChart.tsx`, improving how the Y-axis is defined for qualitative trend charts.

* Added the `dataKey="value"` prop to the `YAxis` component to explicitly specify which data field should be used for the Y-axis values.