### PR TITLE
fix(patient_sharing): correct pending invitation check in patient sharing logic

### DIFF
--- a/app/services/patient_sharing.py
+++ b/app/services/patient_sharing.py
@@ -494,14 +494,18 @@ class PatientSharingService:
         if existing_share:
             raise AlreadySharedError("Patient already shared with this user")
 
-        # Check for existing pending invitations using database-level JSON filtering
-        existing_invitation = self.db.query(Invitation).filter(
+        pending_invitations = self.db.query(Invitation).filter(
             Invitation.invitation_type == 'patient_share',
             Invitation.sent_by_user_id == owner.id,
             Invitation.sent_to_user_id == recipient.id,
             Invitation.status == 'pending',
-            sa.func.json_extract(Invitation.context_data, '$.patient_id').cast(sa.Integer) == patient_id
-        ).first()
+        ).all()
+
+        existing_invitation = next(
+            (inv for inv in pending_invitations
+             if inv.context_data.get("patient_id") == patient_id),
+            None
+        )
 
         if existing_invitation:
             raise PendingInvitationError("Pending invitation already exists for this patient and user")


### PR DESCRIPTION
This pull request updates the logic for checking pending patient share invitations to improve compatibility and reliability. The main change is how the code checks for existing pending invitations by filtering in Python rather than relying on database-level JSON filtering.

**Improvements to invitation checking logic:**

* Changed the pending invitation check in `send_patient_share_invitation` in `patient_sharing.py` to first retrieve all pending invitations with matching user and type, then filter by `patient_id` in Python instead of using a database JSON filter. This increases compatibility and avoids potential issues with database-specific JSON functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logic for patient sharing invitation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->