### PR TITLE
fix: reset scroll position on route change in NavigationTracker

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -166,6 +166,9 @@ function NavigationTracker() {
     const currentPath = location.pathname;
     const previousPath = previousLocation.current;
     if (currentPath !== previousPath) {
+      // Reset scroll position to top on route change
+      window.scrollTo(0, 0);
+
       // Track navigation as user activity (for session timeout)
       trackNavigationActivity({
         fromPath: previousPath,


### PR DESCRIPTION
This pull request introduces a small but important usability improvement to the app's navigation behavior. Now, whenever the user navigates to a new route, the scroll position will automatically reset to the top of the page.

- User Experience Enhancement:
  * Added logic in `NavigationTracker` within `App.jsx` to reset the scroll position to the top (`window.scrollTo(0, 0)`) on every route change, ensuring consistent navigation behavior.