### PR TITLE
feat: Add bandit SAST, pip-audit dependency scanning, and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,97 @@
+name: Security Checks
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: '3.12'
+
+jobs:
+  bandit:
+    name: Bandit SAST
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install bandit
+        run: pip install "bandit[toml,sarif]"
+      - name: Run bandit (SARIF for Security tab)
+        run: bandit -c pyproject.toml -r app/ -f sarif -o bandit-results.sarif --exit-zero
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: bandit-results.sarif
+          category: bandit
+      - name: Run bandit (blocking - MEDIUM+ severity/confidence)
+        run: bandit -c pyproject.toml -r app/ -ll -ii -f txt
+        # -ll: MEDIUM+ severity, -ii: MEDIUM+ confidence
+        # Lower-severity findings are still captured in SARIF above
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-report
+          path: bandit-results.sarif
+          retention-days: 30
+
+  pip-audit:
+    name: pip-audit Dependency Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install pip-audit
+        run: pip install pip-audit
+      - name: Run pip-audit (JSON report)
+        run: pip-audit -r requirements.txt -f json -o pip-audit-report.json --progress-spinner off || true
+      - name: Run pip-audit (blocking)
+        run: >-
+          pip-audit -r requirements.txt --progress-spinner off
+          --ignore-vuln CVE-2025-53643
+          --ignore-vuln CVE-2025-69223
+          --ignore-vuln CVE-2025-69224
+          --ignore-vuln CVE-2025-69225
+          --ignore-vuln CVE-2025-69226
+          --ignore-vuln CVE-2025-69227
+          --ignore-vuln CVE-2025-69228
+          --ignore-vuln CVE-2025-69229
+          --ignore-vuln CVE-2025-69230
+          --ignore-vuln CVE-2026-26007
+          --ignore-vuln CVE-2024-23342
+          --ignore-vuln CVE-2025-54121
+          --ignore-vuln CVE-2025-62727
+          --ignore-vuln CVE-2026-25990
+          --ignore-vuln CVE-2024-47081
+          --ignore-vuln CVE-2026-21441
+          --ignore-vuln CVE-2025-64512
+          --ignore-vuln CVE-2025-70559
+        # Pre-existing CVEs in pinned dependencies. Remove ignores as packages are upgraded:
+        #   aiohttp 3.12.12 -> 3.12.14+ (9 CVEs)
+        #   cryptography 45.0.3 -> 46.0.5+ (1 CVE)
+        #   ecdsa 0.19.1 - no fix available (1 CVE)
+        #   starlette 0.46.2 -> 0.47.2+ (2 CVEs, tied to FastAPI version)
+        #   pillow 11.3.0 -> 12.1.1+ (1 CVE)
+        #   requests 2.32.3 -> 2.32.4+ (1 CVE)
+        #   urllib3 2.6.0 -> 2.6.3+ (1 CVE)
+        #   pdfminer-six 20221105 -> 20251107+ (2 CVEs)
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-report
+          path: pip-audit-report.json
+          retention-days: 30

--- a/app/services/restore_service.py
+++ b/app/services/restore_service.py
@@ -655,7 +655,7 @@ class RestoreService:
                 "no-new-privileges",  # Security: prevent privilege escalation
                 "--read-only",  # Security: read-only container
                 "--tmpfs",
-                "/tmp:noexec,nosuid,size=100m",  # Secure temp space
+                "/tmp:noexec,nosuid,size=100m",  # nosec B108
                 "-v",
                 f"{temp_dir}:/backup:ro",  # Read-only mount
                 "-e",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.bandit]
+exclude_dirs = ["tests", ".venv", "node_modules", "frontend", "dist", "build", "alembic"]
+skips = [
+    "B101",  # assert usage - acceptable in application code
+    "B110",  # try/except/pass - common Python pattern
+    "B112",  # try/except/continue - common Python pattern
+    "B404",  # subprocess import - flagging imports alone is not actionable
+]
+# Note: Scan targets (app/) must be passed via CLI, not config
+# Note: Blocking CI uses -ll -ii (MEDIUM+ severity/confidence); SARIF captures all remaining findings


### PR DESCRIPTION
This pull request introduces improvements to automated dependency management and security checks in the project. It adds configuration for Dependabot to keep dependencies up-to-date and sets up GitHub Actions workflows for security scanning of Python code and dependencies. Additionally, it configures Bandit static analysis and updates a comment in the restore service for clarity.

Automated dependency management:

* Added `.github/dependabot.yml` to enable weekly dependency updates for Python (`pip`), JavaScript (`npm`), and monthly updates for GitHub Actions, with grouping for minor and patch updates and relevant labels.

Security checks and static analysis:

* Added `.github/workflows/security.yml` workflow to run Bandit static analysis and pip-audit dependency vulnerability scans on push and pull requests to `main` and `develop` branches. Reports are uploaded as artifacts and to GitHub's Security tab; specific CVEs are ignored due to pinned dependencies.
* Added Bandit configuration in `pyproject.toml` to exclude non-app directories and skip select findings that are acceptable in the codebase.

Code comments:

* Updated a comment in `_restore_with_docker_psql` in `app/services/restore_service.py` to clarify the Bandit ignore annotation for the secure temp space mount.