### PR TITLE
fix: corrected tests broken by recent i18n rework

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Patient erstellen",
         "saveChanges": "Änderungen speichern"
       },
+      "createTitle": "Neuen Patienten hinzufügen",
+      "editTitle": "Patient bearbeiten",
       "firstName": {
         "placeholder": "Vorname eingeben"
       },
@@ -1165,7 +1167,7 @@
       "frequencyDesc": "Wie oft die Behandlung verabreicht wird",
       "frequencyPlaceholder": "z.B. Täglich, Zweimal wöchentlich",
       "linkingPartialFailure": "Einige Elemente konnten nicht verknüpft werden",
-      "linkingPartialFailureMessage": "",
+      "linkingPartialFailureMessage": "Die Behandlung wurde erstellt, aber einige Elemente konnten nicht verknüpft werden. Sie können sie manuell verknüpfen, indem Sie die Behandlung bearbeiten.",
       "notesDesc": "Zusätzliche Informationen zu dieser Behandlung",
       "notesPlaceholder": "Behandlungsnotizen, Beobachtungen oder zusätzliche Details eingeben",
       "practitionerDesc": "Gesundheitsdienstleister, der die Behandlung durchführt",
@@ -1272,7 +1274,7 @@
   },
   "vitals": {
     "form": {
-      "dateTimePlaceholder": "",
+      "dateTimePlaceholder": "Datum und Uhrzeit auswählen",
       "devicePlaceholder": "z.B. Digitales Blutdruckmessgerät, Thermometer-Modell...",
       "heightNotSet": "Größe nicht im Patientenprofil hinterlegt – BMI-Berechnung nicht verfügbar",
       "locationPlaceholder": "Wo wurden diese Messungen vorgenommen?",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Create Patient",
         "saveChanges": "Save Changes"
       },
+      "createTitle": "Add New Patient",
+      "editTitle": "Edit Patient",
       "firstName": {
         "placeholder": "Enter first name"
       },
@@ -1165,7 +1167,7 @@
       "frequencyDesc": "How often treatment is administered",
       "frequencyPlaceholder": "e.g., Daily, Twice weekly",
       "linkingPartialFailure": "Some items could not be linked",
-      "linkingPartialFailureMessage": "",
+      "linkingPartialFailureMessage": "The treatment was created, but some items could not be linked. You can link them manually by editing the treatment.",
       "notesDesc": "Additional information about this treatment",
       "notesPlaceholder": "Enter treatment notes, observations, or additional details",
       "practitionerDesc": "Healthcare provider administering treatment",
@@ -1272,7 +1274,7 @@
   },
   "vitals": {
     "form": {
-      "dateTimePlaceholder": "",
+      "dateTimePlaceholder": "Select date and time",
       "devicePlaceholder": "e.g., Digital BP monitor, Thermometer model...",
       "heightNotSet": "Height not set in patient profile - BMI calculation unavailable",
       "locationPlaceholder": "Where were these readings taken?",

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Crear paciente",
         "saveChanges": "Guardar cambios"
       },
+      "createTitle": "Agregar nuevo paciente",
+      "editTitle": "Editar paciente",
       "firstName": {
         "placeholder": "Introduzca el nombre"
       },

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Créer le patient",
         "saveChanges": "Enregistrer les modifications"
       },
+      "createTitle": "Ajouter un nouveau patient",
+      "editTitle": "Modifier le patient",
       "firstName": {
         "placeholder": "Saisir le prénom"
       },

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Crea paziente",
         "saveChanges": "Salva modifiche"
       },
+      "createTitle": "Aggiungi nuovo paziente",
+      "editTitle": "Modifica paziente",
       "firstName": {
         "placeholder": "Inserisci il nome"
       },
@@ -1165,7 +1167,7 @@
       "frequencyDesc": "Con quale frequenza viene somministrato il trattamento",
       "frequencyPlaceholder": "ad es., Giornaliero, Due volte a settimana",
       "linkingPartialFailure": "Alcuni elementi non hanno potuto essere collegati",
-      "linkingPartialFailureMessage": "",
+      "linkingPartialFailureMessage": "Il trattamento è stato creato, ma alcuni elementi non sono stati collegati. Puoi collegarli manualmente modificando il trattamento.",
       "notesDesc": "Informazioni aggiuntive su questo trattamento",
       "notesPlaceholder": "Inserisci note, osservazioni o dettagli aggiuntivi sul trattamento",
       "practitionerDesc": "Operatore sanitario che somministra il trattamento",
@@ -1272,7 +1274,7 @@
   },
   "vitals": {
     "form": {
-      "dateTimePlaceholder": "",
+      "dateTimePlaceholder": "Seleziona data e ora",
       "devicePlaceholder": "ad es., Misuratore di pressione digitale, modello termometro...",
       "heightNotSet": "Altezza non impostata nel profilo del paziente - calcolo BMI non disponibile",
       "locationPlaceholder": "Dove sono state rilevate queste misurazioni?",

--- a/frontend/public/locales/nl/common.json
+++ b/frontend/public/locales/nl/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Patiënt aanmaken",
         "saveChanges": "Wijzigingen opslaan"
       },
+      "createTitle": "Nieuwe patiënt toevoegen",
+      "editTitle": "Patiënt bewerken",
       "firstName": {
         "placeholder": "Voer voornaam in"
       },
@@ -1272,7 +1274,7 @@
   },
   "vitals": {
     "form": {
-      "dateTimePlaceholder": "",
+      "dateTimePlaceholder": "Selecteer datum en tijd",
       "devicePlaceholder": "bijv. digitale bloeddrukmeter, thermometermodel...",
       "heightNotSet": "Lengte niet ingesteld in patiëntprofiel - BMI-berekening niet beschikbaar",
       "locationPlaceholder": "Waar zijn deze metingen afgenomen?",

--- a/frontend/public/locales/pl/common.json
+++ b/frontend/public/locales/pl/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Utwórz pacjenta",
         "saveChanges": "Zapisz zmiany"
       },
+      "createTitle": "Dodaj nowego pacjenta",
+      "editTitle": "Edytuj pacjenta",
       "firstName": {
         "placeholder": "Wprowadź imię"
       },
@@ -1165,7 +1167,7 @@
       "frequencyDesc": "Jak często leczenie jest przeprowadzane",
       "frequencyPlaceholder": "np. Codziennie, Dwa razy w tygodniu",
       "linkingPartialFailure": "Nie udało się połączyć niektórych elementów",
-      "linkingPartialFailureMessage": "",
+      "linkingPartialFailureMessage": "Leczenie zostało utworzone, ale niektóre elementy nie mogły zostać powiązane. Możesz powiązać je ręcznie, edytując leczenie.",
       "notesDesc": "Dodatkowe informacje o tym leczeniu",
       "notesPlaceholder": "Wprowadź notatki dotyczące leczenia, obserwacje lub dodatkowe szczegóły",
       "practitionerDesc": "Pracownik ochrony zdrowia przeprowadzający leczenie",
@@ -1272,7 +1274,7 @@
   },
   "vitals": {
     "form": {
-      "dateTimePlaceholder": "",
+      "dateTimePlaceholder": "Wybierz datę i godzinę",
       "devicePlaceholder": "np. Monitor ciśnienia cyfrowy, Model termometru...",
       "heightNotSet": "Wzrost nie ustawiony w profilu pacjenta - obliczanie BMI niedostępne",
       "locationPlaceholder": "Gdzie wykonano te pomiary?",

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Criar Paciente",
         "saveChanges": "Salvar Alterações"
       },
+      "createTitle": "Adicionar novo paciente",
+      "editTitle": "Editar paciente",
       "firstName": {
         "placeholder": "Digite o nome"
       },
@@ -1165,7 +1167,7 @@
       "frequencyDesc": "Com que frequência o tratamento é administrado",
       "frequencyPlaceholder": "por exemplo, Diariamente, Duas vezes por semana",
       "linkingPartialFailure": "Alguns itens não puderam ser vinculados",
-      "linkingPartialFailureMessage": "",
+      "linkingPartialFailureMessage": "O tratamento foi criado, mas alguns itens não puderam ser vinculados. Você pode vinculá-los manualmente editando o tratamento.",
       "notesDesc": "Informações adicionais sobre este tratamento",
       "notesPlaceholder": "Digite notas, observações ou detalhes adicionais do tratamento",
       "practitionerDesc": "Profissional de saúde que administra o tratamento",
@@ -1272,7 +1274,7 @@
   },
   "vitals": {
     "form": {
-      "dateTimePlaceholder": "",
+      "dateTimePlaceholder": "Selecione data e hora",
       "devicePlaceholder": "por exemplo, Monitor de PA Digital, Modelo de Termômetro...",
       "heightNotSet": "Altura não definida no perfil do paciente - cálculo de IMC indisponível",
       "locationPlaceholder": "Onde essas medições foram feitas?",

--- a/frontend/public/locales/ru/common.json
+++ b/frontend/public/locales/ru/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Создать пациента",
         "saveChanges": "Сохранить изменения"
       },
+      "createTitle": "Добавить нового пациента",
+      "editTitle": "Редактировать пациента",
       "firstName": {
         "placeholder": "Введите имя"
       },
@@ -1165,7 +1167,7 @@
       "frequencyDesc": "Как часто проводится лечение",
       "frequencyPlaceholder": "напр., Ежедневно, Дважды в неделю",
       "linkingPartialFailure": "Некоторые элементы не удалось связать",
-      "linkingPartialFailureMessage": "",
+      "linkingPartialFailureMessage": "Лечение создано, но некоторые элементы не удалось связать. Вы можете связать их вручную, отредактировав лечение.",
       "notesDesc": "Дополнительная информация об этом лечении",
       "notesPlaceholder": "Введите заметки о лечении, наблюдения или дополнительные сведения",
       "practitionerDesc": "Медицинский специалист, проводящий лечение",
@@ -1272,7 +1274,7 @@
   },
   "vitals": {
     "form": {
-      "dateTimePlaceholder": "",
+      "dateTimePlaceholder": "Выберите дату и время",
       "devicePlaceholder": "напр., цифровой тонометр, модель термометра...",
       "heightNotSet": "Рост не указан в профиле пациента - расчёт ИМТ недоступен",
       "locationPlaceholder": "Где были сделаны эти измерения?",

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -615,6 +615,8 @@
         "createPatient": "Skapa patient",
         "saveChanges": "Spara ändringar"
       },
+      "createTitle": "Lägg till ny patient",
+      "editTitle": "Redigera patient",
       "firstName": {
         "placeholder": "Ange förnamn"
       },

--- a/frontend/public/locales/th/common.json
+++ b/frontend/public/locales/th/common.json
@@ -615,6 +615,8 @@
         "createPatient": "สร้างผู้ป่วย",
         "saveChanges": "บันทึกการเปลี่ยนแปลง"
       },
+      "createTitle": "เพิ่มผู้ป่วยใหม่",
+      "editTitle": "แก้ไขผู้ป่วย",
       "firstName": {
         "placeholder": "ป้อนชื่อ"
       },
@@ -1165,7 +1167,7 @@
       "frequencyDesc": "ความถี่ในการรักษา",
       "frequencyPlaceholder": "เช่น ทุกวัน, สัปดาห์ละ 2 ครั้ง",
       "linkingPartialFailure": "ไม่สามารถเชื่อมโยงรายการบางส่วนได้",
-      "linkingPartialFailureMessage": "",
+      "linkingPartialFailureMessage": "สร้างการรักษาเรียบร้อยแล้ว แต่ไม่สามารถเชื่อมโยงบางรายการได้ คุณสามารถเชื่อมโยงด้วยตนเองโดยแก้ไขการรักษา",
       "notesDesc": "ข้อมูลเพิ่มเติมเกี่ยวกับการรักษานี้",
       "notesPlaceholder": "ป้อนหมายเหตุการรักษา ข้อสังเกต หรือรายละเอียดเพิ่มเติม",
       "practitionerDesc": "ผู้ให้บริการสุขภาพที่ให้การรักษา",
@@ -1272,7 +1274,7 @@
   },
   "vitals": {
     "form": {
-      "dateTimePlaceholder": "",
+      "dateTimePlaceholder": "เลือกวันที่และเวลา",
       "devicePlaceholder": "เช่น เครื่องวัดความดันแบบดิจิทัล รุ่นเครื่องวัดอุณหภูมิ...",
       "heightNotSet": "ไม่ได้ตั้งค่าส่วนสูงในโปรไฟล์ผู้ป่วย - ไม่สามารถคำนวณ BMI ได้",
       "locationPlaceholder": "วัดค่าเหล่านี้ที่ไหน?",

--- a/frontend/src/__tests__/localization/translationKeys.test.js
+++ b/frontend/src/__tests__/localization/translationKeys.test.js
@@ -166,9 +166,9 @@ describe('Translation Key Consistency', () => {
         const common = loadTranslations(locale, 'common');
 
         expect(common.modals).toBeDefined();
-        expect(common.modals.linkMedicationToCondition).toBeDefined();
+        expect(common.modals.linkMedicationsToCondition).toBeDefined();
         expect(common.modals.linkConditionToLabResult).toBeDefined();
-        expect(common.modals.selectMedication).toBeDefined();
+        expect(common.modals.selectMedications).toBeDefined();
         expect(common.modals.selectCondition).toBeDefined();
         expect(common.modals.relevanceNoteOptional).toBeDefined();
       });
@@ -181,8 +181,8 @@ describe('Translation Key Consistency', () => {
         expect(common.patients?.form).toBeDefined();
         expect(common.patients.form.createTitle).toBeDefined();
         expect(common.patients.form.editTitle).toBeDefined();
-        expect(common.patients.form.firstName?.label).toBeDefined();
-        expect(common.patients.form.lastName?.label).toBeDefined();
+        expect(common.patients.form.firstName?.placeholder).toBeDefined();
+        expect(common.patients.form.lastName?.placeholder).toBeDefined();
         expect(common.patients.form.birthDate?.label).toBeDefined();
         expect(common.patients.form.gender?.options).toBeDefined();
       });
@@ -191,25 +191,28 @@ describe('Translation Key Consistency', () => {
     it('should have symptom episode translations', () => {
       locales.forEach(locale => {
         const common = loadTranslations(locale, 'common');
+        const medical = loadTranslations(locale, 'medical');
 
         expect(common.symptoms).toBeDefined();
         expect(common.symptoms.logEpisodeTitle).toBeDefined();
         expect(common.symptoms.editEpisodeTitle).toBeDefined();
         expect(common.symptoms.addSymptomTitle).toBeDefined();
-        expect(common.symptoms.occurrence?.additionalNotes).toBeDefined();
+        expect(medical.symptoms?.occurrence?.additionalNotes).toBeDefined();
       });
     });
 
-    it('should have lab result enhanced translations', () => {
+    it('should have lab result translations', () => {
       locales.forEach(locale => {
+        const common = loadTranslations(locale, 'common');
         const medical = loadTranslations(locale, 'medical');
 
-        expect(medical.labResults).toBeDefined();
-        expect(medical.labResults.status).toBeDefined();
-        expect(medical.labResults.category).toBeDefined();
-        expect(medical.labResults.testType).toBeDefined();
-        expect(medical.labResults.result).toBeDefined();
-        expect(medical.labResults.form?.relatedConditions).toBeDefined();
+        // Lab result UI strings live in common.labResults after the i18n refactor.
+        expect(common.labResults).toBeDefined();
+        expect(common.labResults.labResultCreated).toBeDefined();
+        expect(common.labResults.quickImportModalTitle).toBeDefined();
+        expect(common.labResults.form?.linkVisitsTitle).toBeDefined();
+        // The medical namespace retains the form-warning strings.
+        expect(medical.labResults?.form).toBeDefined();
       });
     });
 
@@ -235,8 +238,8 @@ describe('Translation Key Consistency', () => {
 
         expect(medical.treatments?.frequency).toBeDefined();
         expect(medical.treatments.frequency.label).toBeDefined();
-        expect(medical.treatments.startDate?.label).toBeDefined();
-        expect(medical.treatments.endDate?.label).toBeDefined();
+        expect(medical.treatments.startDate?.description).toBeDefined();
+        expect(medical.treatments.endDate?.description).toBeDefined();
       });
     });
 

--- a/frontend/src/hooks/__tests__/useFormSubmissionWithUploads.test.jsx
+++ b/frontend/src/hooks/__tests__/useFormSubmissionWithUploads.test.jsx
@@ -126,10 +126,8 @@ describe('useFormSubmissionWithUploads Hook', () => {
       expect(result.current.submissionState.isCompleted).toBe(true);
       expect(result.current.submissionState.canClose).toBe(true);
 
-      // Verify onSuccess callback is triggered
-      await waitFor(() => {
-        expect(mockOnSuccess).toHaveBeenCalled();
-      });
+      // Verify onSuccess callback is triggered (state effect fires synchronously in act())
+      expect(mockOnSuccess).toHaveBeenCalled();
 
       expect(notifications.show).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -471,9 +469,7 @@ describe('useFormSubmissionWithUploads Hook', () => {
         result.current.completeFileUpload(true, 2, 0);
       });
 
-      await waitFor(() => {
-        expect(mockOnSuccess).toHaveBeenCalledTimes(1);
-      });
+      expect(mockOnSuccess).toHaveBeenCalledTimes(1);
     });
 
     test('should not call onSuccess when form fails', async () => {
@@ -522,9 +518,7 @@ describe('useFormSubmissionWithUploads Hook', () => {
       });
 
       // Should not throw error
-      await waitFor(() => {
-        expect(result.current.submissionState.isCompleted).toBe(true);
-      });
+      expect(result.current.submissionState.isCompleted).toBe(true);
     });
 
     test('should handle missing onError callback gracefully', () => {

--- a/frontend/src/hooks/__tests__/useUploadProgress.test.jsx
+++ b/frontend/src/hooks/__tests__/useUploadProgress.test.jsx
@@ -168,12 +168,10 @@ describe('useUploadProgress Hook', () => {
         vi.runAllTimers();
       });
 
-      await waitFor(() => {
-        const file = result.current.uploadState.files[0];
-        expect(file.progress).toBe(100);
-        expect(file.status).toBe('uploading');
-        expect(file.lastUpdate).toBeDefined();
-      });
+      const file = result.current.uploadState.files[0];
+      expect(file.progress).toBe(100);
+      expect(file.status).toBe('uploading');
+      expect(file.lastUpdate).toBeDefined();
     });
 
     test('should prevent progress from exceeding bounds (0-100)', () => {

--- a/frontend/src/pages/medical/__tests__/EmergencyContacts.integration.test.jsx
+++ b/frontend/src/pages/medical/__tests__/EmergencyContacts.integration.test.jsx
@@ -618,21 +618,24 @@ describe('Emergency Contacts Page Integration Tests', () => {
     });
 
     test('filters contacts by active status', async () => {
+      const activeContacts = mockEmergencyContacts.filter(c => c.is_active);
       useDataManagement.mockReturnValue({
         ...mockDataManagement,
-        data: mockEmergencyContacts.filter(c => c.is_active),
+        data: activeContacts,
         hasActiveFilters: true,
       });
 
       renderWithPatient(<EmergencyContacts />);
 
+      // Wait for the filtered set to settle — in the full suite a prior render may
+      // still be flushing, so poll until Robert Smith (inactive) is gone.
       await waitFor(() => {
         expect(screen.getByText('Sarah Johnson')).toBeInTheDocument();
+        expect(screen.queryByText('Robert Smith')).not.toBeInTheDocument();
       });
 
       expect(screen.getByText('Michael Johnson')).toBeInTheDocument();
       expect(screen.getByText('Dr. Emily Chen')).toBeInTheDocument();
-      expect(screen.queryByText('Robert Smith')).not.toBeInTheDocument();
     });
 
     test('searches contacts by name and notes', async () => {

--- a/frontend/src/services/api/index.test.js
+++ b/frontend/src/services/api/index.test.js
@@ -237,29 +237,33 @@ describe('API Service', () => {
       await expect(apiService.getRecentActivity()).rejects.toThrow();
     });
 
-    test('handles requests without authentication token', async () => {
-      // Clear token from secureStorage
-      secureStorage.getItem.mockResolvedValue(null);
+    test('surfaces backend 401 as Not authenticated error', async () => {
+      // Force the /patients/me handler to return a 401 regardless of credentials.
+      server.use(
+        rest.get('*/api/v1/patients/me', (req, res, ctx) =>
+          res(ctx.status(401), ctx.json({ detail: 'Not authenticated' }))
+        )
+      );
 
       await expect(apiService.getCurrentPatient()).rejects.toThrow('Not authenticated');
     });
   });
 
   describe('Request Headers', () => {
-    test('includes authorization header when token is present', async () => {
-      let capturedHeaders;
-      
-      // Capture request headers
+    test('sends credentials so HttpOnly auth cookie is included', async () => {
+      let capturedCredentials;
+
+      // Capture request credentials mode (cookie-based auth replaced bearer tokens).
       server.use(
         rest.get('*/api/v1/patients/me', (req, res, ctx) => {
-          capturedHeaders = req.headers.get('Authorization');
+          capturedCredentials = req.credentials;
           return res(ctx.status(200), ctx.json({}));
         })
       );
 
       await apiService.getCurrentPatient();
 
-      expect(capturedHeaders).toBe('Bearer mock-jwt-token');
+      expect(capturedCredentials).toBe('include');
     });
 
     test('includes content-type header for POST requests', async () => {

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -114,6 +114,13 @@ Object.defineProperty(window, 'scrollTo', {
   value: vi.fn(),
 });
 
+// jsdom lacks Element.prototype.scrollIntoView. Mantine Combobox schedules it via
+// setTimeout after the test finishes, which leaks an unhandled exception into the
+// next test file. Polyfill it globally so the callback is a no-op.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+
 // Mock localStorage
 const localStorageMock = {
   getItem: vi.fn(),

--- a/frontend/src/test-utils/mocks/handlers.js
+++ b/frontend/src/test-utils/mocks/handlers.js
@@ -69,7 +69,7 @@ export const handlers = [
   // Patient endpoints
   rest.get(`${API_BASE}/patients/me`, (req, res, ctx) => {
     // Auth is handled via HttpOnly cookies in production; tests assume authenticated state.
-return res(
+    return res(
       ctx.json({
         id: 1,
         user_id: 1,
@@ -90,8 +90,8 @@ return res(
 
   rest.put(`${API_BASE}/patients/me`, (req, res, ctx) => {
     // Auth is handled via HttpOnly cookies in production; tests assume authenticated state.
-const updatedData = req.body;
-    
+    const updatedData = req.body;
+
     return res(
       ctx.json({
         id: 1,
@@ -104,8 +104,8 @@ const updatedData = req.body;
 
   rest.post(`${API_BASE}/patients/me`, (req, res, ctx) => {
     // Auth is handled via HttpOnly cookies in production; tests assume authenticated state.
-const patientData = req.body;
-    
+    const patientData = req.body;
+
     return res(
       ctx.status(201),
       ctx.json({

--- a/frontend/src/test-utils/mocks/handlers.js
+++ b/frontend/src/test-utils/mocks/handlers.js
@@ -68,16 +68,8 @@ export const handlers = [
 
   // Patient endpoints
   rest.get(`${API_BASE}/patients/me`, (req, res, ctx) => {
-    const authHeader = req.headers.get('Authorization');
-    
-    if (!authHeader || !authHeader.includes('Bearer')) {
-      return res(
-        ctx.status(401),
-        ctx.json({ detail: 'Not authenticated' })
-      );
-    }
-
-    return res(
+    // Auth is handled via HttpOnly cookies in production; tests assume authenticated state.
+return res(
       ctx.json({
         id: 1,
         user_id: 1,
@@ -97,16 +89,8 @@ export const handlers = [
   }),
 
   rest.put(`${API_BASE}/patients/me`, (req, res, ctx) => {
-    const authHeader = req.headers.get('Authorization');
-    
-    if (!authHeader || !authHeader.includes('Bearer')) {
-      return res(
-        ctx.status(401),
-        ctx.json({ detail: 'Not authenticated' })
-      );
-    }
-
-    const updatedData = req.body;
+    // Auth is handled via HttpOnly cookies in production; tests assume authenticated state.
+const updatedData = req.body;
     
     return res(
       ctx.json({
@@ -119,16 +103,8 @@ export const handlers = [
   }),
 
   rest.post(`${API_BASE}/patients/me`, (req, res, ctx) => {
-    const authHeader = req.headers.get('Authorization');
-    
-    if (!authHeader || !authHeader.includes('Bearer')) {
-      return res(
-        ctx.status(401),
-        ctx.json({ detail: 'Not authenticated' })
-      );
-    }
-
-    const patientData = req.body;
+    // Auth is handled via HttpOnly cookies in production; tests assume authenticated state.
+const patientData = req.body;
     
     return res(
       ctx.status(201),


### PR DESCRIPTION
This pull request updates translation files across multiple languages and improves translation key consistency checks in the test suite. The main focus is on enhancing patient form labels, error messages, and placeholder text, as well as ensuring the translation keys in the codebase match the updated structure after recent i18n refactors.

**Translation updates across languages:**

* Added `createTitle` and `editTitle` fields for patient forms to all supported languages in their respective `common.json` files, providing consistent UI titles for creating and editing patients. [[1]](diffhunk://#diff-33c499047fc22cc766f0d8b1be2a6103ce9c582c107b84d8219031120f04bd7aR618-R619) [[2]](diffhunk://#diff-2e67589bc551d2f12ba1499b32925674c0611ff673460af46437902cab5f058eR618-R619) [[3]](diffhunk://#diff-13c52b69dfe950d320432dae53ccb8a566a5d4d69ac5a7ba54f4a909a3bb4e6fR618-R619) [[4]](diffhunk://#diff-285d4745ded42255660eafafa54fc7490496e86f0ed40a9d9ea2f6687b8b32d6R618-R619) [[5]](diffhunk://#diff-7f4d6bada4d4e07a00f12836e045c0d3337f22b8b4cee8a62ec4d4d807f084a5R618-R619) [[6]](diffhunk://#diff-eb3abd7a6bed0d48909f22c3c1b0fa4e70460354dc8700a7dd8475aff026061dR618-R619) [[7]](diffhunk://#diff-e384602a1509f3538b8dc4379eec79f9eda68d2994c44ec58c29583da5c57e4bR618-R619) [[8]](diffhunk://#diff-176f05b6abedc9e7880d4ed22413ca5c6b41f830a638582cd3eaffecf4ebcf4cR618-R619) [[9]](diffhunk://#diff-b799d7eb879fabaf02950f3f21cf5b9cdd7b1cbf50039f1076570753d35946c5R618-R619) [[10]](diffhunk://#diff-5540ab968f171eb495e54200ccd528d6517ef32f2d4d447a031a7242d7074700R618-R619) [[11]](diffhunk://#diff-d351c7198f36a210b77113a1c9f074b7e9b44cc7ac9da77dd00f1a30d8204bacR618-R619)
* Improved `linkingPartialFailureMessage` for treatments in all languages, providing users with clear instructions when some items could not be linked automatically. [[1]](diffhunk://#diff-33c499047fc22cc766f0d8b1be2a6103ce9c582c107b84d8219031120f04bd7aL1168-R1170) [[2]](diffhunk://#diff-2e67589bc551d2f12ba1499b32925674c0611ff673460af46437902cab5f058eL1168-R1170) [[3]](diffhunk://#diff-7f4d6bada4d4e07a00f12836e045c0d3337f22b8b4cee8a62ec4d4d807f084a5L1168-R1170) [[4]](diffhunk://#diff-e384602a1509f3538b8dc4379eec79f9eda68d2994c44ec58c29583da5c57e4bL1168-R1170) [[5]](diffhunk://#diff-176f05b6abedc9e7880d4ed22413ca5c6b41f830a638582cd3eaffecf4ebcf4cL1168-R1170) [[6]](diffhunk://#diff-b799d7eb879fabaf02950f3f21cf5b9cdd7b1cbf50039f1076570753d35946c5L1168-R1170) [[7]](diffhunk://#diff-d351c7198f36a210b77113a1c9f074b7e9b44cc7ac9da77dd00f1a30d8204bacL1168-R1170)
* Added or updated the `dateTimePlaceholder` in the vitals form for all languages, ensuring users see a helpful prompt when entering date and time. [[1]](diffhunk://#diff-33c499047fc22cc766f0d8b1be2a6103ce9c582c107b84d8219031120f04bd7aL1275-R1277) [[2]](diffhunk://#diff-2e67589bc551d2f12ba1499b32925674c0611ff673460af46437902cab5f058eL1275-R1277) [[3]](diffhunk://#diff-7f4d6bada4d4e07a00f12836e045c0d3337f22b8b4cee8a62ec4d4d807f084a5L1275-R1277) [[4]](diffhunk://#diff-eb3abd7a6bed0d48909f22c3c1b0fa4e70460354dc8700a7dd8475aff026061dL1275-R1277) [[5]](diffhunk://#diff-e384602a1509f3538b8dc4379eec79f9eda68d2994c44ec58c29583da5c57e4bL1275-R1277) [[6]](diffhunk://#diff-176f05b6abedc9e7880d4ed22413ca5c6b41f830a638582cd3eaffecf4ebcf4cL1275-R1277) [[7]](diffhunk://#diff-b799d7eb879fabaf02950f3f21cf5b9cdd7b1cbf50039f1076570753d35946c5L1275-R1277) [[8]](diffhunk://#diff-d351c7198f36a210b77113a1c9f074b7e9b44cc7ac9da77dd00f1a30d8204bacL1275-R1277)

**Test suite improvements for translation key consistency:**

* Updated test assertions in `translationKeys.test.js` to reflect new or renamed keys, such as checking for `linkMedicationsToCondition` and `selectMedications` instead of their singular forms.
* Adjusted the test to check for `placeholder` instead of `label` for patient name fields, matching the updated translation structure.
* Modified symptom and lab result translation tests to reference the correct namespaces (`medical` vs `common`) after the i18n refactor, and updated lab result test descriptions for clarity.
* Changed treatment-related test assertions to expect `description` fields for `startDate` and `endDate` instead of `label`, aligning with the translation file updates.