### PR TITLE
Update admin header navigation

### DIFF
--- a/frontend/src/components/admin/AdminHeader.jsx
+++ b/frontend/src/components/admin/AdminHeader.jsx
@@ -16,7 +16,6 @@ import {
   IconMenu2,
   IconSearch,
   IconArrowLeft,
-  IconHome,
   IconUser,
   IconMoon,
   IconSun,
@@ -93,29 +92,17 @@ const AdminHeader = ({ user, onLogout, onToggleSidebar }) => {
         </Box>
 
         <Group gap="sm" wrap="nowrap" style={{ flexShrink: 0 }}>
-          <Tooltip label="Return to Admin Dashboard">
+          <Tooltip label="Return to Dashboard">
             <Button
               variant="default"
               size="compact-sm"
               leftSection={<IconArrowLeft size={14} />}
-              onClick={() => navigate('/admin')}
-              title="Return to Admin Dashboard"
+              onClick={() => navigate('/dashboard')}
+              title="Return to Dashboard"
               visibleFrom="md"
             >
               Dashboard
             </Button>
-          </Tooltip>
-
-          <Tooltip label="Return to Normal Dashboard">
-            <ActionIcon
-              variant="light"
-              color="blue"
-              size="lg"
-              onClick={() => navigate('/dashboard')}
-              title="Return to Normal Dashboard"
-            >
-              <IconHome size={18} />
-            </ActionIcon>
           </Tooltip>
 
           <Group

--- a/frontend/src/components/admin/__tests__/AdminHeader.test.jsx
+++ b/frontend/src/components/admin/__tests__/AdminHeader.test.jsx
@@ -43,20 +43,10 @@ describe('AdminHeader', () => {
     expect(screen.getByText('Medical Records Admin')).toBeInTheDocument();
   });
 
-  test('Dashboard button calls navigate with /admin', () => {
-    renderAdminHeader();
-
-    const dashboardBtn = screen.getByTitle('Return to Admin Dashboard');
-    fireEvent.click(dashboardBtn);
-
-    expect(mockNavigate).toHaveBeenCalledWith('/admin');
-    expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining('http'));
-  });
-
   test('Home button calls navigate with /dashboard', () => {
     renderAdminHeader();
 
-    const homeBtn = screen.getByTitle('Return to Normal Dashboard');
+    const homeBtn = screen.getByTitle('Return to Dashboard');
     fireEvent.click(homeBtn);
 
     expect(mockNavigate).toHaveBeenCalledWith('/dashboard');


### PR DESCRIPTION
Update the admin header navigation so that:
* "Dashboard" button is removed, it duplicated functionality with left pane "Overview" option.
* Updated small icon that returns to main app dashboard with a larger "Dashboard" button