### PR TITLE
feat: Make Notes/Documents consistent in View/Edit panels

### DIFF
--- a/frontend/src/components/medical/MantineMedicationForm.jsx
+++ b/frontend/src/components/medical/MantineMedicationForm.jsx
@@ -301,11 +301,6 @@ const MantineMedicationForm = ({
               <Tabs.Tab value="details" leftSection={<IconPill size={16} />}>
                 {t('medications.tabs.details')}
               </Tabs.Tab>
-              <Tabs.Tab value="documents" leftSection={<IconFileText size={16} />}>
-                {editingMedication
-                  ? t('medications.tabs.documents')
-                  : t('medications.tabs.addFiles', 'Add Files')}
-              </Tabs.Tab>
               {editingMedication && (
                 <Tabs.Tab value="conditions" leftSection={<IconStethoscope size={16} />}>
                   {t('medications.tabs.conditions')}
@@ -313,6 +308,11 @@ const MantineMedicationForm = ({
               )}
               <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
                 {t('medications.tabs.notes')}
+              </Tabs.Tab>
+              <Tabs.Tab value="documents" leftSection={<IconFileText size={16} />}>
+                {editingMedication
+                  ? t('medications.tabs.documents')
+                  : t('medications.tabs.addFiles', 'Add Files')}
               </Tabs.Tab>
             </Tabs.List>
 
@@ -342,26 +342,6 @@ const MantineMedicationForm = ({
               </Box>
             </Tabs.Panel>
 
-            {/* Documents Tab */}
-            <Tabs.Panel value="documents">
-              <Box mt="md">
-                <Stack gap="md">
-                  {editingMedication && (
-                    <Title order={4}>{t('medications.form.attachedDocuments')}</Title>
-                  )}
-                  <DocumentManagerWithProgress
-                    entityType="medication"
-                    entityId={editingMedication?.id || null}
-                    mode={editingMedication ? 'edit' : 'create'}
-                    onUploadPendingFiles={handleDocumentManagerRef}
-                    showProgressModal={true}
-                    onUploadComplete={handleDocumentUploadComplete}
-                    onError={handleDocumentError}
-                  />
-                </Stack>
-              </Box>
-            </Tabs.Panel>
-
             {/* Conditions Tab */}
             {editingMedication && (
               <Tabs.Panel value="conditions">
@@ -387,6 +367,26 @@ const MantineMedicationForm = ({
                     </Grid.Col>
                   ))}
                 </Grid>
+              </Box>
+            </Tabs.Panel>
+
+            {/* Documents Tab */}
+            <Tabs.Panel value="documents">
+              <Box mt="md">
+                <Stack gap="md">
+                  {editingMedication && (
+                    <Title order={4}>{t('medications.form.attachedDocuments')}</Title>
+                  )}
+                  <DocumentManagerWithProgress
+                    entityType="medication"
+                    entityId={editingMedication?.id || null}
+                    mode={editingMedication ? 'edit' : 'create'}
+                    onUploadPendingFiles={handleDocumentManagerRef}
+                    showProgressModal={true}
+                    onUploadComplete={handleDocumentUploadComplete}
+                    onError={handleDocumentError}
+                  />
+                </Stack>
               </Box>
             </Tabs.Panel>
           </Tabs>

--- a/frontend/src/components/medical/allergies/AllergyFormWrapper.jsx
+++ b/frontend/src/components/medical/allergies/AllergyFormWrapper.jsx
@@ -155,13 +155,13 @@ const AllergyFormWrapper = ({
               <Tabs.Tab value="reaction" leftSection={<IconAlertTriangle size={16} />}>
                 {t('allergies.tabs.reactionDetails')}
               </Tabs.Tab>
+              <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
+                {t('allergies.tabs.notes')}
+              </Tabs.Tab>
               <Tabs.Tab value="documents" leftSection={<IconFileText size={16} />}>
                 {editingAllergy
                   ? t('allergies.form.tabs.documents', 'Documents')
                   : t('allergies.form.tabs.addFiles', 'Add Files')}
-              </Tabs.Tab>
-              <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
-                {t('allergies.tabs.notes')}
               </Tabs.Tab>
             </Tabs.List>
 
@@ -333,21 +333,6 @@ const AllergyFormWrapper = ({
               </Box>
             </Tabs.Panel>
 
-            {/* Documents Tab */}
-            <Tabs.Panel value="documents">
-              <Box mt="md">
-                <DocumentManagerWithProgress
-                  entityType="allergy"
-                  entityId={editingAllergy?.id || null}
-                  mode={editingAllergy ? 'edit' : 'create'}
-                  onUploadPendingFiles={handleDocumentManagerRef}
-                  showProgressModal={true}
-                  onUploadComplete={handleDocumentUploadComplete}
-                  onError={handleDocumentError}
-                />
-              </Box>
-            </Tabs.Panel>
-
             {/* Notes Tab */}
             <Tabs.Panel value="notes">
               <Box mt="md">
@@ -360,6 +345,21 @@ const AllergyFormWrapper = ({
                   rows={5}
                   minRows={3}
                   autosize
+                />
+              </Box>
+            </Tabs.Panel>
+
+            {/* Documents Tab */}
+            <Tabs.Panel value="documents">
+              <Box mt="md">
+                <DocumentManagerWithProgress
+                  entityType="allergy"
+                  entityId={editingAllergy?.id || null}
+                  mode={editingAllergy ? 'edit' : 'create'}
+                  onUploadPendingFiles={handleDocumentManagerRef}
+                  showProgressModal={true}
+                  onUploadComplete={handleDocumentUploadComplete}
+                  onError={handleDocumentError}
                 />
               </Box>
             </Tabs.Panel>

--- a/frontend/src/components/medical/conditions/ConditionFormWrapper.jsx
+++ b/frontend/src/components/medical/conditions/ConditionFormWrapper.jsx
@@ -164,13 +164,13 @@ const ConditionFormWrapper = ({
               <Tabs.Tab value="medications" leftSection={<IconPill size={16} />}>
                 {t('conditions.form.tabs.medications', 'Medications')}
               </Tabs.Tab>
+              <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
+                {t('conditions.form.tabs.notes', 'Notes')}
+              </Tabs.Tab>
               <Tabs.Tab value="documents" leftSection={<IconFileText size={16} />}>
                 {editingCondition
                   ? t('conditions.form.tabs.documents', 'Documents')
                   : t('conditions.form.tabs.addFiles', 'Add Files')}
-              </Tabs.Tab>
-              <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
-                {t('conditions.form.tabs.notes', 'Notes')}
               </Tabs.Tab>
             </Tabs.List>
 
@@ -362,21 +362,6 @@ const ConditionFormWrapper = ({
               </Box>
             </Tabs.Panel>
 
-            {/* Documents Tab */}
-            <Tabs.Panel value="documents">
-              <Box mt="md">
-                <DocumentManagerWithProgress
-                  entityType="condition"
-                  entityId={editingCondition?.id || null}
-                  mode={editingCondition ? 'edit' : 'create'}
-                  onUploadPendingFiles={handleDocumentManagerRef}
-                  showProgressModal={true}
-                  onUploadComplete={handleDocumentUploadComplete}
-                  onError={handleDocumentError}
-                />
-              </Box>
-            </Tabs.Panel>
-
             {/* Notes Tab */}
             <Tabs.Panel value="notes">
               <Box mt="md">
@@ -389,6 +374,21 @@ const ConditionFormWrapper = ({
                   rows={5}
                   minRows={3}
                   autosize
+                />
+              </Box>
+            </Tabs.Panel>
+
+            {/* Documents Tab */}
+            <Tabs.Panel value="documents">
+              <Box mt="md">
+                <DocumentManagerWithProgress
+                  entityType="condition"
+                  entityId={editingCondition?.id || null}
+                  mode={editingCondition ? 'edit' : 'create'}
+                  onUploadPendingFiles={handleDocumentManagerRef}
+                  showProgressModal={true}
+                  onUploadComplete={handleDocumentUploadComplete}
+                  onError={handleDocumentError}
                 />
               </Box>
             </Tabs.Panel>

--- a/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
+++ b/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
@@ -159,13 +159,13 @@ const ImmunizationFormWrapper = ({
               <Tabs.Tab value="administration" leftSection={<IconNeedle size={16} />}>
                 {t('immunizations.form.tabs.administration', 'Administration')}
               </Tabs.Tab>
+              <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
+                {t('immunizations.form.tabs.notes', 'Notes')}
+              </Tabs.Tab>
               <Tabs.Tab value="documents" leftSection={<IconFileText size={16} />}>
                 {editingImmunization
                   ? t('immunizations.form.tabs.documents', 'Documents')
                   : t('immunizations.form.tabs.addFiles', 'Add Files')}
-              </Tabs.Tab>
-              <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
-                {t('immunizations.form.tabs.notes', 'Notes')}
               </Tabs.Tab>
             </Tabs.List>
 
@@ -365,21 +365,6 @@ const ImmunizationFormWrapper = ({
               </Box>
             </Tabs.Panel>
 
-            {/* Documents Tab */}
-            <Tabs.Panel value="documents">
-              <Box mt="md">
-                <DocumentManagerWithProgress
-                  entityType="immunization"
-                  entityId={editingImmunization?.id || null}
-                  mode={editingImmunization ? 'edit' : 'create'}
-                  onUploadPendingFiles={handleDocumentManagerRef}
-                  showProgressModal={true}
-                  onUploadComplete={handleDocumentUploadComplete}
-                  onError={handleDocumentError}
-                />
-              </Box>
-            </Tabs.Panel>
-
             {/* Notes Tab */}
             <Tabs.Panel value="notes">
               <Box mt="md">
@@ -392,6 +377,21 @@ const ImmunizationFormWrapper = ({
                   rows={5}
                   minRows={3}
                   autosize
+                />
+              </Box>
+            </Tabs.Panel>
+
+            {/* Documents Tab */}
+            <Tabs.Panel value="documents">
+              <Box mt="md">
+                <DocumentManagerWithProgress
+                  entityType="immunization"
+                  entityId={editingImmunization?.id || null}
+                  mode={editingImmunization ? 'edit' : 'create'}
+                  onUploadPendingFiles={handleDocumentManagerRef}
+                  showProgressModal={true}
+                  onUploadComplete={handleDocumentUploadComplete}
+                  onError={handleDocumentError}
                 />
               </Box>
             </Tabs.Panel>

--- a/frontend/src/components/medical/procedures/ProcedureFormWrapper.jsx
+++ b/frontend/src/components/medical/procedures/ProcedureFormWrapper.jsx
@@ -154,13 +154,13 @@ const ProcedureFormWrapper = ({
               <Tabs.Tab value="clinical" leftSection={<IconStethoscope size={16} />}>
                 {t('procedures.form.tabs.clinical', 'Clinical Details')}
               </Tabs.Tab>
+              <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
+                {t('procedures.form.tabs.notes', 'Notes')}
+              </Tabs.Tab>
               <Tabs.Tab value="documents" leftSection={<IconFileText size={16} />}>
                 {editingItem
                   ? t('procedures.form.tabs.documents', 'Documents')
                   : t('procedures.form.tabs.addFiles', 'Add Files')}
-              </Tabs.Tab>
-              <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
-                {t('procedures.form.tabs.notes', 'Notes')}
               </Tabs.Tab>
             </Tabs.List>
 
@@ -374,21 +374,6 @@ const ProcedureFormWrapper = ({
               </Box>
             </Tabs.Panel>
 
-            {/* Documents Tab */}
-            <Tabs.Panel value="documents">
-              <Box mt="md">
-                <DocumentManagerWithProgress
-                  entityType="procedure"
-                  entityId={editingItem?.id || null}
-                  mode={editingItem ? 'edit' : 'create'}
-                  onUploadPendingFiles={handleDocumentManagerRef}
-                  showProgressModal={true}
-                  onUploadComplete={handleDocumentUploadComplete}
-                  onError={handleDocumentError}
-                />
-              </Box>
-            </Tabs.Panel>
-
             {/* Notes Tab */}
             <Tabs.Panel value="notes">
               <Box mt="md">
@@ -401,6 +386,21 @@ const ProcedureFormWrapper = ({
                   rows={5}
                   minRows={3}
                   autosize
+                />
+              </Box>
+            </Tabs.Panel>
+
+            {/* Documents Tab */}
+            <Tabs.Panel value="documents">
+              <Box mt="md">
+                <DocumentManagerWithProgress
+                  entityType="procedure"
+                  entityId={editingItem?.id || null}
+                  mode={editingItem ? 'edit' : 'create'}
+                  onUploadPendingFiles={handleDocumentManagerRef}
+                  showProgressModal={true}
+                  onUploadComplete={handleDocumentUploadComplete}
+                  onError={handleDocumentError}
                 />
               </Box>
             </Tabs.Panel>


### PR DESCRIPTION
Fix inconsistent tab order between View and Edit modals across medical subsystems                 
                                                                                                  
- Notes and Documents tabs appeared in opposite order between View modals (Notes → Documents) and   
  Edit forms (Documents → Notes) in five subsystems: Medications, Allergies, Conditions, Procedures,
   and Immunizations. Updated all Edit forms to match the View modal order (Notes before Documents).