### PR TITLE
fix correct date input formatting across medical forms

### DIFF
--- a/frontend/src/components/medical/BaseMedicalForm.jsx
+++ b/frontend/src/components/medical/BaseMedicalForm.jsx
@@ -28,6 +28,7 @@ import { MedicalFormLayoutStrategy } from '../../strategies/MedicalFormLayoutStr
 import { TagInput } from '../common/TagInput';
 import { translateField } from '../../utils/translateField';
 import logger from '../../services/logger';
+import { useDateFormat } from '../../hooks/useDateFormat';
 
 // Initialize medical form layout strategy
 const medicalFormStrategy = new MedicalFormLayoutStrategy();
@@ -96,6 +97,8 @@ const BaseMedicalForm = ({
 
   // Translation hooks
   const { t } = useTranslation(['medical', 'common']);
+
+  const { dateInputFormat } = useDateFormat();
 
   const {
     handleTextInputChange,
@@ -278,6 +281,8 @@ const BaseMedicalForm = ({
         {...baseProps}
         value={dateValue}
         onChange={handleDateChange(name)}
+        valueFormat={dateInputFormat}
+        placeholder={dateInputFormat}
         firstDayOfWeek={0}
         clearable
         maxDate={dynamicMaxDate}
@@ -285,7 +290,7 @@ const BaseMedicalForm = ({
         popoverProps={{ withinPortal: true, zIndex: 3000 }}
       />
     );
-  }, [handleDateChange, formData]);
+  }, [handleDateChange, formData, dateInputFormat]);
 
   // Callback for time input fields
   const renderTimeField = useCallback((fieldConfig, baseProps) => {

--- a/frontend/src/components/medical/DataExport.jsx
+++ b/frontend/src/components/medical/DataExport.jsx
@@ -25,8 +25,11 @@ import {
   IconDatabase,
 } from '@tabler/icons-react';
 import { exportService } from '../../services/exportService';
+import { useDateFormat } from '../../hooks/useDateFormat';
 
 const DataExport = () => {
+  const { dateInputFormat } = useDateFormat();
+
   const [loading, setLoading] = useState(false);
   const [summary, setSummary] = useState(null);
   const [formats, setFormats] = useState([]);
@@ -290,7 +293,8 @@ const DataExport = () => {
                 <DateInput
                   value={startDate}
                   onChange={setStartDate}
-                  placeholder="Filter from date"
+                  placeholder={dateInputFormat}
+                  valueFormat={dateInputFormat}
                   clearable
                 />
               </Grid.Col>
@@ -301,7 +305,8 @@ const DataExport = () => {
                 <DateInput
                   value={endDate}
                   onChange={setEndDate}
-                  placeholder="Filter to date"
+                  placeholder={dateInputFormat}
+                  valueFormat={dateInputFormat}
                   clearable
                 />
               </Grid.Col>

--- a/frontend/src/components/medical/MantineMedicationForm.jsx
+++ b/frontend/src/components/medical/MantineMedicationForm.jsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { medicationFormFields } from '../../utils/medicalFormFields';
 import { useFormHandlers } from '../../hooks/useFormHandlers';
 import { formatDateInputChange, parseDateInput } from '../../utils/dateUtils';
+import { useDateFormat } from '../../hooks/useDateFormat';
 import FormLoadingOverlay from '../shared/FormLoadingOverlay';
 import DocumentManagerWithProgress from '../shared/DocumentManagerWithProgress';
 import { TagInput } from '../common/TagInput';
@@ -47,6 +48,7 @@ const MantineMedicationForm = ({
 }) => {
   // Translation
   const { t } = useTranslation(['medical', 'common']);
+  const { dateInputFormat } = useDateFormat();
 
   // Tab state management
   const [activeTab, setActiveTab] = useState('basic');
@@ -159,12 +161,13 @@ const MantineMedicationForm = ({
         return (
           <DateInput
             {...commonProps}
+            placeholder={dateInputFormat}
             value={parseDateInput(formData[field.name])}
             onChange={(date) => {
               const formattedDate = formatDateInputChange(date);
               onInputChange({ target: { name: field.name, value: formattedDate } });
             }}
-            valueFormat="YYYY-MM-DD"
+            valueFormat={dateInputFormat}
             popoverProps={{ withinPortal: true, zIndex: 3000 }}
           />
         );

--- a/frontend/src/components/medical/MantinePatientForm.jsx
+++ b/frontend/src/components/medical/MantinePatientForm.jsx
@@ -17,6 +17,7 @@ import { IconUser, IconStethoscope, IconHome, IconCheck, IconX } from '@tabler/i
 import { useTranslation } from 'react-i18next';
 import { useFormHandlers } from '../../hooks/useFormHandlers';
 import { useUserPreferences } from '../../contexts/UserPreferencesContext';
+import { useDateFormat } from '../../hooks/useDateFormat';
 import {
   unitLabels,
   validationRanges,
@@ -39,6 +40,7 @@ const MantinePatientForm = ({
   onPhotoChange, // New callback for photo changes
 }) => {
   const { unitSystem } = useUserPreferences();
+  const { dateInputFormat } = useDateFormat();
 
   // Photo state
   const [photoUrl, setPhotoUrl] = useState(null);
@@ -206,7 +208,7 @@ const MantinePatientForm = ({
             <Grid.Col span={{ base: 12, sm: 6 }}>
               <DateInput
                 label={t('patients.form.birthDate.label')}
-                placeholder={t('patients.form.birthDate.placeholder')}
+                placeholder={dateInputFormat}
                 value={
                   formData.birth_date
                     ? (() => {
@@ -227,6 +229,7 @@ const MantinePatientForm = ({
                     : null
                 }
                 onChange={handleDateChange('birth_date')}
+                valueFormat={dateInputFormat}
                 firstDayOfWeek={0}
                 required
                 withAsterisk

--- a/frontend/src/components/medical/MantineVisitForm.jsx
+++ b/frontend/src/components/medical/MantineVisitForm.jsx
@@ -26,6 +26,7 @@ import { visitFormFields } from '../../utils/medicalFormFields';
 import { useFormHandlers } from '../../hooks/useFormHandlers';
 import { formatDateInputChange, parseDateInput } from '../../utils/dateUtils';
 import { translateField } from '../../utils/translateField';
+import { useDateFormat } from '../../hooks/useDateFormat';
 import FormLoadingOverlay from '../shared/FormLoadingOverlay';
 import DocumentManagerWithProgress from '../shared/DocumentManagerWithProgress';
 import { TagInput } from '../common/TagInput';
@@ -48,6 +49,7 @@ const MantineVisitForm = ({
 }) => {
   // Translation hooks - medical for field translations, common for UI elements
   const { t } = useTranslation(['medical', 'common']);
+  const { dateInputFormat } = useDateFormat();
 
   // Tab state management
   const [activeTab, setActiveTab] = useState('info');
@@ -150,12 +152,13 @@ const MantineVisitForm = ({
         return (
           <DateInput
             {...commonProps}
+            placeholder={dateInputFormat}
             value={parseDateInput(formData[translatedField.name])}
             onChange={(date) => {
               const formattedDate = formatDateInputChange(date);
               onInputChange({ target: { name: translatedField.name, value: formattedDate } });
             }}
-            valueFormat="YYYY-MM-DD"
+            valueFormat={dateInputFormat}
             maxDate={translatedField.maxDate && typeof translatedField.maxDate === 'function' ? translatedField.maxDate() : translatedField.maxDate}
             popoverProps={{ withinPortal: true, zIndex: 3000 }}
           />

--- a/frontend/src/components/medical/VitalsForm.jsx
+++ b/frontend/src/components/medical/VitalsForm.jsx
@@ -79,7 +79,7 @@ const VitalsForm = ({
   const { isReady, getCurrentTime, timezone } = useTimezone();
   const { patient: currentPatient } = useCurrentPatient();
   const { unitSystem, loading: preferencesLoading } = useUserPreferences();
-  const { formatDateTimeInput, dateFormat, dateTimePlaceholder } = useDateFormat();
+  const { formatDateTimeInput, dateFormat, dateTimePlaceholder, dateInputFormat } = useDateFormat();
 
   // Generate dynamic configs based on user's unit system
   const FORM_FIELDS = useMemo(() => ({
@@ -669,9 +669,10 @@ const VitalsForm = ({
         <DateInput
           key={fieldName}
           label={config.label}
-          placeholder={t('vitals.form.selectDate', 'Select date')}
+          placeholder={dateInputFormat}
           value={value}
           onChange={val => handleInputChange(fieldName, val)}
+          valueFormat={dateInputFormat}
           leftSection={<IconComponent size={16} />}
           required={config.required}
           error={error}

--- a/frontend/src/components/medical/allergies/AllergyFormWrapper.jsx
+++ b/frontend/src/components/medical/allergies/AllergyFormWrapper.jsx
@@ -20,6 +20,7 @@ import {
   IconNotes,
 } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
 import SubmitButton from '../../shared/SubmitButton';
 import { useFormHandlers } from '../../../hooks/useFormHandlers';
@@ -42,6 +43,7 @@ const AllergyFormWrapper = ({
 }) => {
   // Translation hooks
   const { t } = useTranslation(['medical', 'common']);
+  const { dateInputFormat } = useDateFormat();
 
   // Tab state management
   const [activeTab, setActiveTab] = useState('basic');
@@ -199,7 +201,8 @@ const AllergyFormWrapper = ({
                         const formattedDate = formatDateInputChange(date);
                         onInputChange({ target: { name: 'onset_date', value: formattedDate } });
                       }}
-                      placeholder={t('allergies.onsetDate.placeholder')}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
                       description={t('allergies.onsetDate.description')}
                       clearable
                       firstDayOfWeek={0}

--- a/frontend/src/components/medical/conditions/ConditionFormWrapper.jsx
+++ b/frontend/src/components/medical/conditions/ConditionFormWrapper.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import {
   Modal,
   Tabs,
@@ -48,6 +49,7 @@ const ConditionFormWrapper = ({
   navigate,
 }) => {
   const { t } = useTranslation('common');
+  const { dateInputFormat } = useDateFormat();
 
   // Tab state management
   const [activeTab, setActiveTab] = useState('basic');
@@ -189,7 +191,8 @@ const ConditionFormWrapper = ({
                       label={t('conditions.form.fields.onsetDate', 'Onset Date')}
                       value={parseDateInput(formData.onset_date)}
                       onChange={handleDateChange('onset_date')}
-                      placeholder={t('conditions.form.placeholders.onsetDate', 'Select onset date')}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
                       description={t('conditions.form.descriptions.onsetDate', 'When the condition started')}
                       clearable
                       firstDayOfWeek={0}
@@ -202,7 +205,8 @@ const ConditionFormWrapper = ({
                       label={t('conditions.form.fields.endDate', 'End Date')}
                       value={parseDateInput(formData.end_date)}
                       onChange={handleDateChange('end_date')}
-                      placeholder={t('conditions.form.placeholders.endDate', 'Select end date')}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
                       description={t('conditions.form.descriptions.endDate', 'When the condition ended (if applicable)')}
                       clearable
                       firstDayOfWeek={0}

--- a/frontend/src/components/medical/equipment/EquipmentFormWrapper.jsx
+++ b/frontend/src/components/medical/equipment/EquipmentFormWrapper.jsx
@@ -12,6 +12,7 @@ import {
 } from '@mantine/core';
 import { DateInput } from '@mantine/dates';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
 import SubmitButton from '../../shared/SubmitButton';
 import { useFormHandlers } from '../../../hooks/useFormHandlers';
@@ -35,6 +36,7 @@ const EquipmentFormWrapper = ({
   isLoading = false,
 }) => {
   const { t } = useTranslation('common');
+  const { dateInputFormat } = useDateFormat();
 
   const {
     handleTextInputChange,
@@ -166,7 +168,8 @@ const EquipmentFormWrapper = ({
                   const formattedDate = formatDateInputChange(date);
                   onInputChange({ target: { name: 'prescribed_date', value: formattedDate } });
                 }}
-                placeholder={t('equipment.form.datePlaceholder', 'Select date')}
+                placeholder={dateInputFormat}
+                valueFormat={dateInputFormat}
                 clearable
                 popoverProps={{ withinPortal: true, zIndex: 3000 }}
               />
@@ -179,7 +182,8 @@ const EquipmentFormWrapper = ({
                   const formattedDate = formatDateInputChange(date);
                   onInputChange({ target: { name: 'last_service_date', value: formattedDate } });
                 }}
-                placeholder={t('equipment.form.datePlaceholder', 'Select date')}
+                placeholder={dateInputFormat}
+                valueFormat={dateInputFormat}
                 clearable
                 popoverProps={{ withinPortal: true, zIndex: 3000 }}
               />
@@ -192,7 +196,8 @@ const EquipmentFormWrapper = ({
                   const formattedDate = formatDateInputChange(date);
                   onInputChange({ target: { name: 'next_service_date', value: formattedDate } });
                 }}
-                placeholder={t('equipment.form.datePlaceholder', 'Select date')}
+                placeholder={dateInputFormat}
+                valueFormat={dateInputFormat}
                 clearable
                 minDate={parseDateInput(formData.last_service_date) || undefined}
                 popoverProps={{ withinPortal: true, zIndex: 3000 }}

--- a/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
+++ b/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
@@ -21,6 +21,7 @@ import {
   IconNotes,
 } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
 import SubmitButton from '../../shared/SubmitButton';
 import { useFormHandlers } from '../../../hooks/useFormHandlers';
@@ -42,6 +43,7 @@ const ImmunizationFormWrapper = ({
   statusMessage,
 }) => {
   const { t } = useTranslation('common');
+  const { dateInputFormat } = useDateFormat();
   // Tab state management
   const [activeTab, setActiveTab] = useState('basic');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -195,7 +197,8 @@ const ImmunizationFormWrapper = ({
                         const formattedDate = formatDateInputChange(date);
                         onInputChange({ target: { name: 'expiration_date', value: formattedDate } });
                       }}
-                      placeholder={t('immunizations.form.expirationDatePlaceholder', 'Select expiration date')}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
                       description={t('immunizations.form.expirationDateDesc', 'When the vaccine expires')}
                       clearable
                       firstDayOfWeek={0}
@@ -235,7 +238,8 @@ const ImmunizationFormWrapper = ({
                         const formattedDate = formatDateInputChange(date);
                         onInputChange({ target: { name: 'date_administered', value: formattedDate } });
                       }}
-                      placeholder={t('immunizations.form.dateAdministeredPlaceholder', 'Select administration date')}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
                       description={t('immunizations.form.dateAdministeredDesc', 'When the vaccine was administered')}
                       required
                       clearable

--- a/frontend/src/components/medical/injuries/InjuryFormWrapper.jsx
+++ b/frontend/src/components/medical/injuries/InjuryFormWrapper.jsx
@@ -19,6 +19,7 @@ import {
   IconNotes,
 } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
 import SubmitButton from '../../shared/SubmitButton';
 import { useFormHandlers } from '../../../hooks/useFormHandlers';
@@ -47,6 +48,7 @@ const InjuryFormWrapper = ({
 }) => {
   // Translation hooks
   const { t } = useTranslation(['medical', 'common']);
+  const { dateInputFormat } = useDateFormat();
 
   // Tab state management
   const [activeTab, setActiveTab] = useState('basic');
@@ -211,10 +213,8 @@ const InjuryFormWrapper = ({
                       label={t('injuries.dateOfInjury.label', 'Date of Injury')}
                       value={parseDateInput(formData.date_of_injury)}
                       onChange={handleDateChange('date_of_injury')}
-                      placeholder={t(
-                        'injuries.dateOfInjury.placeholder',
-                        'When the injury occurred'
-                      )}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
                       maxDate={today}
                       clearable
                       firstDayOfWeek={0}

--- a/frontend/src/components/medical/insurance/InsuranceFormWrapper.jsx
+++ b/frontend/src/components/medical/insurance/InsuranceFormWrapper.jsx
@@ -28,6 +28,7 @@ import { getFormFields } from '../../../utils/medicalFormFields';
 import { isValidPhoneNumber, isPhoneField } from '../../../utils/phoneUtils';
 import { formatDateInputChange, parseDateInput } from '../../../utils/dateUtils';
 import { useFormHandlers } from '../../../hooks/useFormHandlers';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
 import DocumentManagerWithProgress from '../../shared/DocumentManagerWithProgress';
 import { TagInput } from '../../common/TagInput';
@@ -47,6 +48,7 @@ const InsuranceFormWrapper = ({
   onFileUploadComplete,
 }) => {
   const { t } = useTranslation(['medical', 'common']);
+  const { dateInputFormat } = useDateFormat();
 
   // Get insurance form fields
   const fields = getFormFields('insurance');
@@ -404,12 +406,13 @@ const InsuranceFormWrapper = ({
         return (
           <DateInput
             {...commonProps}
+            placeholder={dateInputFormat}
             value={parseDateInput(formData[field.name])}
             onChange={(date) => {
               const formattedDate = formatDateInputChange(date);
               onInputChange({ target: { name: field.name, value: formattedDate } });
             }}
-            valueFormat="YYYY-MM-DD"
+            valueFormat={dateInputFormat}
             popoverProps={{ withinPortal: true, zIndex: 3000 }}
           />
         );

--- a/frontend/src/components/medical/labresults/TestComponentBulkEntry.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentBulkEntry.tsx
@@ -49,6 +49,7 @@ import { apiService } from '../../../services/api';
 import { searchTests } from '../../../constants/testLibrary';
 import { ComponentCategory, ComponentStatus, getQualitativeDisplayName, getQualitativeColor } from '../../../constants/labCategories';
 import logger from '../../../services/logger';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 
 /**
  * Validates and normalizes a date value from DateInput.
@@ -398,6 +399,8 @@ const TestComponentBulkEntry: React.FC<TestComponentBulkEntryProps> = ({
   onError,
   disabled = false
 }) => {
+  const { dateInputFormat } = useDateFormat();
+
   const [rawText, setRawText] = useState('');
   const [debouncedText] = useDebouncedValue(rawText, 300);
   const [parsedComponents, setParsedComponents] = useState<ParsedTestComponent[]>([]);
@@ -1278,7 +1281,8 @@ SARS-CoV-2: Not Detected`
                         value={completedDate}
                         onChange={setCompletedDate}
                         label="Test Completed Date"
-                        placeholder="Select date"
+                        placeholder={dateInputFormat}
+                        valueFormat={dateInputFormat}
                         clearable
                         required
                         allowDeselect={false}

--- a/frontend/src/components/medical/procedures/ProcedureFormWrapper.jsx
+++ b/frontend/src/components/medical/procedures/ProcedureFormWrapper.jsx
@@ -21,6 +21,7 @@ import {
   IconNotes,
 } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
 import SubmitButton from '../../shared/SubmitButton';
 import { useFormHandlers } from '../../../hooks/useFormHandlers';
@@ -45,6 +46,7 @@ const ProcedureFormWrapper = ({
   onError,
 }) => {
   const { t } = useTranslation('common');
+  const { dateInputFormat } = useDateFormat();
 
   // Tab state management
   const [activeTab, setActiveTab] = useState('basic');
@@ -197,7 +199,8 @@ const ProcedureFormWrapper = ({
                         const formattedDate = formatDateInputChange(date);
                         onInputChange({ target: { name: 'procedure_date', value: formattedDate } });
                       }}
-                      placeholder={t('procedures.form.procedureDatePlaceholder', 'Select procedure date')}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
                       description={t('procedures.form.procedureDateDesc', 'When the procedure is scheduled or was performed')}
                       clearable
                       firstDayOfWeek={0}

--- a/frontend/src/components/medical/treatments/TreatmentEquipmentRelationships.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentEquipmentRelationships.jsx
@@ -33,6 +33,7 @@ import {
 import { apiService } from '../../../services/api';
 import logger from '../../../services/logger';
 import { parseDateInput, formatDateInputChange } from '../../../utils/dateUtils';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import {
   EQUIPMENT_TYPE_OPTIONS,
   EQUIPMENT_STATUS_OPTIONS,
@@ -77,6 +78,7 @@ function TreatmentEquipmentRelationships({
   const safeEquipment = Array.isArray(equipment) ? equipment : [];
   const safePractitioners = Array.isArray(practitioners) ? practitioners : [];
   const { t } = useTranslation(['common', 'errors']);
+  const { dateInputFormat } = useDateFormat();
 
   const [relationships, setRelationships] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -688,12 +690,13 @@ function TreatmentEquipmentRelationships({
                     />
                     <DateInput
                       label="Prescribed Date"
-                      placeholder="Select date"
+                      placeholder={dateInputFormat}
                       value={parseDateInput(newEquipment.prescribed_date)}
                       onChange={(date) => setNewEquipment(prev => ({
                         ...prev,
                         prescribed_date: date,
                       }))}
+                      valueFormat={dateInputFormat}
                       clearable
                       popoverProps={{ withinPortal: true, zIndex: 4000 }}
                     />

--- a/frontend/src/components/medical/treatments/TreatmentFormWrapper.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentFormWrapper.jsx
@@ -28,6 +28,7 @@ import {
   IconDeviceDesktop,
 } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import { notifications } from '@mantine/notifications';
 import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
 import SubmitButton from '../../shared/SubmitButton';
@@ -62,6 +63,7 @@ const TreatmentFormWrapper = ({
   isLoading = false,
 }) => {
   const { t } = useTranslation('common');
+  const { dateInputFormat } = useDateFormat();
 
   // Tab state management
   const [activeTab, setActiveTab] = useState('basic');
@@ -477,7 +479,8 @@ const TreatmentFormWrapper = ({
                         const formattedDate = formatDateInputChange(date);
                         onInputChange({ target: { name: 'start_date', value: formattedDate } });
                       }}
-                      placeholder={t('treatments.form.selectStartDate', 'Select start date')}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
                       description={t('treatments.form.startDateDesc', 'When treatment is planned to begin or began')}
                       clearable
                       firstDayOfWeek={0}
@@ -492,7 +495,8 @@ const TreatmentFormWrapper = ({
                         const formattedDate = formatDateInputChange(date);
                         onInputChange({ target: { name: 'end_date', value: formattedDate } });
                       }}
-                      placeholder={t('treatments.form.selectEndDate', 'Select end date')}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
                       description={t('treatments.form.endDateDesc', 'When treatment ends (if applicable)')}
                       clearable
                       firstDayOfWeek={0}

--- a/frontend/src/components/medical/treatments/TreatmentMedicationRelationships.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentMedicationRelationships.jsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import {
   Badge,
   Group,
@@ -89,6 +90,7 @@ function TreatmentMedicationRelationships({
   onEntityClick,
 }) {
   const { t } = useTranslation('common');
+  const { dateInputFormat } = useDateFormat();
   // Ensure medications is always an array
   const safeMedications = Array.isArray(medications) ? medications : [];
 
@@ -223,17 +225,19 @@ function TreatmentMedicationRelationships({
                         <Group grow gap="xs">
                           <DateInput
                             size="xs"
-                            placeholder="Start date"
+                            placeholder={dateInputFormat}
                             value={parseDateInput(editingRelationship?.specific_start_date)}
                             onChange={(date) => updateEditingRelationship('specific_start_date', formatDateInputChange(date))}
+                            valueFormat={dateInputFormat}
                             clearable
                             popoverProps={{ withinPortal: true, zIndex: 4000 }}
                           />
                           <DateInput
                             size="xs"
-                            placeholder="End date"
+                            placeholder={dateInputFormat}
                             value={parseDateInput(editingRelationship?.specific_end_date)}
                             onChange={(date) => updateEditingRelationship('specific_end_date', formatDateInputChange(date))}
+                            valueFormat={dateInputFormat}
                             clearable
                             popoverProps={{ withinPortal: true, zIndex: 4000 }}
                           />
@@ -369,17 +373,19 @@ function TreatmentMedicationRelationships({
               <Group grow gap="sm">
                 <DateInput
                   label="Treatment Start Date"
-                  placeholder="Override start date"
+                  placeholder={dateInputFormat}
                   value={parseDateInput(newRelationship.specific_start_date)}
                   onChange={(date) => updateNewRelationship('specific_start_date', formatDateInputChange(date))}
+                  valueFormat={dateInputFormat}
                   clearable
                   popoverProps={{ withinPortal: true, zIndex: 4000 }}
                 />
                 <DateInput
                   label="Treatment End Date"
-                  placeholder="Override end date"
+                  placeholder={dateInputFormat}
                   value={parseDateInput(newRelationship.specific_end_date)}
                   onChange={(date) => updateNewRelationship('specific_end_date', formatDateInputChange(date))}
+                  valueFormat={dateInputFormat}
                   clearable
                   popoverProps={{ withinPortal: true, zIndex: 4000 }}
                 />

--- a/frontend/src/components/medical/treatments/TreatmentPlanSetup.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentPlanSetup.jsx
@@ -28,6 +28,7 @@ import { useTranslation } from 'react-i18next';
 import { apiService } from '../../../services/api';
 import logger from '../../../services/logger';
 import { parseDateInput, formatDateInputChange } from '../../../utils/dateUtils';
+import { useDateFormat } from '../../../hooks/useDateFormat';
 import {
   createDateSortedOptions,
   formatDateDisplay,
@@ -96,6 +97,7 @@ const TreatmentPlanSetup = ({
   onRelationshipsChange,
 }) => {
   const { t } = useTranslation('medical');
+  const { dateInputFormat } = useDateFormat();
   const [loading, setLoading] = useState(true);
 
   // Available entities for selection
@@ -351,8 +353,10 @@ const TreatmentPlanSetup = ({
                             <DateInput
                               size="xs"
                               label={t('treatments.medications.specificStartDate', 'Treatment Start Date')}
+                              placeholder={dateInputFormat}
                               value={parseDateInput(metadata.specific_start_date)}
                               onChange={(date) => updateItemMetadata('medications', medId, 'specific_start_date', formatDateInputChange(date))}
+                              valueFormat={dateInputFormat}
                               clearable
                               firstDayOfWeek={0}
                               popoverProps={{ withinPortal: true, zIndex: 4000 }}
@@ -360,8 +364,10 @@ const TreatmentPlanSetup = ({
                             <DateInput
                               size="xs"
                               label={t('treatments.medications.specificEndDate', 'Treatment End Date')}
+                              placeholder={dateInputFormat}
                               value={parseDateInput(metadata.specific_end_date)}
                               onChange={(date) => updateItemMetadata('medications', medId, 'specific_end_date', formatDateInputChange(date))}
+                              valueFormat={dateInputFormat}
                               clearable
                               firstDayOfWeek={0}
                               minDate={parseDateInput(metadata.specific_start_date) || undefined}

--- a/frontend/src/hooks/useDateFormat.js
+++ b/frontend/src/hooks/useDateFormat.js
@@ -92,6 +92,12 @@ export const useDateFormat = () => {
     [effectiveFormat]
   );
 
+  // Date-only input format pattern (e.g., "MM/DD/YYYY") for DateInput valueFormat/placeholder
+  const dateInputFormat = useMemo(
+    () => DATE_FORMAT_OPTIONS[effectiveFormat]?.pattern || DATE_FORMAT_OPTIONS[DEFAULT_DATE_FORMAT].pattern,
+    [effectiveFormat]
+  );
+
   return {
     formatDate,
     formatDateWithTime,
@@ -99,6 +105,7 @@ export const useDateFormat = () => {
     formatLongDate,
     formatDateTimeInput,
     dateFormat: effectiveFormat,
+    dateInputFormat,
     locale,
     formatLabel,
     formatExample,

--- a/frontend/src/hooks/useDateFormat.test.jsx
+++ b/frontend/src/hooks/useDateFormat.test.jsx
@@ -50,9 +50,9 @@ vi.mock('../utils/dateFormatUtils', () => ({
 // Mock constants
 vi.mock('../utils/constants', () => ({
   DATE_FORMAT_OPTIONS: {
-    mdy: { code: 'mdy', label: 'MM/DD/YYYY (US)', locale: 'en-US' },
-    dmy: { code: 'dmy', label: 'DD/MM/YYYY (EU)', locale: 'en-GB' },
-    ymd: { code: 'ymd', label: 'YYYY-MM-DD (ISO)', locale: 'sv-SE' },
+    mdy: { code: 'mdy', label: 'MM/DD/YYYY (US)', locale: 'en-US', pattern: 'MM/DD/YYYY' },
+    dmy: { code: 'dmy', label: 'DD/MM/YYYY (EU)', locale: 'en-GB', pattern: 'DD/MM/YYYY' },
+    ymd: { code: 'ymd', label: 'YYYY-MM-DD (ISO)', locale: 'sv-SE', pattern: 'YYYY-MM-DD' },
   },
   DEFAULT_DATE_FORMAT: 'mdy',
 }));
@@ -92,6 +92,7 @@ describe('useDateFormat', () => {
     expect(result.current).toHaveProperty('formatLabel');
     expect(result.current).toHaveProperty('formatExample');
     expect(result.current).toHaveProperty('dateTimePlaceholder');
+    expect(result.current).toHaveProperty('dateInputFormat');
     expect(result.current).toHaveProperty('formatOptions');
   });
 
@@ -145,6 +146,12 @@ describe('useDateFormat', () => {
     const { result } = renderHook(() => useDateFormat());
 
     expect(result.current.formatExample).toBe('01/25/2026');
+  });
+
+  test('dateInputFormat returns the pattern for the active format', () => {
+    const { result } = renderHook(() => useDateFormat());
+
+    expect(result.current.dateInputFormat).toBe('MM/DD/YYYY');
   });
 
   test('formatOptions contains available format options', () => {


### PR DESCRIPTION
This pull request standardizes the date input format across all medical-related forms in the frontend by integrating the `useDateFormat` hook. Now, all `DateInput` components use a consistent date format for both their `placeholder` and `valueFormat` properties, improving user experience and localization support.

**Date Format Standardization Across Medical Forms:**

* Added the `useDateFormat` hook to all relevant form components, including `BaseMedicalForm`, `MantineMedicationForm`, `MantinePatientForm`, `MantineVisitForm`, `VitalsForm`, `AllergyFormWrapper`, `ConditionFormWrapper`, `EquipmentFormWrapper`, and `ImmunizationFormWrapper`, to provide a consistent `dateInputFormat`. [[1]](diffhunk://#diff-140ebb1c94cfe9622167b65bbc27fc1a1d06d9aead8bd98d4d03b76e9050b8bdR31) [[2]](diffhunk://#diff-4f21a36e6027585e468c9b11e62d561d2d126f613dbeb657a550370bc951a873R27) [[3]](diffhunk://#diff-a37a664071fefbfd05009425ed0000450b0bb80109f0f5a14bc3a58b1662c390R20) [[4]](diffhunk://#diff-f8854d7f7161198fd74d5ca904558b2766ef9f65b229399692f00d80d1a39cb5R29) [[5]](diffhunk://#diff-402f1a457d6bcaa906cba7143302f948933ea7eb887446d3213cee49a0d988bcR23) [[6]](diffhunk://#diff-40a25cb43ffea3f5191734b81b5d9938ee71f5b2be9c6eb8bf587de4c883816aR3) [[7]](diffhunk://#diff-d14434e0e4ed4f2641a383acc75b144ff88d588b8c9458029f655fd7beab69d1R15) [[8]](diffhunk://#diff-6b9d9de8bca4ee67041a2e77ca90079acbde24da77aad4098b5d06b398c4d36bR24)
* Updated the initialization of each form component to retrieve `dateInputFormat` from the `useDateFormat` hook. [[1]](diffhunk://#diff-140ebb1c94cfe9622167b65bbc27fc1a1d06d9aead8bd98d4d03b76e9050b8bdR101-R102) [[2]](diffhunk://#diff-4f21a36e6027585e468c9b11e62d561d2d126f613dbeb657a550370bc951a873R51) [[3]](diffhunk://#diff-a37a664071fefbfd05009425ed0000450b0bb80109f0f5a14bc3a58b1662c390R43) [[4]](diffhunk://#diff-f8854d7f7161198fd74d5ca904558b2766ef9f65b229399692f00d80d1a39cb5R52) [[5]](diffhunk://#diff-402f1a457d6bcaa906cba7143302f948933ea7eb887446d3213cee49a0d988bcR46) [[6]](diffhunk://#diff-40a25cb43ffea3f5191734b81b5d9938ee71f5b2be9c6eb8bf587de4c883816aR52) [[7]](diffhunk://#diff-d14434e0e4ed4f2641a383acc75b144ff88d588b8c9458029f655fd7beab69d1R39)
* Modified all `DateInput` components in these forms to use `dateInputFormat` for both the `placeholder` and `valueFormat` props, replacing hardcoded formats and translation-based placeholders. This ensures dates are displayed and entered in the user's preferred format. [[1]](diffhunk://#diff-140ebb1c94cfe9622167b65bbc27fc1a1d06d9aead8bd98d4d03b76e9050b8bdR284-R293) [[2]](diffhunk://#diff-a5be298511fcb738a17dc8811cf6d7e6555f5d47a73d997a0f0305734ed5be0dL293-R297) [[3]](diffhunk://#diff-a5be298511fcb738a17dc8811cf6d7e6555f5d47a73d997a0f0305734ed5be0dL304-R309) [[4]](diffhunk://#diff-4f21a36e6027585e468c9b11e62d561d2d126f613dbeb657a550370bc951a873R164-R170) [[5]](diffhunk://#diff-a37a664071fefbfd05009425ed0000450b0bb80109f0f5a14bc3a58b1662c390L209-R211) [[6]](diffhunk://#diff-a37a664071fefbfd05009425ed0000450b0bb80109f0f5a14bc3a58b1662c390R232) [[7]](diffhunk://#diff-f8854d7f7161198fd74d5ca904558b2766ef9f65b229399692f00d80d1a39cb5R155-R161) [[8]](diffhunk://#diff-9fb74c081b44298f080800971e2baf7b42b0df8606714cd81abec508ce9f9467L672-R675) [[9]](diffhunk://#diff-402f1a457d6bcaa906cba7143302f948933ea7eb887446d3213cee49a0d988bcL202-R205) [[10]](diffhunk://#diff-40a25cb43ffea3f5191734b81b5d9938ee71f5b2be9c6eb8bf587de4c883816aL192-R195) [[11]](diffhunk://#diff-40a25cb43ffea3f5191734b81b5d9938ee71f5b2be9c6eb8bf587de4c883816aL205-R209) [[12]](diffhunk://#diff-d14434e0e4ed4f2641a383acc75b144ff88d588b8c9458029f655fd7beab69d1L169-R172) [[13]](diffhunk://#diff-d14434e0e4ed4f2641a383acc75b144ff88d588b8c9458029f655fd7beab69d1L182-R186) [[14]](diffhunk://#diff-d14434e0e4ed4f2641a383acc75b144ff88d588b8c9458029f655fd7beab69d1L195-R200)
* Ensured that all dependencies and memoization hooks include `dateInputFormat` where necessary to prevent stale values.
* Applied the same standardization to the data export date filters for consistency. [[1]](diffhunk://#diff-a5be298511fcb738a17dc8811cf6d7e6555f5d47a73d997a0f0305734ed5be0dR28-R32) [[2]](diffhunk://#diff-a5be298511fcb738a17dc8811cf6d7e6555f5d47a73d997a0f0305734ed5be0dL293-R297) [[3]](diffhunk://#diff-a5be298511fcb738a17dc8811cf6d7e6555f5d47a73d997a0f0305734ed5be0dL304-R309) [[4]](diffhunk://#diff-9fb74c081b44298f080800971e2baf7b42b0df8606714cd81abec508ce9f9467L82-R82)

These changes collectively improve consistency, localization, and maintainability of date inputs throughout the application's medical forms.