### PR TITLE
fix(PatientSelector): refine patient badge logic to include ownership check

### DIFF
--- a/frontend/src/components/medical/PatientSelector.jsx
+++ b/frontend/src/components/medical/PatientSelector.jsx
@@ -604,7 +604,7 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
    * Get patient type badge
    */
   const getPatientBadge = (patient) => {
-    if (patient.is_self_record) {
+    if (patient.is_self_record && isPatientOwned(patient)) {
       return (
         <Badge size="xs" color="blue" variant="light">
           <IconUserCheck size="0.7rem" style={{ marginRight: 4 }} />


### PR DESCRIPTION
This pull request makes a small change to the `PatientSelector` component to improve how the patient type badge is displayed. Now, the self-record badge is only shown if the patient both is a self-record and is owned by the current user.

* Only show the self-record badge in `PatientSelector` if the patient is both a self-record and owned by the user (`frontend/src/components/medical/PatientSelector.jsx`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated patient badge logic to ensure the "Self" badge appears only under the correct conditions. The badge now requires additional verification to display accurately alongside the patient ownership status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->