### PR TITLE
fix(i18n): implement virtual module for bundling English locale JSONs

### DIFF
--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -7,20 +7,28 @@ import { isDevelopment } from '../config/env';
 // Bundle English translations so the fallback language is always available synchronously.
 // This eliminates the race condition where components render before HTTP-loaded translations
 // arrive, which caused translation keys to flash in the UI.
-import commonEn from '../../public/locales/en/common.json';
-import medicalEn from '../../public/locales/en/medical.json';
-import adminEn from '../../public/locales/en/admin.json';
-import errorsEn from '../../public/locales/en/errors.json';
-import navigationEn from '../../public/locales/en/navigation.json';
-import notificationsEn from '../../public/locales/en/notifications.json';
-import sharedEn from '../../public/locales/en/shared.json';
-import authEn from '../../public/locales/en/auth.json';
-import settingsEn from '../../public/locales/en/settings.json';
-import reportsEn from '../../public/locales/en/reports.json';
-import labresultsEn from '../../public/locales/en/labresults.json';
-import vitalsEn from '../../public/locales/en/vitals.json';
-import invitationsEn from '../../public/locales/en/invitations.json';
-import documentsEn from '../../public/locales/en/documents.json';
+// The JSONs live in public/locales/en so the HTTP backend can serve other languages from
+// the same tree; the `virtual:bundled-en-locales` module (see vite.config.ts) reads them
+// at build time so they can be bundled without violating Vite's public/ import rule.
+// @ts-expect-error - virtual module provided by Vite plugin
+import bundledEn from 'virtual:bundled-en-locales';
+
+const {
+  common: commonEn,
+  medical: medicalEn,
+  admin: adminEn,
+  errors: errorsEn,
+  navigation: navigationEn,
+  notifications: notificationsEn,
+  shared: sharedEn,
+  auth: authEn,
+  settings: settingsEn,
+  reports: reportsEn,
+  labresults: labresultsEn,
+  vitals: vitalsEn,
+  invitations: invitationsEn,
+  documents: documentsEn,
+} = bundledEn as Record<string, Record<string, unknown>>;
 
 i18n
   .use(HttpBackend)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,28 @@ export default defineConfig({
     }),
     svgr(), // Allows importing SVGs as React components
     tsconfigPaths(), // Respects tsconfig baseUrl: "src"
+    // Expose English locale JSONs (which live in public/locales/en so the HTTP backend
+    // can serve other languages from the same tree) as a virtual module so they can be
+    // bundled synchronously by the i18n config without triggering Vite's
+    // "no imports from public/" restriction.
+    {
+      name: 'bundled-en-locales',
+      resolveId(id) {
+        if (id === 'virtual:bundled-en-locales') return '\0' + id;
+        return null;
+      },
+      load(id) {
+        if (id !== '\0virtual:bundled-en-locales') return null;
+        const dir = path.resolve(__dirname, 'public/locales/en');
+        const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+        const entries = files.map((f) => {
+          const ns = f.replace(/\.json$/, '');
+          const content = fs.readFileSync(path.join(dir, f), 'utf-8');
+          return `  ${JSON.stringify(ns)}: ${content}`;
+        });
+        return `export default {\n${entries.join(',\n')}\n};\n`;
+      },
+    },
     // Inject build version into service-worker.js so the browser detects SW updates
     {
       name: 'sw-version-inject',


### PR DESCRIPTION
This pull request updates how English locale JSON files are bundled and imported in the frontend, ensuring synchronous availability of translations and compliance with Vite's import restrictions. The changes introduce a custom Vite plugin to expose the English locales as a virtual module, simplifying and improving the i18n configuration.

**Internationalization improvements:**

* Added a custom Vite plugin in `vite.config.ts` to expose English locale JSON files from `public/locales/en` as a virtual module (`virtual:bundled-en-locales`), allowing them to be bundled synchronously without violating Vite's restriction on importing from `public/`.
* Updated `i18n/config.ts` to import all English locale namespaces from the new virtual module instead of directly importing each JSON file, simplifying the import logic and ensuring all translations are available synchronously.- 