### PR TITLE
feat: labs visit creation linkage

### DIFF
--- a/frontend/src/components/medical/MantineVisitForm.jsx
+++ b/frontend/src/components/medical/MantineVisitForm.jsx
@@ -12,6 +12,7 @@ import {
   Textarea,
   NumberInput,
   Text,
+  MultiSelect,
 } from '@mantine/core';
 import { DateInput } from '@mantine/dates';
 import {
@@ -274,11 +275,9 @@ const MantineVisitForm = ({
                   ? t('shared:tabs.documents', 'Documents')
                   : t('shared:tabs.addFiles', 'Add Files')}
               </Tabs.Tab>
-              {editingVisit && fetchEncounterLabResults && (
-                <Tabs.Tab value="lab-results" leftSection={<IconFlask size={16} />}>
-                  {t('shared:categories.lab_results', 'Lab Results')}
-                </Tabs.Tab>
-              )}
+              <Tabs.Tab value="lab-results" leftSection={<IconFlask size={16} />}>
+                {t('shared:categories.lab_results', 'Lab Results')}
+              </Tabs.Tab>
               <Tabs.Tab value="notes" leftSection={<IconNotes size={16} />}>
                 {t('shared:tabs.notes', 'Notes')}
               </Tabs.Tab>
@@ -322,9 +321,9 @@ const MantineVisitForm = ({
             </Tabs.Panel>
 
             {/* Lab Results Tab */}
-            {editingVisit && fetchEncounterLabResults && (
-              <Tabs.Panel value="lab-results">
-                <Box mt="md">
+            <Tabs.Panel value="lab-results">
+              <Box mt="md">
+                {editingVisit && fetchEncounterLabResults ? (
                   <EncounterLabResultRelationships
                     encounterId={editingVisit.id}
                     encounterLabResults={encounterLabResults}
@@ -332,9 +331,30 @@ const MantineVisitForm = ({
                     fetchEncounterLabResults={fetchEncounterLabResults}
                     navigate={navigate}
                   />
-                </Box>
-              </Tabs.Panel>
-            )}
+                ) : (
+                  <>
+                    <Text size="sm" c="dimmed" mb="md">
+                      {t('common:visits.form.labResultsDescription', 'Link lab results relevant to this visit. You can set purpose and notes after creating the visit.')}
+                    </Text>
+                    <MultiSelect
+                      label={t('common:visits.form.selectLabResults', 'Select Lab Results')}
+                      placeholder={t('common:visits.form.chooseLabResultsToLink', 'Choose lab results to link')}
+                      data={(labResults || []).map(lr => ({
+                        value: lr.id.toString(),
+                        label: `${lr.test_name}${lr.ordered_date ? ` (${lr.ordered_date})` : ''}${lr.status ? ` - ${lr.status}` : ''}`,
+                      }))}
+                      value={formData.pending_lab_result_ids || []}
+                      onChange={(values) => {
+                        onInputChange({ target: { name: 'pending_lab_result_ids', value: values } });
+                      }}
+                      searchable
+                      clearable
+                      comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+                    />
+                  </>
+                )}
+              </Box>
+            </Tabs.Panel>
 
             {/* Notes Tab */}
             <Tabs.Panel value="notes">

--- a/frontend/src/components/medical/MantineVisitForm.jsx
+++ b/frontend/src/components/medical/MantineVisitForm.jsx
@@ -332,26 +332,22 @@ const MantineVisitForm = ({
                     navigate={navigate}
                   />
                 ) : (
-                  <>
-                    <Text size="sm" c="dimmed" mb="md">
-                      {t('common:visits.form.labResultsDescription', 'Link lab results relevant to this visit. You can set purpose and notes after creating the visit.')}
-                    </Text>
-                    <MultiSelect
-                      label={t('common:visits.form.selectLabResults', 'Select Lab Results')}
-                      placeholder={t('common:visits.form.chooseLabResultsToLink', 'Choose lab results to link')}
-                      data={(labResults || []).map(lr => ({
-                        value: lr.id.toString(),
-                        label: `${lr.test_name}${lr.ordered_date ? ` (${lr.ordered_date})` : ''}${lr.status ? ` - ${lr.status}` : ''}`,
-                      }))}
-                      value={formData.pending_lab_result_ids || []}
-                      onChange={(values) => {
-                        onInputChange({ target: { name: 'pending_lab_result_ids', value: values } });
-                      }}
-                      searchable
-                      clearable
-                      comboboxProps={{ withinPortal: true, zIndex: 3000 }}
-                    />
-                  </>
+                  <MultiSelect
+                    label={t('common:visits.form.selectLabResults', 'Select Lab Results')}
+                    placeholder={t('common:visits.form.chooseLabResultsToLink', 'Choose lab results to link')}
+                    description={t('common:visits.form.labResultsDescription', 'Link lab results relevant to this visit. You can set purpose and notes after creating the visit.')}
+                    data={(labResults || []).map(lr => ({
+                      value: lr.id.toString(),
+                      label: `${lr.test_name}${lr.ordered_date ? ` (${lr.ordered_date})` : ''}${lr.status ? ` - ${lr.status}` : ''}`,
+                    }))}
+                    value={formData.pending_lab_result_ids || []}
+                    onChange={(values) => {
+                      onInputChange({ target: { name: 'pending_lab_result_ids', value: values } });
+                    }}
+                    searchable
+                    clearable
+                    comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+                  />
                 )}
               </Box>
             </Tabs.Panel>

--- a/frontend/src/pages/medical/Visits.jsx
+++ b/frontend/src/pages/medical/Visits.jsx
@@ -8,6 +8,7 @@ import {
   IconPlus,
   IconShieldCheck,
 } from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
 import { useTranslation } from 'react-i18next';
 import { useMedicalData } from '../../hooks/useMedicalData';
 import { useDataManagement } from '../../hooks/useDataManagement';
@@ -250,6 +251,7 @@ const Visits = () => {
     location: '',
     priority: '',
     tags: [],
+    pending_lab_result_ids: [],
   });
 
   const handleAddVisit = () => {
@@ -271,6 +273,7 @@ const Visits = () => {
       location: '',
       priority: '',
       tags: [],
+      pending_lab_result_ids: [],
     });
     setShowModal(true);
   };
@@ -294,6 +297,7 @@ const Visits = () => {
       location: visit.location || '',
       priority: visit.priority || '',
       tags: visit.tags || [],
+      pending_lab_result_ids: [],
     });
     setShowModal(true);
   };
@@ -380,6 +384,31 @@ const Visits = () => {
       completeFormSubmission(success, resultId);
 
       if (success && resultId) {
+        // Link pending lab results for new visits
+        const pendingLabResults = formData.pending_lab_result_ids || [];
+        if (!editingVisit && pendingLabResults.length > 0) {
+          try {
+            await apiService.linkEncounterLabResultsBulk(resultId, {
+              lab_result_ids: pendingLabResults.map(id => parseInt(id)),
+              purpose: null,
+              relevance_note: null,
+            });
+            await fetchEncounterLabResults(resultId);
+          } catch (err) {
+            logger.error('visits_lab_result_link_failed', {
+              message: 'Failed to link lab results to new visit',
+              visitId: resultId,
+              error: err.message,
+              component: 'Visits',
+            });
+            notifications.show({
+              title: t('visits.notifications.labResultLinkWarning', 'Lab Result Linking Issue'),
+              message: t('visits.notifications.labResultLinkFailed', 'Visit was created, but some lab results could not be linked. You can link them manually by editing the visit.'),
+              color: 'yellow',
+            });
+          }
+        }
+
         // Check if we have files to upload
         const hasPendingFiles = documentManagerMethods?.hasPendingFiles?.();
         

--- a/frontend/src/pages/medical/Visits.jsx
+++ b/frontend/src/pages/medical/Visits.jsx
@@ -379,16 +379,17 @@ const Visits = () => {
         }
       }
 
-      // Complete form submission
-      completeFormSubmission(success, resultId);
+      // Link pending lab results for new visits before completing submission,
+      // so the form stays in a blocking state until linking finishes.
+      if (success && resultId && !editingVisit) {
+        const labResultIds = (formData.pending_lab_result_ids || [])
+          .map(id => parseInt(id, 10))
+          .filter(id => Number.isInteger(id) && id > 0);
 
-      if (success && resultId) {
-        // Link pending lab results for new visits
-        const pendingLabResults = formData.pending_lab_result_ids || [];
-        if (!editingVisit && pendingLabResults.length > 0) {
+        if (labResultIds.length > 0) {
           try {
             await apiService.linkEncounterLabResultsBulk(resultId, {
-              lab_result_ids: pendingLabResults.map(id => parseInt(id)),
+              lab_result_ids: labResultIds,
               purpose: null,
               relevance_note: null,
             });
@@ -406,7 +407,12 @@ const Visits = () => {
             });
           }
         }
+      }
 
+      // Complete form submission
+      completeFormSubmission(success, resultId);
+
+      if (success && resultId) {
         // Check if we have files to upload
         const hasPendingFiles = documentManagerMethods?.hasPendingFiles?.();
         

--- a/frontend/src/pages/medical/Visits.jsx
+++ b/frontend/src/pages/medical/Visits.jsx
@@ -297,7 +297,6 @@ const Visits = () => {
       location: visit.location || '',
       priority: visit.priority || '',
       tags: visit.tags || [],
-      pending_lab_result_ids: [],
     });
     setShowModal(true);
   };
@@ -393,7 +392,6 @@ const Visits = () => {
               purpose: null,
               relevance_note: null,
             });
-            await fetchEncounterLabResults(resultId);
           } catch (err) {
             logger.error('visits_lab_result_link_failed', {
               message: 'Failed to link lab results to new visit',


### PR DESCRIPTION
This pull request updates the visit creation and editing workflow to allow users to link lab results to a visit at the time of creation, improving usability and reducing manual work later. The most significant changes are the addition of a `MultiSelect` component for selecting lab results when creating a new visit, and the backend logic to bulk-link these results upon visit creation.

**User Experience Improvements:**

* Added a `MultiSelect` input to the "Lab Results" tab in `MantineVisitForm` for new visits, allowing users to select and link lab results during visit creation. For existing visits, the previous interface remains. [[1]](diffhunk://#diff-f8854d7f7161198fd74d5ca904558b2766ef9f65b229399692f00d80d1a39cb5R15) [[2]](diffhunk://#diff-f8854d7f7161198fd74d5ca904558b2766ef9f65b229399692f00d80d1a39cb5L325-L337)

**Form Data and State Management:**

* Updated initial form state in `Visits.jsx` to include a `pending_lab_result_ids` array, ensuring selected lab results are tracked for new visits. [[1]](diffhunk://#diff-c14e40f798ef267de7b4a200fdfba5d78b9216c22fe3d752a118b4157eecf4e3R254) [[2]](diffhunk://#diff-c14e40f798ef267de7b4a200fdfba5d78b9216c22fe3d752a118b4157eecf4e3R276)

**Backend Integration:**

* Implemented logic in `Visits.jsx` to call a new `linkEncounterLabResultsBulk` API after creating a new visit, linking all selected lab results. Error handling and user notifications are provided if any linking fails. [[1]](diffhunk://#diff-c14e40f798ef267de7b4a200fdfba5d78b9216c22fe3d752a118b4157eecf4e3R386-R409) [[2]](diffhunk://#diff-c14e40f798ef267de7b4a200fdfba5d78b9216c22fe3d752a118b4157eecf4e3R11)

**UI Consistency:**

* Adjusted tab rendering in `MantineVisitForm` to always show the "Lab Results" tab, ensuring users can access lab result linking for both new and existing visits.

These changes streamline the process of associating lab results with visits and improve the overall workflow for users managing medical records.