### PR TITLE
fix:  regex patterns and tests for lab results parsing

### DIFF
--- a/frontend/src/components/medical/labresults/TestComponentBulkEntry.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentBulkEntry.tsx
@@ -95,7 +95,7 @@ export const REGEX_PATTERNS = {
   FULL_PATTERN: new RegExp(
     String.raw`^${TEST_NAME}:${ZERO_OR_MORE_SPACES}${NUMERIC_VALUE}${ZERO_OR_MORE_SPACES}(${UNIT_PATTERN})?${ZERO_OR_MORE_SPACES}` +
     String.raw`(?:\((?:.*?range.*?:${ZERO_OR_MORE_SPACES})?${NUMERIC_VALUE}${ZERO_OR_MORE_SPACES}${RANGE_SEPARATOR}${ZERO_OR_MORE_SPACES}${NUMERIC_VALUE}.*?\)|` +
-    String.raw`\((${COMPARISON_OP}${ZERO_OR_MORE_SPACES}[0-9.,]+)\)|` +
+    String.raw`\((?:.*?range.*?:${ZERO_OR_MORE_SPACES})?(${COMPARISON_OP}${ZERO_OR_MORE_SPACES}[0-9.,]+)\)|` +
     String.raw`\(Not\s+Estab\.?\)|` +
     String.raw`(\([^)]*\)))?`,
     'i'
@@ -118,7 +118,10 @@ export const REGEX_PATTERNS = {
   // Pattern 4: CSV-like "Test,Value,Unit,Range,Status"
   CSV_PATTERN: new RegExp(
     String.raw`^${TEST_NAME}[,\t]+${NUMERIC_VALUE}[,\t]+(${UNIT_PATTERN})` +
-    String.raw`(?:[,\t]+([^,\t]*?))?(?:[,\t]+([^,\t]*?))?$`,
+    String.raw`(?:[,\t]+${NUMERIC_VALUE}${ZERO_OR_MORE_SPACES}${RANGE_SEPARATOR}${ZERO_OR_MORE_SPACES}${NUMERIC_VALUE}` +
+    String.raw`|[,\t]+(${COMPARISON_OP}${ZERO_OR_MORE_SPACES}[0-9.,]+)` +
+    String.raw`|[,\t]+([^,\t]*?))?` +
+    String.raw`(?:[,\t]+${STATUS_VALUES})?$`,
     'i'
   )
 };
@@ -1436,14 +1439,24 @@ SARS-CoV-2: Not Detected`
               >
                 Clear All
               </Button>
-              <Button
-                onClick={handleSubmit}
-                disabled={isSubmitting || validComponents.length === 0}
-                loading={isSubmitting}
-                leftSection={<IconCheck size={16} />}
-              >
-                Add {validComponents.length} Component{validComponents.length !== 1 ? 's' : ''}
-              </Button>
+              {activeTab !== 'preview' ? (
+                <Button
+                  onClick={() => setActiveTab('preview')}
+                  disabled={validComponents.length === 0}
+                  leftSection={<IconTable size={16} />}
+                >
+                  Preview {validComponents.length} Component{validComponents.length !== 1 ? 's' : ''}
+                </Button>
+              ) : (
+                <Button
+                  onClick={handleSubmit}
+                  disabled={isSubmitting || validComponents.length === 0}
+                  loading={isSubmitting}
+                  leftSection={<IconCheck size={16} />}
+                >
+                  Add {validComponents.length} Component{validComponents.length !== 1 ? 's' : ''}
+                </Button>
+              )}
             </Group>
     </Box>
   );

--- a/frontend/src/components/medical/labresults/__tests__/TestComponentBulkEntry.test.tsx
+++ b/frontend/src/components/medical/labresults/__tests__/TestComponentBulkEntry.test.tsx
@@ -233,6 +233,88 @@ describe('TestComponentBulkEntry Parser', () => {
       expect(result!.ref_range_max).toBe(1.0);
       expect(result!.status).toBe('high');
     });
+
+    it('should parse "Normal range:" prefix with less-than comparison', () => {
+      const result = parseLine('Cholesterol: 195 mg/dL (Normal range: <200)');
+      expect(result).not.toBeNull();
+      expect(result!.ref_range_text).toBe('<200');
+      expect(result!.ref_range_max).toBe(200);
+      expect(result!.ref_range_min).toBeNull();
+      expect(result!.status).toBe('normal');
+    });
+
+    it('should parse "Normal range:" prefix with greater-than comparison', () => {
+      const result = parseLine('HDL: 45 mg/dL (Normal range: >40)');
+      expect(result).not.toBeNull();
+      expect(result!.ref_range_text).toBe('>40');
+      expect(result!.ref_range_min).toBe(40);
+      expect(result!.ref_range_max).toBeNull();
+      expect(result!.status).toBe('normal');
+    });
+  });
+
+  describe('CSV_PATTERN: reference range parsing', () => {
+    it('should parse numeric range from CSV format', () => {
+      const result = parseLine('Glucose,125,mg/dL,70-100,Normal');
+      expect(result).not.toBeNull();
+      expect(result!.patternName).toBe('CSV_PATTERN');
+      expect(result!.test_name).toBe('Glucose');
+      expect(result!.value).toBe(125);
+      expect(result!.unit).toBe('mg/dL');
+      expect(result!.ref_range_min).toBe(70);
+      expect(result!.ref_range_max).toBe(100);
+    });
+
+    it('should parse BUN with numeric range', () => {
+      const result = parseLine('BUN,18,mg/dL,7-20,Normal');
+      expect(result).not.toBeNull();
+      expect(result!.ref_range_min).toBe(7);
+      expect(result!.ref_range_max).toBe(20);
+      expect(result!.status).toBe('normal');
+    });
+
+    it('should auto-calculate high status from CSV range', () => {
+      const result = parseLine('Glucose,125,mg/dL,70-100');
+      expect(result).not.toBeNull();
+      expect(result!.ref_range_min).toBe(70);
+      expect(result!.ref_range_max).toBe(100);
+      expect(result!.status).toBe('high');
+    });
+
+    it('should parse comparison operator range from CSV', () => {
+      const result = parseLine('Cholesterol,195,mg/dL,<200,Normal');
+      expect(result).not.toBeNull();
+      expect(result!.ref_range_text).toBe('<200');
+      expect(result!.ref_range_max).toBe(200);
+      expect(result!.ref_range_min).toBeNull();
+      expect(result!.status).toBe('normal');
+    });
+
+    it('should parse greater-than comparison from CSV', () => {
+      const result = parseLine('HDL,55,mg/dL,>40');
+      expect(result).not.toBeNull();
+      expect(result!.ref_range_text).toBe('>40');
+      expect(result!.ref_range_min).toBe(40);
+      expect(result!.ref_range_max).toBeNull();
+      expect(result!.status).toBe('normal');
+    });
+
+    it('should handle CSV with no range column', () => {
+      const result = parseLine('BUN,18,mg/dL');
+      expect(result).not.toBeNull();
+      expect(result!.test_name).toBe('BUN');
+      expect(result!.value).toBe(18);
+      expect(result!.unit).toBe('mg/dL');
+      expect(result!.ref_range_min).toBeNull();
+      expect(result!.ref_range_max).toBeNull();
+    });
+
+    it('should handle tab-separated CSV format', () => {
+      const result = parseLine('WBC\t7.5\tK/uL\t4.5-11.0\tNormal');
+      expect(result).not.toBeNull();
+      expect(result!.ref_range_min).toBe(4.5);
+      expect(result!.ref_range_max).toBe(11.0);
+    });
   });
 
   describe('Auto-status calculation edge cases', () => {


### PR DESCRIPTION
This pull request improves the parsing and user experience of the lab results bulk entry component, focusing on enhanced support for different reference range formats and better UI feedback. The changes expand the ability to parse comparison operator ranges (like `<200` or `>40`) in both standard and CSV formats, and add tests to ensure correct behavior. Additionally, the UI now includes a "Preview" button for valid components before submission.

**Parsing improvements:**

* Enhanced the `FULL_PATTERN` regex to support parsing reference ranges with prefixes like "Normal range:" followed by comparison operators (e.g., `<200`, `>40`).
* Updated the `CSV_PATTERN` regex to allow parsing of comparison operator ranges in CSV-like formats, in addition to numeric ranges.

**Testing:**

* Added comprehensive tests for parsing comparison operator ranges and numeric ranges in both standard and CSV formats, including edge cases for status calculation and tab-separated input.

**User interface:**

* Added a "Preview" button that allows users to preview valid components before submitting, improving workflow and feedback. The button is only enabled if there are valid components to preview. [[1]](diffhunk://#diff-cec0081561483500a26a697d74a34b3a1fbe19c3fc0909e5138d2a62ce197e47R1442-R1450) [[2]](diffhunk://#diff-cec0081561483500a26a697d74a34b3a1fbe19c3fc0909e5138d2a62ce197e47R1459)