### PR TITLE
feat: enhance patient access verification across endpoints

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -555,10 +555,9 @@ def get_current_user_patient_id(
         # ensure_active_patient already verified ownership
         return resolved.id
 
-    # Verify the active patient exists and belongs to this user
+    # Verify the active patient exists and user has access (owned or shared)
     patient_record = db.query(Patient).filter(
         Patient.id == user.active_patient_id,
-        Patient.owner_user_id == current_user_id
     ).first()
 
     if not patient_record:
@@ -567,7 +566,20 @@ def get_current_user_patient_id(
             request=None
         )
 
-    return patient_record.id
+    # Owner always has access
+    if patient_record.owner_user_id == current_user_id:
+        return patient_record.id
+
+    # Check shared access
+    from app.services.patient_access import PatientAccessService
+    access_service = PatientAccessService(db)
+    if access_service.can_access_patient(user, patient_record, "view"):
+        return patient_record.id
+
+    raise NotFoundException(
+        message="Active patient record not found",
+        request=None
+    )
 
 
 def verify_patient_record_access(

--- a/app/api/v1/endpoints/allergy.py
+++ b/app/api/v1/endpoints/allergy.py
@@ -39,6 +39,8 @@ def create_allergy(
     db: Session = Depends(deps.get_db),
     allergy_in: AllergyCreate,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """
     Create new allergy record.
@@ -51,6 +53,8 @@ def create_allergy(
         user_id=current_user_id,
         entity_name="Allergy",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -159,6 +163,7 @@ def read_allergy(
     allergy_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """
     Get allergy by ID with related information - only allows access to user's own allergies.
@@ -169,7 +174,7 @@ def read_allergy(
             db=db, record_id=allergy_id, relations=["patient", "medication"]
         )
         handle_not_found(allergy_obj, "Allergy", request)
-        verify_patient_ownership(allergy_obj, current_user_patient_id, "allergy")
+        verify_patient_ownership(allergy_obj, current_user_patient_id, "allergy", db=db, current_user=current_user)
 
         log_data_access(
             logger,

--- a/app/api/v1/endpoints/condition.py
+++ b/app/api/v1/endpoints/condition.py
@@ -192,7 +192,7 @@ def get_condition_medications(
             "read",
             "ConditionMedication",
             record_id=condition_id,
-            patient_id=current_user_patient_id,
+            patient_id=db_condition.patient_id,
             count=len(relationships)
         )
 
@@ -295,7 +295,7 @@ def create_condition_medication(
             "create",
             "ConditionMedication",
             record_id=relationship.id,
-            patient_id=current_user_patient_id,
+            patient_id=db_condition.patient_id,
             condition_id=condition_id,
             medication_id=medication_in.medication_id
         )
@@ -388,7 +388,7 @@ def create_condition_medications_bulk(
             current_user_id,
             "create",
             "ConditionMedication",
-            patient_id=current_user_patient_id,
+            patient_id=db_condition.patient_id,
             condition_id=condition_id,
             created_count=len(created),
             skipped_count=len(skipped)
@@ -650,7 +650,7 @@ def read_condition(
             "read",
             "Condition",
             record_id=condition_id,
-            patient_id=current_user_patient_id
+            patient_id=condition_obj.patient_id
         )
 
         return condition_obj

--- a/app/api/v1/endpoints/condition.py
+++ b/app/api/v1/endpoints/condition.py
@@ -51,6 +51,8 @@ def create_condition(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new condition."""
     return handle_create_with_logging(
@@ -61,6 +63,8 @@ def create_condition(
         user_id=current_user_id,
         entity_name="Condition",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -154,6 +158,7 @@ def get_condition_medications(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ):
     """Simple endpoint to get medications for a condition."""
     with handle_database_errors(request=request):
@@ -173,21 +178,10 @@ def get_condition_medications(
                 request=request
             )
 
-        # Verify condition belongs to current user
-        if db_condition.patient_id != current_user_patient_id:
-            log_security_event(
-                logger,
-                "unauthorized_condition_access",
-                request,
-                f"User attempted to access condition {condition_id} without permission",
-                user_id=current_user_id,
-                condition_id=condition_id
-            )
-            raise NotFoundException(
-                resource="Condition",
-                message="Condition not found",
-                request=request
-            )
+        verify_patient_ownership(
+            db_condition, current_user_patient_id, "condition",
+            db=db, current_user=current_user
+        )
 
         relationships = condition_medication.get_by_condition(db, condition_id=condition_id)
 
@@ -221,6 +215,7 @@ def create_condition_medication(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Create a new condition medication relationship."""
     with handle_database_errors(request=request):
@@ -240,21 +235,10 @@ def create_condition_medication(
                 request=request
             )
 
-        # Verify condition belongs to current user
-        if db_condition.patient_id != current_user_patient_id:
-            log_security_event(
-                logger,
-                "unauthorized_condition_access",
-                request,
-                f"User attempted to access condition {condition_id} without permission",
-                user_id=current_user_id,
-                condition_id=condition_id
-            )
-            raise NotFoundException(
-                resource="Condition",
-                message="Condition not found",
-                request=request
-            )
+        verify_patient_ownership(
+            db_condition, current_user_patient_id, "condition",
+            db=db, current_user=current_user
+        )
 
         # Verify medication exists and belongs to the same patient
         db_medication = medication_crud.get(db, id=medication_in.medication_id)
@@ -273,7 +257,7 @@ def create_condition_medication(
             )
 
         # Ensure medication belongs to the same patient as the condition
-        if db_medication.patient_id != current_user_patient_id:
+        if db_medication.patient_id != db_condition.patient_id:
             log_security_event(
                 logger,
                 "cross_patient_medication_link",
@@ -328,6 +312,7 @@ def create_condition_medications_bulk(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Create multiple condition medication relationships at once.
 
@@ -355,21 +340,10 @@ def create_condition_medications_bulk(
                 request=request
             )
 
-        # Verify condition belongs to current user
-        if db_condition.patient_id != current_user_patient_id:
-            log_security_event(
-                logger,
-                "unauthorized_condition_access",
-                request,
-                f"User attempted to access condition {condition_id} without permission",
-                user_id=current_user_id,
-                condition_id=condition_id
-            )
-            raise NotFoundException(
-                resource="Condition",
-                message="Condition not found",
-                request=request
-            )
+        verify_patient_ownership(
+            db_condition, current_user_patient_id, "condition",
+            db=db, current_user=current_user
+        )
 
         # Verify all medications exist and belong to the same patient
         for med_id in bulk_data.medication_ids:
@@ -388,7 +362,7 @@ def create_condition_medications_bulk(
                     request=request
                 )
 
-            if db_medication.patient_id != current_user_patient_id:
+            if db_medication.patient_id != db_condition.patient_id:
                 log_security_event(
                     logger,
                     "cross_patient_medication_link",
@@ -656,6 +630,7 @@ def read_condition(
     condition_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get condition by ID with related information - only allows access to user's own conditions."""
     with handle_database_errors(request=request):
@@ -666,7 +641,7 @@ def read_condition(
             relations=["patient", "practitioner", "treatments"],
         )
         handle_not_found(condition_obj, "Condition")
-        verify_patient_ownership(condition_obj, current_user_patient_id, "condition")
+        verify_patient_ownership(condition_obj, current_user_patient_id, "condition", db=db, current_user=current_user)
 
         log_data_access(
             logger,

--- a/app/api/v1/endpoints/condition.py
+++ b/app/api/v1/endpoints/condition.py
@@ -237,7 +237,7 @@ def create_condition_medication(
 
         verify_patient_ownership(
             db_condition, current_user_patient_id, "condition",
-            db=db, current_user=current_user
+            db=db, current_user=current_user, permission='edit'
         )
 
         # Verify medication exists and belongs to the same patient
@@ -342,7 +342,7 @@ def create_condition_medications_bulk(
 
         verify_patient_ownership(
             db_condition, current_user_patient_id, "condition",
-            db=db, current_user=current_user
+            db=db, current_user=current_user, permission='edit'
         )
 
         # Verify all medications exist and belong to the same patient

--- a/app/api/v1/endpoints/emergency_contact.py
+++ b/app/api/v1/endpoints/emergency_contact.py
@@ -38,9 +38,21 @@ def create_emergency_contact(
     db: Session = Depends(deps.get_db),
     emergency_contact_in: EmergencyContactCreate,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     target_patient_id: int = Depends(deps.get_accessible_patient_id),
 ) -> Any:
     """Create new emergency contact."""
+    # Verify user has edit permission (get_accessible_patient_id only checks 'view')
+    deps.verify_patient_record_access(
+        record_patient_id=target_patient_id,
+        current_user_patient_id=current_user_patient_id,
+        record_type="emergency_contact",
+        db=db,
+        current_user=current_user,
+        permission='edit',
+    )
+
     # Use the specialized method that handles patient_id properly
     emergency_contact_obj = emergency_contact.create_for_patient(
         db=db, patient_id=target_patient_id, obj_in=emergency_contact_in

--- a/app/api/v1/endpoints/encounter.py
+++ b/app/api/v1/endpoints/encounter.py
@@ -47,6 +47,8 @@ def create_encounter(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new encounter."""
     return handle_create_with_logging(
@@ -57,6 +59,8 @@ def create_encounter(
         user_id=current_user_id,
         entity_name="Encounter",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -124,6 +128,7 @@ def read_encounter(
     encounter_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get encounter by ID with related information - only allows access to user's own encounters."""
     with handle_database_errors(request=request):
@@ -131,7 +136,7 @@ def read_encounter(
             db=db, record_id=encounter_id, relations=["patient", "practitioner", "condition"]
         )
         handle_not_found(encounter_obj, "Encounter", request)
-        verify_patient_ownership(encounter_obj, current_user_patient_id, "encounter")
+        verify_patient_ownership(encounter_obj, current_user_patient_id, "encounter", db=db, current_user=current_user)
 
         log_data_access(
             logger,
@@ -267,12 +272,13 @@ def get_encounter_lab_results(
     encounter_id: int,
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all lab result relationships for a specific encounter."""
     with handle_database_errors(request=request):
         db_encounter = encounter.get(db, id=encounter_id)
         handle_not_found(db_encounter, "Encounter", request)
-        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter")
+        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter", db=db, current_user=current_user)
 
         results = encounter_lab_result.get_by_encounter_with_details(
             db, encounter_id=encounter_id
@@ -308,17 +314,18 @@ def create_encounter_lab_result(
     link_in: EncounterLabResultCreate,
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link a lab result to an encounter."""
     with handle_database_errors(request=request):
         db_encounter = encounter.get(db, id=encounter_id)
         handle_not_found(db_encounter, "Encounter", request)
-        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter")
+        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter", db=db, current_user=current_user, permission='edit')
 
         db_lab = lab_result.get(db, id=link_in.lab_result_id)
         handle_not_found(db_lab, "Lab result", request)
 
-        if db_lab.patient_id != current_user_patient_id:
+        if db_lab.patient_id != db_encounter.patient_id:
             raise BusinessLogicException(
                 message="Cannot link lab result that doesn't belong to the same patient",
                 request=request,
@@ -357,17 +364,18 @@ def bulk_create_encounter_lab_results(
     bulk_in: EncounterLabResultBulkCreate,
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Bulk link lab results to an encounter."""
     with handle_database_errors(request=request):
         db_encounter = encounter.get(db, id=encounter_id)
         handle_not_found(db_encounter, "Encounter", request)
-        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter")
+        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter", db=db, current_user=current_user, permission='edit')
 
         for lr_id in bulk_in.lab_result_ids:
             db_lab = lab_result.get(db, id=lr_id)
             handle_not_found(db_lab, "Lab result", request)
-            if db_lab.patient_id != current_user_patient_id:
+            if db_lab.patient_id != db_encounter.patient_id:
                 raise BusinessLogicException(
                     message=f"Lab result {lr_id} doesn't belong to the same patient",
                     request=request,
@@ -395,12 +403,13 @@ def update_encounter_lab_result(
     link_in: EncounterLabResultUpdate,
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Update an encounter-lab result relationship."""
     with handle_database_errors(request=request):
         db_encounter = encounter.get(db, id=encounter_id)
         handle_not_found(db_encounter, "Encounter", request)
-        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter")
+        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter", db=db, current_user=current_user, permission='edit')
 
         relationship = encounter_lab_result.get(db, id=relationship_id)
         handle_not_found(relationship, "Encounter lab result relationship", request)
@@ -423,12 +432,13 @@ def delete_encounter_lab_result(
     relationship_id: int,
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Unlink a lab result from an encounter."""
     with handle_database_errors(request=request):
         db_encounter = encounter.get(db, id=encounter_id)
         handle_not_found(db_encounter, "Encounter", request)
-        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter")
+        verify_patient_ownership(db_encounter, current_user_patient_id, "encounter", db=db, current_user=current_user, permission='edit')
 
         relationship = encounter_lab_result.get(db, id=relationship_id)
         handle_not_found(relationship, "Encounter lab result relationship", request)

--- a/app/api/v1/endpoints/entity_file.py
+++ b/app/api/v1/endpoints/entity_file.py
@@ -238,6 +238,7 @@ async def create_pending_file_record(
     storage_backend: Optional[str] = Form(None),
     current_user_id: int = Depends(deps.get_current_user_id),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> EntityFileResponse:
     """
     Create a pending file record without actual file upload.
@@ -260,7 +261,7 @@ async def create_pending_file_record(
         # Get the parent entity (lab-result, procedure, etc.) and verify ownership
         parent_entity = get_entity_by_type_and_id(db, entity_type, entity_id)
         handle_not_found(parent_entity, entity_type)
-        verify_patient_ownership(parent_entity, current_user_patient_id, entity_type)
+        verify_patient_ownership(parent_entity, current_user_patient_id, entity_type, db=db, current_user=current_user, permission='edit')
 
         log_endpoint_access(
             logger,
@@ -338,6 +339,7 @@ async def update_file_upload_status(
     paperless_document_id: Optional[str] = Form(None),
     current_user_id: int = Depends(deps.get_current_user_id),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> EntityFileResponse:
     """
     Update the upload status of a pending file record.
@@ -355,11 +357,11 @@ async def update_file_upload_status(
         # Get file record first to check authorization
         file_record = file_service.get_file_by_id(db, file_id)
         handle_not_found(file_record, "File")
-        
+
         # Get the parent entity and verify ownership
         parent_entity = get_entity_by_type_and_id(db, file_record.entity_type, file_record.entity_id)
         handle_not_found(parent_entity, file_record.entity_type)
-        verify_patient_ownership(parent_entity, current_user_patient_id, file_record.entity_type)
+        verify_patient_ownership(parent_entity, current_user_patient_id, file_record.entity_type, db=db, current_user=current_user, permission='edit')
 
         log_endpoint_access(
             logger,

--- a/app/api/v1/endpoints/family_member.py
+++ b/app/api/v1/endpoints/family_member.py
@@ -42,6 +42,8 @@ def create_family_member(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new family member."""
     return handle_create_with_logging(
@@ -52,6 +54,8 @@ def create_family_member(
         user_id=current_user_id,
         entity_name="Family Member",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -91,9 +95,11 @@ def get_family_members_for_dropdown(
 @router.get("/{family_member_id}", response_model=FamilyMemberResponse)
 def read_family_member(
     *,
+    request: Request,
     db: Session = Depends(deps.get_db),
     family_member_id: int,
     target_patient_id: int = Depends(deps.get_accessible_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get family member by ID with conditions - supports patient switching."""
     family_member_obj = family_member.get_with_relations(
@@ -102,7 +108,7 @@ def read_family_member(
         relations=["family_conditions"],
     )
     handle_not_found(family_member_obj, "Family Member", request)
-    verify_patient_ownership(family_member_obj, target_patient_id, "family_member")
+    verify_patient_ownership(family_member_obj, target_patient_id, "family_member", db=db, current_user=current_user)
     return family_member_obj
 
 
@@ -183,13 +189,14 @@ def get_family_member_conditions(
     family_member_id: int,
     db: Session = Depends(deps.get_db),
     target_patient_id: int = Depends(deps.get_accessible_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all conditions for a specific family member - supports patient switching."""
     with handle_database_errors(request=request):
         # Verify family member exists and belongs to the accessible patient
         family_member_obj = family_member.get(db, id=family_member_id)
         handle_not_found(family_member_obj, "Family Member", request)
-        verify_patient_ownership(family_member_obj, target_patient_id, "family_member")
+        verify_patient_ownership(family_member_obj, target_patient_id, "family_member", db=db, current_user=current_user)
         
         # Get conditions
         conditions = family_condition.get_by_family_member(db, family_member_id=family_member_id)
@@ -205,13 +212,14 @@ def create_family_condition(
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
     target_patient_id: int = Depends(deps.get_accessible_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Create a new condition for a family member - supports patient switching."""
     with handle_database_errors(request=request):
         # Verify family member exists and belongs to the accessible patient
         family_member_obj = family_member.get(db, id=family_member_id)
         handle_not_found(family_member_obj, "Family Member", request)
-        verify_patient_ownership(family_member_obj, target_patient_id, "family_member")
+        verify_patient_ownership(family_member_obj, target_patient_id, "family_member", db=db, current_user=current_user, permission='edit')
         
         # Set family_member_id
         condition_in.family_member_id = family_member_id

--- a/app/api/v1/endpoints/immunization.py
+++ b/app/api/v1/endpoints/immunization.py
@@ -40,6 +40,8 @@ def create_immunization(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new immunization record."""
     return handle_create_with_logging(
@@ -50,6 +52,8 @@ def create_immunization(
         user_id=current_user_id,
         entity_name="Immunization",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -128,6 +132,7 @@ def read_immunization(
     immunization_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get immunization by ID - only allows access to user's own immunizations.
 
@@ -137,7 +142,7 @@ def read_immunization(
     with handle_database_errors(request=request):
         immunization_obj = immunization.get(db=db, id=immunization_id)
         handle_not_found(immunization_obj, "Immunization", request)
-        verify_patient_ownership(immunization_obj, current_user_patient_id, "immunization")
+        verify_patient_ownership(immunization_obj, current_user_patient_id, "immunization", db=db, current_user=current_user)
 
         log_data_access(
             logger,

--- a/app/api/v1/endpoints/injury.py
+++ b/app/api/v1/endpoints/injury.py
@@ -68,6 +68,8 @@ def create_injury(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create a new injury record."""
     injury_obj = handle_create_with_logging(
@@ -78,6 +80,8 @@ def create_injury(
         user_id=current_user_id,
         entity_name="Injury",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
     # Return with relationships loaded
@@ -151,12 +155,13 @@ def read_injury(
     injury_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get an injury by ID with related information."""
     with handle_database_errors(request=request):
         injury_obj = injury.get_with_relations(db=db, record_id=injury_id)
         handle_not_found(injury_obj, "Injury")
-        verify_patient_ownership(injury_obj, current_user_patient_id, "injury")
+        verify_patient_ownership(injury_obj, current_user_patient_id, "injury", db=db, current_user=current_user)
 
         log_data_access(
             logger,
@@ -235,13 +240,14 @@ def get_injury_medications(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all medications linked to an injury."""
     with handle_database_errors(request=request):
         # Verify injury exists and belongs to user
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user)
 
         relationships = injury_medication.get_by_injury(db, injury_id=injury_id)
 
@@ -281,18 +287,19 @@ def create_injury_medication(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link a medication to an injury."""
     with handle_database_errors(request=request):
         # Verify injury exists and belongs to user
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user, permission='edit')
 
         # Verify medication exists and belongs to same patient
         db_medication = medication_crud.get(db, id=medication_in.medication_id)
         handle_not_found(db_medication, "Medication")
-        if db_medication.patient_id != current_user_patient_id:
+        if db_medication.patient_id != db_injury.patient_id:
             raise BusinessLogicException(
                 message="Cannot link medication that belongs to a different patient",
                 request=request
@@ -329,13 +336,14 @@ def delete_injury_medication(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Unlink a medication from an injury."""
     with handle_database_errors(request=request):
         # Verify injury exists and belongs to user
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user, permission='edit')
 
         success = injury_medication.delete_by_injury_and_medication(
             db, injury_id=injury_id, medication_id=medication_id
@@ -367,12 +375,13 @@ def get_injury_conditions(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all conditions linked to an injury."""
     with handle_database_errors(request=request):
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user)
 
         relationships = injury_condition.get_by_injury(db, injury_id=injury_id)
 
@@ -411,16 +420,17 @@ def create_injury_condition(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link a condition to an injury."""
     with handle_database_errors(request=request):
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user, permission='edit')
 
         db_condition = condition_crud.get(db, id=condition_in.condition_id)
         handle_not_found(db_condition, "Condition")
-        if db_condition.patient_id != current_user_patient_id:
+        if db_condition.patient_id != db_injury.patient_id:
             raise BusinessLogicException(
                 message="Cannot link condition that belongs to a different patient",
                 request=request
@@ -456,12 +466,13 @@ def delete_injury_condition(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Unlink a condition from an injury."""
     with handle_database_errors(request=request):
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user, permission='edit')
 
         success = injury_condition.delete_by_injury_and_condition(
             db, injury_id=injury_id, condition_id=condition_id
@@ -493,12 +504,13 @@ def get_injury_treatments(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all treatments linked to an injury."""
     with handle_database_errors(request=request):
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user)
 
         relationships = injury_treatment.get_by_injury(db, injury_id=injury_id)
 
@@ -536,16 +548,17 @@ def create_injury_treatment(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link a treatment to an injury."""
     with handle_database_errors(request=request):
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user, permission='edit')
 
         db_treatment = treatment_crud.get(db, id=treatment_in.treatment_id)
         handle_not_found(db_treatment, "Treatment")
-        if db_treatment.patient_id != current_user_patient_id:
+        if db_treatment.patient_id != db_injury.patient_id:
             raise BusinessLogicException(
                 message="Cannot link treatment that belongs to a different patient",
                 request=request
@@ -581,12 +594,13 @@ def delete_injury_treatment(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Unlink a treatment from an injury."""
     with handle_database_errors(request=request):
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user, permission='edit')
 
         success = injury_treatment.delete_by_injury_and_treatment(
             db, injury_id=injury_id, treatment_id=treatment_id
@@ -618,12 +632,13 @@ def get_injury_procedures(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all procedures linked to an injury."""
     with handle_database_errors(request=request):
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user)
 
         relationships = injury_procedure.get_by_injury(db, injury_id=injury_id)
 
@@ -661,16 +676,17 @@ def create_injury_procedure(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link a procedure to an injury."""
     with handle_database_errors(request=request):
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user, permission='edit')
 
         db_procedure = procedure_crud.get(db, id=procedure_in.procedure_id)
         handle_not_found(db_procedure, "Procedure")
-        if db_procedure.patient_id != current_user_patient_id:
+        if db_procedure.patient_id != db_injury.patient_id:
             raise BusinessLogicException(
                 message="Cannot link procedure that belongs to a different patient",
                 request=request
@@ -706,12 +722,13 @@ def delete_injury_procedure(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Unlink a procedure from an injury."""
     with handle_database_errors(request=request):
         db_injury = injury.get(db, id=injury_id)
         handle_not_found(db_injury, "Injury")
-        verify_patient_ownership(db_injury, current_user_patient_id, "injury")
+        verify_patient_ownership(db_injury, current_user_patient_id, "injury", db=db, current_user=current_user, permission='edit')
 
         success = injury_procedure.delete_by_injury_and_procedure(
             db, injury_id=injury_id, procedure_id=procedure_id

--- a/app/api/v1/endpoints/insurance.py
+++ b/app/api/v1/endpoints/insurance.py
@@ -43,6 +43,8 @@ def create_insurance(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new insurance record."""
     insurance_obj = handle_create_with_logging(
@@ -53,6 +55,8 @@ def create_insurance(
         user_id=current_user_id,
         entity_name="Insurance",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
     return insurance_obj
@@ -174,6 +178,7 @@ def get_insurance(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get insurance record by ID."""
     with handle_database_errors(request=request):
@@ -182,7 +187,7 @@ def get_insurance(
 
         # Verify patient ownership using current user's patient record
         verify_patient_ownership(
-            insurance_obj, current_user_patient_id, "insurance"
+            insurance_obj, current_user_patient_id, "insurance", db=db, current_user=current_user
         )
 
         log_data_access(
@@ -294,7 +299,7 @@ def set_primary_insurance(
         insurance_obj = insurance.get(db=db, id=insurance_id)
         handle_not_found(insurance_obj, "Insurance", request)
 
-        verify_patient_ownership(insurance_obj, target_patient_id, "insurance")
+        verify_patient_ownership(insurance_obj, target_patient_id, "insurance", db=db, current_user=current_user, permission='edit')
 
         # Set as primary
         updated_insurance = insurance.set_primary(

--- a/app/api/v1/endpoints/lab_result.py
+++ b/app/api/v1/endpoints/lab_result.py
@@ -30,6 +30,7 @@ from app.api.v1.endpoints.utils import (
     handle_delete_with_logging,
     handle_not_found,
     handle_update_with_logging,
+    verify_patient_ownership,
 )
 from app.core.config import settings
 from app.core.database.database import get_db
@@ -233,6 +234,8 @@ def create_lab_result(
     request: Request,
     db: Session = Depends(get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ):
     """Create a new lab result."""
     return handle_create_with_logging(
@@ -243,6 +246,8 @@ def create_lab_result(
         user_id=current_user_id,
         entity_name="Lab result",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -892,6 +897,7 @@ def create_lab_result_condition(
     condition_in: LabResultConditionCreate,
     db: Session = Depends(get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ):
     """Create a new lab result condition relationship."""
     with handle_database_errors(request=request):
@@ -899,18 +905,17 @@ def create_lab_result_condition(
         db_lab_result = lab_result.get(db, id=lab_result_id)
         handle_not_found(db_lab_result, "Lab result", request)
 
-        if db_lab_result.patient_id != current_user_patient_id:
-            raise ForbiddenException(
-                message="Access denied to this lab result",
-                request=request
-            )
+        verify_patient_ownership(
+            db_lab_result, current_user_patient_id, "lab_result",
+            db=db, current_user=current_user
+        )
 
         # Verify condition exists and belongs to the same patient
         db_condition = condition_crud.get(db, id=condition_in.condition_id)
         handle_not_found(db_condition, "Condition", request)
 
         # Ensure condition belongs to the same patient as the lab result
-        if db_condition.patient_id != current_user_patient_id:
+        if db_condition.patient_id != db_lab_result.patient_id:
             raise BusinessLogicException(
                 message="Cannot link condition that doesn't belong to the same patient",
                 request=request
@@ -946,6 +951,7 @@ def update_lab_result_condition(
     condition_in: LabResultConditionUpdate,
     db: Session = Depends(get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ):
     """Update a lab result condition relationship."""
     with handle_database_errors(request=request):
@@ -953,11 +959,10 @@ def update_lab_result_condition(
         db_lab_result = lab_result.get(db, id=lab_result_id)
         handle_not_found(db_lab_result, "Lab result", request)
 
-        if db_lab_result.patient_id != current_user_patient_id:
-            raise ForbiddenException(
-                message="Access denied to this lab result",
-                request=request
-            )
+        verify_patient_ownership(
+            db_lab_result, current_user_patient_id, "lab_result",
+            db=db, current_user=current_user
+        )
 
         # Verify relationship exists
         relationship = lab_result_condition.get(db, id=relationship_id)
@@ -984,6 +989,7 @@ def delete_lab_result_condition(
     relationship_id: int,
     db: Session = Depends(get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ):
     """Delete a lab result condition relationship."""
     with handle_database_errors(request=request):
@@ -991,11 +997,10 @@ def delete_lab_result_condition(
         db_lab_result = lab_result.get(db, id=lab_result_id)
         handle_not_found(db_lab_result, "Lab result", request)
 
-        if db_lab_result.patient_id != current_user_patient_id:
-            raise ForbiddenException(
-                message="Access denied to this lab result",
-                request=request
-            )
+        verify_patient_ownership(
+            db_lab_result, current_user_patient_id, "lab_result",
+            db=db, current_user=current_user
+        )
 
         # Verify relationship exists
         relationship = lab_result_condition.get(db, id=relationship_id)
@@ -1025,17 +1030,17 @@ def get_lab_result_encounters(
     lab_result_id: int,
     db: Session = Depends(get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ):
     """Get all encounter relationships for a specific lab result."""
     with handle_database_errors(request=request):
         db_lab_result = lab_result.get(db, id=lab_result_id)
         handle_not_found(db_lab_result, "Lab result", request)
 
-        if db_lab_result.patient_id != current_user_patient_id:
-            raise ForbiddenException(
-                message="Access denied to this lab result",
-                request=request,
-            )
+        verify_patient_ownership(
+            db_lab_result, current_user_patient_id, "lab_result",
+            db=db, current_user=current_user
+        )
 
         results = encounter_lab_result.get_by_lab_result_with_details(
             db, lab_result_id=lab_result_id
@@ -1071,23 +1076,23 @@ def create_lab_result_encounter(
     link_in: LabResultEncounterCreate,
     db: Session = Depends(get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ):
     """Link an encounter to a lab result."""
     with handle_database_errors(request=request):
         db_lab_result = lab_result.get(db, id=lab_result_id)
         handle_not_found(db_lab_result, "Lab result", request)
 
-        if db_lab_result.patient_id != current_user_patient_id:
-            raise ForbiddenException(
-                message="Access denied to this lab result",
-                request=request,
-            )
+        verify_patient_ownership(
+            db_lab_result, current_user_patient_id, "lab_result",
+            db=db, current_user=current_user
+        )
 
         encounter_id = link_in.encounter_id
         db_enc = encounter_crud.get(db, id=encounter_id)
         handle_not_found(db_enc, "Encounter", request)
 
-        if db_enc.patient_id != current_user_patient_id:
+        if db_enc.patient_id != db_lab_result.patient_id:
             raise BusinessLogicException(
                 message="Cannot link encounter that doesn't belong to the same patient",
                 request=request,
@@ -1126,23 +1131,23 @@ def bulk_create_lab_result_encounters(
     bulk_in: LabResultEncounterBulkCreate,
     db: Session = Depends(get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ):
     """Bulk link encounters to a lab result."""
     with handle_database_errors(request=request):
         db_lab_result = lab_result.get(db, id=lab_result_id)
         handle_not_found(db_lab_result, "Lab result", request)
 
-        if db_lab_result.patient_id != current_user_patient_id:
-            raise ForbiddenException(
-                message="Access denied to this lab result",
-                request=request,
-            )
+        verify_patient_ownership(
+            db_lab_result, current_user_patient_id, "lab_result",
+            db=db, current_user=current_user
+        )
 
         encounter_ids = bulk_in.encounter_ids
         for enc_id in encounter_ids:
             db_enc = encounter_crud.get(db, id=enc_id)
             handle_not_found(db_enc, "Encounter", request)
-            if db_enc.patient_id != current_user_patient_id:
+            if db_enc.patient_id != db_lab_result.patient_id:
                 raise BusinessLogicException(
                     message=f"Encounter {enc_id} doesn't belong to the same patient",
                     request=request,
@@ -1182,17 +1187,17 @@ def update_lab_result_encounter(
     link_in: EncounterLabResultUpdate,
     db: Session = Depends(get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ):
     """Update a lab result-encounter relationship."""
     with handle_database_errors(request=request):
         db_lab_result = lab_result.get(db, id=lab_result_id)
         handle_not_found(db_lab_result, "Lab result", request)
 
-        if db_lab_result.patient_id != current_user_patient_id:
-            raise ForbiddenException(
-                message="Access denied to this lab result",
-                request=request,
-            )
+        verify_patient_ownership(
+            db_lab_result, current_user_patient_id, "lab_result",
+            db=db, current_user=current_user
+        )
 
         relationship = encounter_lab_result.get(db, id=relationship_id)
         handle_not_found(relationship, "Lab result encounter relationship", request)
@@ -1215,17 +1220,17 @@ def delete_lab_result_encounter(
     relationship_id: int,
     db: Session = Depends(get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
+    current_user: User = Depends(deps.get_current_user),
 ):
     """Unlink an encounter from a lab result."""
     with handle_database_errors(request=request):
         db_lab_result = lab_result.get(db, id=lab_result_id)
         handle_not_found(db_lab_result, "Lab result", request)
 
-        if db_lab_result.patient_id != current_user_patient_id:
-            raise ForbiddenException(
-                message="Access denied to this lab result",
-                request=request,
-            )
+        verify_patient_ownership(
+            db_lab_result, current_user_patient_id, "lab_result",
+            db=db, current_user=current_user
+        )
 
         relationship = encounter_lab_result.get(db, id=relationship_id)
         handle_not_found(relationship, "Lab result encounter relationship", request)

--- a/app/api/v1/endpoints/lab_result.py
+++ b/app/api/v1/endpoints/lab_result.py
@@ -907,7 +907,7 @@ def create_lab_result_condition(
 
         verify_patient_ownership(
             db_lab_result, current_user_patient_id, "lab_result",
-            db=db, current_user=current_user
+            db=db, current_user=current_user, permission='edit'
         )
 
         # Verify condition exists and belongs to the same patient
@@ -961,7 +961,7 @@ def update_lab_result_condition(
 
         verify_patient_ownership(
             db_lab_result, current_user_patient_id, "lab_result",
-            db=db, current_user=current_user
+            db=db, current_user=current_user, permission='edit'
         )
 
         # Verify relationship exists
@@ -999,7 +999,7 @@ def delete_lab_result_condition(
 
         verify_patient_ownership(
             db_lab_result, current_user_patient_id, "lab_result",
-            db=db, current_user=current_user
+            db=db, current_user=current_user, permission='edit'
         )
 
         # Verify relationship exists
@@ -1085,7 +1085,7 @@ def create_lab_result_encounter(
 
         verify_patient_ownership(
             db_lab_result, current_user_patient_id, "lab_result",
-            db=db, current_user=current_user
+            db=db, current_user=current_user, permission='edit'
         )
 
         encounter_id = link_in.encounter_id
@@ -1140,7 +1140,7 @@ def bulk_create_lab_result_encounters(
 
         verify_patient_ownership(
             db_lab_result, current_user_patient_id, "lab_result",
-            db=db, current_user=current_user
+            db=db, current_user=current_user, permission='edit'
         )
 
         encounter_ids = bulk_in.encounter_ids
@@ -1196,7 +1196,7 @@ def update_lab_result_encounter(
 
         verify_patient_ownership(
             db_lab_result, current_user_patient_id, "lab_result",
-            db=db, current_user=current_user
+            db=db, current_user=current_user, permission='edit'
         )
 
         relationship = encounter_lab_result.get(db, id=relationship_id)
@@ -1229,7 +1229,7 @@ def delete_lab_result_encounter(
 
         verify_patient_ownership(
             db_lab_result, current_user_patient_id, "lab_result",
-            db=db, current_user=current_user
+            db=db, current_user=current_user, permission='edit'
         )
 
         relationship = encounter_lab_result.get(db, id=relationship_id)

--- a/app/api/v1/endpoints/medical_equipment.py
+++ b/app/api/v1/endpoints/medical_equipment.py
@@ -39,6 +39,8 @@ def create_medical_equipment(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new medical equipment record."""
     return handle_create_with_logging(
@@ -49,6 +51,8 @@ def create_medical_equipment(
         user_id=current_user_id,
         entity_name="MedicalEquipment",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -176,6 +180,7 @@ def read_single_equipment(
     equipment_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get medical equipment by ID with related information."""
     with handle_database_errors(request=request):
@@ -185,7 +190,7 @@ def read_single_equipment(
             relations=["patient", "practitioner"],
         )
         handle_not_found(equipment_obj, "MedicalEquipment", request)
-        verify_patient_ownership(equipment_obj, current_user_patient_id, "medical equipment")
+        verify_patient_ownership(equipment_obj, current_user_patient_id, "medical equipment", db=db, current_user=current_user)
 
         log_data_access(
             logger,

--- a/app/api/v1/endpoints/medication.py
+++ b/app/api/v1/endpoints/medication.py
@@ -45,6 +45,8 @@ def create_medication(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new medication."""
     medication_obj = handle_create_with_logging(
@@ -55,6 +57,8 @@ def create_medication(
         user_id=current_user_id,
         entity_name="Medication",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
     # Return with relationships loaded
@@ -167,6 +171,7 @@ def read_medication(
     medication_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get medication by ID - only allows access to user's own medications."""
     with handle_database_errors(request=request):
@@ -174,7 +179,7 @@ def read_medication(
             db=db, record_id=medication_id, relations=["practitioner", "pharmacy", "condition"]
         )
         handle_not_found(medication_obj, "Medication", request)
-        verify_patient_ownership(medication_obj, current_user_patient_id, "medication")
+        verify_patient_ownership(medication_obj, current_user_patient_id, "medication", db=db, current_user=current_user)
 
         log_data_access(
             logger,
@@ -289,6 +294,7 @@ def get_medication_treatments(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all treatments that use a specific medication."""
     with handle_database_errors(request=request):
@@ -299,11 +305,10 @@ def get_medication_treatments(
                 message="Medication not found",
                 request=request,
             )
-        if medication_obj.patient_id != current_user_patient_id:
-            raise ForbiddenException(
-                message="Not authorized to access this medication",
-                request=request,
-            )
+        verify_patient_ownership(
+            medication_obj, current_user_patient_id, "medication",
+            db=db, current_user=current_user,
+        )
 
         relationships = treatment_medication.get_by_medication(db, medication_id=medication_id)
 

--- a/app/api/v1/endpoints/patient_management.py
+++ b/app/api/v1/endpoints/patient_management.py
@@ -134,6 +134,7 @@ class PatientResponse(BaseModel):
     owner_user_id: int
     is_self_record: bool
     privacy_level: str
+    permission_level: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -144,6 +145,18 @@ class PatientListResponse(BaseModel):
     total_count: int
     owned_count: int
     shared_count: int
+
+
+def _build_patient_response(
+    access_service: PatientAccessService,
+    current_user: User,
+    patient: Patient,
+) -> PatientResponse:
+    """Build a PatientResponse with permission_level populated."""
+    response = PatientResponse.model_validate(patient)
+    context = access_service.get_patient_context(current_user, patient)
+    response.permission_level = context['permission_level']
+    return response
 
 
 class SharingStatsResponse(BaseModel):
@@ -208,7 +221,9 @@ def create_patient(
             is_self_record=patient_in.is_self_record
         )
         
-        return PatientResponse.model_validate(patient)
+        response = PatientResponse.model_validate(patient)
+        response.permission_level = 'full'
+        return response
 
 
 @router.get("/", response_model=PatientListResponse)
@@ -239,9 +254,12 @@ def get_accessible_patients(
         owned_count = len(owned_patients)
         shared_count = total_count - owned_count
         
-        # Convert to response format
-        patient_responses = [PatientResponse.model_validate(p) for p in accessible_patients]
-        
+        # Convert to response format with permission levels
+        patient_responses = [
+            _build_patient_response(access_service, current_user, p)
+            for p in accessible_patients
+        ]
+
         return PatientListResponse(
             patients=patient_responses,
             total_count=total_count,
@@ -264,7 +282,12 @@ def get_owned_patients(
         service = PatientManagementService(db)
         patients = service.get_owned_patients(current_user)
 
-        return [PatientResponse.model_validate(p) for p in patients]
+        responses = []
+        for p in patients:
+            response = PatientResponse.model_validate(p)
+            response.permission_level = 'full'
+            responses.append(response)
+        return responses
 
 
 @router.get("/self-record", response_model=Optional[PatientResponse])
@@ -284,7 +307,9 @@ def get_self_record(
         patient = service.get_self_record(current_user)
 
         if patient:
-            return PatientResponse.model_validate(patient)
+            response = PatientResponse.model_validate(patient)
+            response.permission_level = 'full'
+            return response
         else:
             return None
 
@@ -323,7 +348,8 @@ def switch_active_patient(
             patient_id=switch_request.patient_id
         )
 
-        return PatientResponse.model_validate(patient)
+        access_service = PatientAccessService(db)
+        return _build_patient_response(access_service, current_user, patient)
 
 
 @router.get("/active/current", response_model=Optional[PatientResponse])
@@ -343,7 +369,8 @@ def get_active_patient(
         patient = service.get_active_patient(current_user)
 
         if patient:
-            return PatientResponse.model_validate(patient)
+            access_service = PatientAccessService(db)
+            return _build_patient_response(access_service, current_user, patient)
         else:
             return None
 
@@ -397,7 +424,8 @@ def get_patient(
                 request=request
             )
 
-        return PatientResponse.model_validate(patient)
+        access_service = PatientAccessService(db)
+        return _build_patient_response(access_service, current_user, patient)
 
 
 @router.put("/{patient_id}", response_model=PatientResponse)
@@ -471,7 +499,7 @@ def update_patient(
             patient_id=patient_id
         )
 
-        return PatientResponse.model_validate(patient)
+        return _build_patient_response(access_service, current_user, patient)
 
 
 @router.delete("/{patient_id}")

--- a/app/api/v1/endpoints/procedure.py
+++ b/app/api/v1/endpoints/procedure.py
@@ -40,6 +40,8 @@ def create_procedure(
     db: Session = Depends(deps.get_db),
     procedure_in: ProcedureCreate,
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """
     Create new procedure.
@@ -52,6 +54,8 @@ def create_procedure(
         user_id=current_user_id,
         entity_name="Procedure",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -127,6 +131,7 @@ def read_procedure(
     procedure_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """
     Get procedure by ID with related information - only allows access to user's own procedures.
@@ -136,7 +141,7 @@ def read_procedure(
             db=db, record_id=procedure_id, relations=["patient", "practitioner", "condition"]
         )
         handle_not_found(procedure_obj, "Procedure", request)
-        verify_patient_ownership(procedure_obj, current_user_patient_id, "procedure")
+        verify_patient_ownership(procedure_obj, current_user_patient_id, "procedure", db=db, current_user=current_user)
 
         log_data_access(
             logger,

--- a/app/api/v1/endpoints/symptom.py
+++ b/app/api/v1/endpoints/symptom.py
@@ -41,6 +41,8 @@ def create_symptom(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new symptom definition (parent)."""
     return handle_create_with_logging(
@@ -51,6 +53,8 @@ def create_symptom(
         user_id=current_user_id,
         entity_name="Symptom",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 

--- a/app/api/v1/endpoints/treatment.py
+++ b/app/api/v1/endpoints/treatment.py
@@ -211,7 +211,7 @@ def read_treatment(
             "read",
             "Treatment",
             record_id=treatment_id,
-            patient_id=current_user_patient_id
+            patient_id=treatment_obj.patient_id
         )
 
         return treatment_obj

--- a/app/api/v1/endpoints/treatment.py
+++ b/app/api/v1/endpoints/treatment.py
@@ -362,6 +362,7 @@ def _verify_treatment_access(
     current_user_id: int,
     request: Request,
     current_user: User = None,
+    permission: str = 'view',
 ):
     """Helper to verify treatment exists and user has access."""
     db_treatment = treatment.get(db, id=treatment_id)
@@ -380,7 +381,7 @@ def _verify_treatment_access(
         )
     verify_patient_ownership(
         db_treatment, current_user_patient_id, "treatment",
-        db=db, current_user=current_user
+        db=db, current_user=current_user, permission=permission
     )
     return db_treatment
 
@@ -393,10 +394,11 @@ def get_treatment_medications(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all medications linked to a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user)
 
         relationships = treatment_medication.get_by_treatment(db, treatment_id=treatment_id)
 
@@ -490,10 +492,11 @@ def create_treatment_medication(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link a medication to a treatment."""
     with handle_database_errors(request=request):
-        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         # Verify medication exists and belongs to same patient
         db_medication = medication_crud.get(db, id=medication_in.medication_id)
@@ -535,10 +538,11 @@ def create_treatment_medications_bulk(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link multiple medications to a treatment at once."""
     with handle_database_errors(request=request):
-        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         # Verify all medications exist and belong to same patient
         for med_id in bulk_data.medication_ids:
@@ -583,10 +587,11 @@ def update_treatment_medication(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Update a treatment medication relationship."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         relationship = treatment_medication.get(db, id=relationship_id)
         if not relationship or relationship.treatment_id != treatment_id:
@@ -620,10 +625,11 @@ def delete_treatment_medication(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Remove a medication link from a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         relationship = treatment_medication.get(db, id=relationship_id)
         if not relationship or relationship.treatment_id != treatment_id:
@@ -661,10 +667,11 @@ def get_treatment_encounters(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all encounters linked to a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user)
 
         relationships = treatment_encounter.get_by_treatment(db, treatment_id=treatment_id)
 
@@ -713,10 +720,11 @@ def create_treatment_encounter(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link an encounter to a treatment."""
     with handle_database_errors(request=request):
-        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         # Verify encounter exists and belongs to same patient
         db_encounter = encounter_crud.get(db, id=encounter_in.encounter_id)
@@ -758,10 +766,11 @@ def create_treatment_encounters_bulk(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link multiple encounters to a treatment at once."""
     with handle_database_errors(request=request):
-        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         # Verify all encounters exist and belong to same patient
         for enc_id in bulk_data.encounter_ids:
@@ -806,10 +815,11 @@ def update_treatment_encounter(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Update a treatment encounter relationship."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         relationship = treatment_encounter.get(db, id=relationship_id)
         if not relationship or relationship.treatment_id != treatment_id:
@@ -843,10 +853,11 @@ def delete_treatment_encounter(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Remove an encounter link from a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         relationship = treatment_encounter.get(db, id=relationship_id)
         if not relationship or relationship.treatment_id != treatment_id:
@@ -884,10 +895,11 @@ def get_treatment_lab_results(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all lab results linked to a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user)
 
         relationships = treatment_lab_result.get_by_treatment(db, treatment_id=treatment_id)
 
@@ -937,10 +949,11 @@ def create_treatment_lab_result(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link a lab result to a treatment."""
     with handle_database_errors(request=request):
-        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         # Verify lab result exists and belongs to same patient
         db_lab_result = lab_result_crud.get(db, id=lab_result_in.lab_result_id)
@@ -982,10 +995,11 @@ def create_treatment_lab_results_bulk(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link multiple lab results to a treatment at once."""
     with handle_database_errors(request=request):
-        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         # Verify all lab results exist and belong to same patient
         for lab_id in bulk_data.lab_result_ids:
@@ -1030,10 +1044,11 @@ def update_treatment_lab_result(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Update a treatment lab result relationship."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         relationship = treatment_lab_result.get(db, id=relationship_id)
         if not relationship or relationship.treatment_id != treatment_id:
@@ -1067,10 +1082,11 @@ def delete_treatment_lab_result(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Remove a lab result link from a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         relationship = treatment_lab_result.get(db, id=relationship_id)
         if not relationship or relationship.treatment_id != treatment_id:
@@ -1108,10 +1124,11 @@ def get_treatment_equipment(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get all equipment linked to a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user)
 
         relationships = treatment_equipment.get_by_treatment(db, treatment_id=treatment_id)
 
@@ -1161,10 +1178,11 @@ def create_treatment_equipment_link(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link equipment to a treatment."""
     with handle_database_errors(request=request):
-        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         # Verify equipment exists and belongs to same patient
         db_equipment = equipment_crud.get(db, id=equipment_in.equipment_id)
@@ -1206,10 +1224,11 @@ def create_treatment_equipment_bulk(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Link multiple equipment to a treatment at once."""
     with handle_database_errors(request=request):
-        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         # Verify all equipment exists and belongs to same patient
         for eq_id in bulk_data.equipment_ids:
@@ -1254,10 +1273,11 @@ def update_treatment_equipment_link(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Update a treatment equipment relationship."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         relationship = treatment_equipment.get(db, id=relationship_id)
         if not relationship or relationship.treatment_id != treatment_id:
@@ -1291,10 +1311,11 @@ def delete_treatment_equipment_link(
     db: Session = Depends(deps.get_db),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Remove an equipment link from a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request, current_user=current_user, permission='edit')
 
         relationship = treatment_equipment.get(db, id=relationship_id)
         if not relationship or relationship.treatment_id != treatment_id:

--- a/app/api/v1/endpoints/treatment.py
+++ b/app/api/v1/endpoints/treatment.py
@@ -98,6 +98,8 @@ def create_treatment(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new treatment."""
     return handle_create_with_logging(
@@ -108,6 +110,8 @@ def create_treatment(
         user_id=current_user_id,
         entity_name="Treatment",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -188,6 +192,7 @@ def read_treatment(
     treatment_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get treatment by ID with related information - only allows access to user's own treatments."""
     with handle_database_errors(request=request):
@@ -197,7 +202,7 @@ def read_treatment(
             relations=["patient", "practitioner", "condition"],
         )
         handle_not_found(treatment_obj, "Treatment", request)
-        verify_patient_ownership(treatment_obj, current_user_patient_id, "treatment")
+        verify_patient_ownership(treatment_obj, current_user_patient_id, "treatment", db=db, current_user=current_user)
 
         log_data_access(
             logger,
@@ -356,6 +361,7 @@ def _verify_treatment_access(
     current_user_patient_id: int,
     current_user_id: int,
     request: Request,
+    current_user: User = None,
 ):
     """Helper to verify treatment exists and user has access."""
     db_treatment = treatment.get(db, id=treatment_id)
@@ -372,20 +378,10 @@ def _verify_treatment_access(
             message=f"Treatment with ID {treatment_id} not found",
             request=request
         )
-    if db_treatment.patient_id != current_user_patient_id:
-        log_security_event(
-            logger,
-            "unauthorized_treatment_access",
-            request,
-            f"User attempted to access treatment {treatment_id} without permission",
-            user_id=current_user_id,
-            treatment_id=treatment_id
-        )
-        raise NotFoundException(
-            resource="Treatment",
-            message="Treatment not found",
-            request=request
-        )
+    verify_patient_ownership(
+        db_treatment, current_user_patient_id, "treatment",
+        db=db, current_user=current_user
+    )
     return db_treatment
 
 
@@ -497,7 +493,7 @@ def create_treatment_medication(
 ) -> Any:
     """Link a medication to a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
 
         # Verify medication exists and belongs to same patient
         db_medication = medication_crud.get(db, id=medication_in.medication_id)
@@ -507,7 +503,7 @@ def create_treatment_medication(
                 message=f"Medication with ID {medication_in.medication_id} not found",
                 request=request
             )
-        if db_medication.patient_id != current_user_patient_id:
+        if db_medication.patient_id != db_treatment.patient_id:
             raise BusinessLogicException(
                 message="Cannot link medication from a different patient",
                 request=request
@@ -542,7 +538,7 @@ def create_treatment_medications_bulk(
 ) -> Any:
     """Link multiple medications to a treatment at once."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
 
         # Verify all medications exist and belong to same patient
         for med_id in bulk_data.medication_ids:
@@ -553,7 +549,7 @@ def create_treatment_medications_bulk(
                     message=f"Medication with ID {med_id} not found",
                     request=request
                 )
-            if db_medication.patient_id != current_user_patient_id:
+            if db_medication.patient_id != db_treatment.patient_id:
                 raise BusinessLogicException(
                     message="Cannot link medication from a different patient",
                     request=request
@@ -720,7 +716,7 @@ def create_treatment_encounter(
 ) -> Any:
     """Link an encounter to a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
 
         # Verify encounter exists and belongs to same patient
         db_encounter = encounter_crud.get(db, id=encounter_in.encounter_id)
@@ -730,7 +726,7 @@ def create_treatment_encounter(
                 message=f"Encounter with ID {encounter_in.encounter_id} not found",
                 request=request
             )
-        if db_encounter.patient_id != current_user_patient_id:
+        if db_encounter.patient_id != db_treatment.patient_id:
             raise BusinessLogicException(
                 message="Cannot link encounter from a different patient",
                 request=request
@@ -765,7 +761,7 @@ def create_treatment_encounters_bulk(
 ) -> Any:
     """Link multiple encounters to a treatment at once."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
 
         # Verify all encounters exist and belong to same patient
         for enc_id in bulk_data.encounter_ids:
@@ -776,7 +772,7 @@ def create_treatment_encounters_bulk(
                     message=f"Encounter with ID {enc_id} not found",
                     request=request
                 )
-            if db_encounter.patient_id != current_user_patient_id:
+            if db_encounter.patient_id != db_treatment.patient_id:
                 raise BusinessLogicException(
                     message="Cannot link encounter from a different patient",
                     request=request
@@ -944,7 +940,7 @@ def create_treatment_lab_result(
 ) -> Any:
     """Link a lab result to a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
 
         # Verify lab result exists and belongs to same patient
         db_lab_result = lab_result_crud.get(db, id=lab_result_in.lab_result_id)
@@ -954,7 +950,7 @@ def create_treatment_lab_result(
                 message=f"Lab result with ID {lab_result_in.lab_result_id} not found",
                 request=request
             )
-        if db_lab_result.patient_id != current_user_patient_id:
+        if db_lab_result.patient_id != db_treatment.patient_id:
             raise BusinessLogicException(
                 message="Cannot link lab result from a different patient",
                 request=request
@@ -989,7 +985,7 @@ def create_treatment_lab_results_bulk(
 ) -> Any:
     """Link multiple lab results to a treatment at once."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
 
         # Verify all lab results exist and belong to same patient
         for lab_id in bulk_data.lab_result_ids:
@@ -1000,7 +996,7 @@ def create_treatment_lab_results_bulk(
                     message=f"Lab result with ID {lab_id} not found",
                     request=request
                 )
-            if db_lab_result.patient_id != current_user_patient_id:
+            if db_lab_result.patient_id != db_treatment.patient_id:
                 raise BusinessLogicException(
                     message="Cannot link lab result from a different patient",
                     request=request
@@ -1168,7 +1164,7 @@ def create_treatment_equipment_link(
 ) -> Any:
     """Link equipment to a treatment."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
 
         # Verify equipment exists and belongs to same patient
         db_equipment = equipment_crud.get(db, id=equipment_in.equipment_id)
@@ -1178,7 +1174,7 @@ def create_treatment_equipment_link(
                 message=f"Equipment with ID {equipment_in.equipment_id} not found",
                 request=request
             )
-        if db_equipment.patient_id != current_user_patient_id:
+        if db_equipment.patient_id != db_treatment.patient_id:
             raise BusinessLogicException(
                 message="Cannot link equipment from a different patient",
                 request=request
@@ -1213,7 +1209,7 @@ def create_treatment_equipment_bulk(
 ) -> Any:
     """Link multiple equipment to a treatment at once."""
     with handle_database_errors(request=request):
-        _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
+        db_treatment = _verify_treatment_access(db, treatment_id, current_user_patient_id, current_user_id, request)
 
         # Verify all equipment exists and belongs to same patient
         for eq_id in bulk_data.equipment_ids:
@@ -1224,7 +1220,7 @@ def create_treatment_equipment_bulk(
                     message=f"Equipment with ID {eq_id} not found",
                     request=request
                 )
-            if db_equipment.patient_id != current_user_patient_id:
+            if db_equipment.patient_id != db_treatment.patient_id:
                 raise BusinessLogicException(
                     message="Cannot link equipment from a different patient",
                     request=request

--- a/app/api/v1/endpoints/utils.py
+++ b/app/api/v1/endpoints/utils.py
@@ -157,9 +157,12 @@ def handle_create_with_logging(
     user_id: int,
     entity_name: str,
     request: Optional[Request] = None,
+    current_user_patient_id: int = None,
+    current_user: Any = None,
+    permission: str = 'edit',
 ) -> Any:
     """
-    Handle entity creation with standardized logging.
+    Handle entity creation with standardized logging and ownership verification.
 
     Args:
         db: Database session
@@ -169,16 +172,31 @@ def handle_create_with_logging(
         user_id: Current user ID
         entity_name: Name of entity type for logging
         request: Request object for additional logging
+        current_user_patient_id: Current user's patient ID (for ownership verification)
+        current_user: Current user object (for multi-patient access verification)
+        permission: Required permission level (default: 'edit')
 
     Returns:
         Created entity object
 
     Raises:
-        HTTPException: If creation fails
+        HTTPException: If creation fails or user lacks permission
     """
     user_ip = request.client.host if request and request.client else "unknown"
 
     with handle_database_errors(request=request):
+        # SECURITY: Verify user has permission to create records for this patient
+        if current_user_patient_id is not None:
+            if getattr(obj_in, "patient_id", None) is not None:
+                verify_patient_ownership(
+                    obj=obj_in,
+                    current_user_patient_id=current_user_patient_id,
+                    entity_name=entity_name,
+                    db=db,
+                    current_user=current_user,
+                    permission=permission,
+                )
+
         entity_obj = crud_obj.create(db=db, obj_in=obj_in)
         entity_id = getattr(entity_obj, "id", None)
         patient_id = getattr(entity_obj, "patient_id", None)

--- a/app/api/v1/endpoints/vitals.py
+++ b/app/api/v1/endpoints/vitals.py
@@ -68,6 +68,8 @@ def create_vitals(
     request: Request,
     db: Session = Depends(deps.get_db),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
+    current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
 ) -> Any:
     """Create new vitals reading."""
     return handle_create_with_logging(
@@ -78,6 +80,8 @@ def create_vitals(
         user_id=current_user_id,
         entity_name="Vitals",
         request=request,
+        current_user_patient_id=current_user_patient_id,
+        current_user=current_user,
     )
 
 
@@ -450,6 +454,7 @@ def read_vitals_by_id(
     vitals_id: int,
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user_id: int = Depends(deps.get_current_user_id),
+    current_user: User = Depends(deps.get_current_user),
 ) -> Any:
     """Get vitals reading by ID with related information - only allows access to user's own vitals."""
     with handle_database_errors(request=request):
@@ -457,7 +462,7 @@ def read_vitals_by_id(
             db=db, record_id=vitals_id, relations=["patient", "practitioner"]
         )
         handle_not_found(vitals_obj, "Vitals reading", request)
-        verify_patient_ownership(vitals_obj, current_user_patient_id, "vitals")
+        verify_patient_ownership(vitals_obj, current_user_patient_id, "vitals", db=db, current_user=current_user)
 
         log_data_access(
             logger,

--- a/frontend/public/locales/de/shared.json
+++ b/frontend/public/locales/de/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Wöchentlich",
     "weight": "Körpergewicht"
   },
+  "permissions": {
+    "viewOnly": "Nur-Lese-Zugriff"
+  },
   "tabs": {
     "addFiles": "Dateien hinzufügen",
     "administration": "Verwaltung",

--- a/frontend/public/locales/en/shared.json
+++ b/frontend/public/locales/en/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Weekly",
     "weight": "Weight"
   },
+  "permissions": {
+    "viewOnly": "View-only access"
+  },
   "tabs": {
     "addFiles": "Add Files",
     "administration": "Administration",

--- a/frontend/public/locales/es/shared.json
+++ b/frontend/public/locales/es/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Semanal",
     "weight": "Peso"
   },
+  "permissions": {
+    "viewOnly": "Acceso de solo lectura"
+  },
   "tabs": {
     "addFiles": "Agregar archivos",
     "administration": "Administración",

--- a/frontend/public/locales/fr/shared.json
+++ b/frontend/public/locales/fr/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Hebdomadaire",
     "weight": "Poids"
   },
+  "permissions": {
+    "viewOnly": "Accès en lecture seule"
+  },
   "tabs": {
     "addFiles": "Ajouter des fichiers",
     "administration": "Administration",

--- a/frontend/public/locales/it/shared.json
+++ b/frontend/public/locales/it/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Settimanale",
     "weight": "Peso"
   },
+  "permissions": {
+    "viewOnly": "Accesso in sola lettura"
+  },
   "tabs": {
     "addFiles": "Aggiungi file",
     "administration": "Somministrazione",

--- a/frontend/public/locales/nl/shared.json
+++ b/frontend/public/locales/nl/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Wekelijks",
     "weight": "Gewicht"
   },
+  "permissions": {
+    "viewOnly": "Alleen-lezen toegang"
+  },
   "tabs": {
     "addFiles": "Bestanden toevoegen",
     "administration": "Toediening",

--- a/frontend/public/locales/pl/shared.json
+++ b/frontend/public/locales/pl/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Co tydzień",
     "weight": "Waga"
   },
+  "permissions": {
+    "viewOnly": "Dostęp tylko do odczytu"
+  },
   "tabs": {
     "addFiles": "Dodaj pliki",
     "administration": "Administracja",

--- a/frontend/public/locales/pt/shared.json
+++ b/frontend/public/locales/pt/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Semanal",
     "weight": "Peso"
   },
+  "permissions": {
+    "viewOnly": "Acesso somente leitura"
+  },
   "tabs": {
     "addFiles": "Adicionar Arquivos",
     "administration": "Administração",

--- a/frontend/public/locales/ru/shared.json
+++ b/frontend/public/locales/ru/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Еженедельно",
     "weight": "Вес"
   },
+  "permissions": {
+    "viewOnly": "Доступ только для чтения"
+  },
   "tabs": {
     "addFiles": "Добавить файлы",
     "administration": "Администрирование",

--- a/frontend/public/locales/sv/shared.json
+++ b/frontend/public/locales/sv/shared.json
@@ -303,6 +303,9 @@
     "weekly": "Veckovis",
     "weight": "Vikt"
   },
+  "permissions": {
+    "viewOnly": "Skrivskyddad åtkomst"
+  },
   "tabs": {
     "addFiles": "Lägg till filer",
     "administration": "Administration",

--- a/frontend/public/locales/th/shared.json
+++ b/frontend/public/locales/th/shared.json
@@ -303,6 +303,9 @@
     "weekly": "รายสัปดาห์",
     "weight": "น้ำหนัก"
   },
+  "permissions": {
+    "viewOnly": "สิทธิ์ดูอย่างเดียว"
+  },
   "tabs": {
     "addFiles": "เพิ่มไฟล์",
     "administration": "การบริหารจัดการ",

--- a/frontend/public/locales/zh/shared.json
+++ b/frontend/public/locales/zh/shared.json
@@ -303,6 +303,9 @@
     "weekly": "每周",
     "weight": "体重"
   },
+  "permissions": {
+    "viewOnly": "仅查看权限"
+  },
   "tabs": {
     "addFiles": "添加文件",
     "administration": "管理",

--- a/frontend/src/components/adapters/ResponsiveTable.jsx
+++ b/frontend/src/components/adapters/ResponsiveTable.jsx
@@ -1,14 +1,15 @@
 import React, { memo, useMemo, useCallback, useState, useEffect, useRef } from 'react';
-import { 
-  Table as MantineTable, 
-  ScrollArea, 
-  Card, 
-  Group, 
-  Text, 
-  Badge, 
-  Stack, 
+import {
+  Table as MantineTable,
+  ScrollArea,
+  Card,
+  Group,
+  Text,
+  Badge,
+  Stack,
   Pagination,
   ActionIcon,
+  Tooltip,
   rem,
   Box,
   Skeleton,
@@ -76,6 +77,9 @@ export const ResponsiveTable = memo(({
   onView,
   onEdit,
   onDelete,
+  disableEdit = false,
+  disableDelete = false,
+  disableActionsTooltip,
   
   // Styling and behavior
   className = '',
@@ -339,30 +343,36 @@ export const ResponsiveTable = memo(({
           </ActionIcon>
         )}
         {onEdit && (
-          <ActionIcon
-            variant="subtle"
-            color="yellow"
-            size={buttonSize}
-            onClick={() => onEdit(row)}
-            aria-label={t('shared:labels.edit')}
-          >
-            <IconEdit size={iconSize} />
-          </ActionIcon>
+          <Tooltip label={disableActionsTooltip} disabled={!disableEdit || !disableActionsTooltip}>
+            <ActionIcon
+              variant="subtle"
+              color="yellow"
+              size={buttonSize}
+              onClick={() => onEdit(row)}
+              aria-label={t('shared:labels.edit')}
+              disabled={disableEdit}
+            >
+              <IconEdit size={iconSize} />
+            </ActionIcon>
+          </Tooltip>
         )}
         {onDelete && row.id != null && (
-          <ActionIcon
-            variant="subtle"
-            color="red"
-            size={buttonSize}
-            onClick={() => onDelete(row.id)}
-            aria-label={t('buttons.delete')}
-          >
-            <IconTrash size={iconSize} />
-          </ActionIcon>
+          <Tooltip label={disableActionsTooltip} disabled={!disableDelete || !disableActionsTooltip}>
+            <ActionIcon
+              variant="subtle"
+              color="red"
+              size={buttonSize}
+              onClick={() => onDelete(row.id)}
+              aria-label={t('buttons.delete')}
+              disabled={disableDelete}
+            >
+              <IconTrash size={iconSize} />
+            </ActionIcon>
+          </Tooltip>
         )}
       </Group>
     );
-  }, [hasActions, isMobile, onView, onEdit, onDelete, t]);
+  }, [hasActions, isMobile, onView, onEdit, onDelete, disableEdit, disableDelete, disableActionsTooltip, t]);
 
   // Render table headers
   const renderTableHeader = useCallback(() => {

--- a/frontend/src/components/adapters/ResponsiveTable.jsx
+++ b/frontend/src/components/adapters/ResponsiveTable.jsx
@@ -348,9 +348,9 @@ export const ResponsiveTable = memo(({
               variant="subtle"
               color="yellow"
               size={buttonSize}
-              onClick={() => onEdit(row)}
+              data-disabled={disableEdit || undefined}
+              onClick={(event) => { if (disableEdit) { event.preventDefault(); return; } onEdit(row); }}
               aria-label={t('shared:labels.edit')}
-              disabled={disableEdit}
             >
               <IconEdit size={iconSize} />
             </ActionIcon>
@@ -362,9 +362,9 @@ export const ResponsiveTable = memo(({
               variant="subtle"
               color="red"
               size={buttonSize}
-              onClick={() => onDelete(row.id)}
+              data-disabled={disableDelete || undefined}
+              onClick={(event) => { if (disableDelete) { event.preventDefault(); return; } onDelete(row.id); }}
               aria-label={t('buttons.delete')}
-              disabled={disableDelete}
             >
               <IconTrash size={iconSize} />
             </ActionIcon>

--- a/frontend/src/components/medical/allergies/AllergyCard.jsx
+++ b/frontend/src/components/medical/allergies/AllergyCard.jsx
@@ -22,6 +22,8 @@ const AllergyCard = ({
   navigate,
   fileCount = 0,
   fileCountLoading = false,
+  disableActions = false,
+  disableActionsTooltip,
   onError
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -153,6 +155,8 @@ const AllergyCard = ({
         onView={() => onView(allergy)}
         onEdit={() => onEdit(allergy)}
         onDelete={() => onDelete(allergy.id)}
+        disableActions={disableActions}
+        disableActionsTooltip={disableActionsTooltip}
         onError={handleError}
       >
         {customContent}

--- a/frontend/src/components/medical/allergies/AllergyViewModal.jsx
+++ b/frontend/src/components/medical/allergies/AllergyViewModal.jsx
@@ -12,6 +12,7 @@ import {
   SimpleGrid,
   Title,
   Paper,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -38,7 +39,9 @@ const AllergyViewModal = ({
   onEdit,
   medications = [],
   navigate,
-  onError
+  onError,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -327,9 +330,13 @@ const AllergyViewModal = ({
             <Button variant="default" onClick={onClose}>
               {t('shared:labels.close')}
             </Button>
-            <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />}>
-              {t('shared:labels.edit')}
-            </Button>
+            <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+              <span>
+                <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />} disabled={disableEdit}>
+                  {t('shared:labels.edit')}
+                </Button>
+              </span>
+            </Tooltip>
           </Group>
         </Stack>
       </Modal>

--- a/frontend/src/components/medical/base/BaseMedicalCard.jsx
+++ b/frontend/src/components/medical/base/BaseMedicalCard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Card, Stack, Group, Text, Badge, Button, Divider } from '@mantine/core';
+import { Card, Stack, Group, Text, Badge, Button, Divider, Tooltip } from '@mantine/core';
 import StatusBadge from '../StatusBadge';
 import FileCountBadge from '../../shared/FileCountBadge';
 import { ClickableTagBadge } from '../../common/ClickableTagBadge';
@@ -26,6 +26,8 @@ const BaseMedicalCard = ({
   children,
   onError,
   disableCardClick = false,
+  disableActions = false,
+  disableActionsTooltip,
   getTagColor: getTagColorProp
 }) => {
   const { t } = useTranslation(['common', 'shared']);
@@ -175,12 +177,20 @@ const BaseMedicalCard = ({
             <Button variant="filled" size="xs" onClick={safeOnView}>
               {t('buttons.view')}
             </Button>
-            <Button variant="filled" size="xs" onClick={safeOnEdit}>
-              {t('shared:labels.edit')}
-            </Button>
-            <Button variant="filled" color="red" size="xs" onClick={safeOnDelete}>
-              {t('buttons.delete')}
-            </Button>
+            <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
+              <span>
+                <Button variant="filled" size="xs" onClick={safeOnEdit} disabled={disableActions}>
+                  {t('shared:labels.edit')}
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
+              <span>
+                <Button variant="filled" color="red" size="xs" onClick={safeOnDelete} disabled={disableActions}>
+                  {t('buttons.delete')}
+                </Button>
+              </span>
+            </Tooltip>
           </Group>
         </Stack>
       </Card>

--- a/frontend/src/components/medical/conditions/ConditionCard.jsx
+++ b/frontend/src/components/medical/conditions/ConditionCard.jsx
@@ -14,6 +14,8 @@ const ConditionCard = ({
   navigate,
   fileCount = 0,
   fileCountLoading = false,
+  disableActions = false,
+  disableActionsTooltip,
   onError
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -163,6 +165,8 @@ const ConditionCard = ({
         onView={() => onView(condition)}
         onEdit={() => onEdit(condition)}
         onDelete={() => onDelete(condition.id)}
+        disableActions={disableActions}
+        disableActionsTooltip={disableActionsTooltip}
         onError={handleError}
       />
     );

--- a/frontend/src/components/medical/conditions/ConditionViewModal.jsx
+++ b/frontend/src/components/medical/conditions/ConditionViewModal.jsx
@@ -12,6 +12,7 @@ import {
   SimpleGrid,
   Title,
   Paper,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -39,6 +40,8 @@ const ConditionViewModal = ({
   conditionMedications = {},
   fetchConditionMedications,
   navigate,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -341,9 +344,13 @@ const ConditionViewModal = ({
           <Button variant="default" onClick={onClose}>
             {t('shared:labels.close', 'Close')}
           </Button>
-          <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />}>
-            {t('shared:labels.edit', 'Edit')}
-          </Button>
+          <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+            <span>
+              <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />} disabled={disableEdit}>
+                {t('shared:labels.edit', 'Edit')}
+              </Button>
+            </span>
+          </Tooltip>
         </Group>
       </Stack>
     </Modal>

--- a/frontend/src/components/medical/equipment/EquipmentCard.jsx
+++ b/frontend/src/components/medical/equipment/EquipmentCard.jsx
@@ -18,6 +18,8 @@ const EquipmentCard = ({
   onView,
   fileCount = 0,
   fileCountLoading = false,
+  disableActions = false,
+  disableActionsTooltip,
   onError
 }) => {
   const { t } = useTranslation(['common', 'shared']);
@@ -107,6 +109,8 @@ const EquipmentCard = ({
         onView={() => onView(equipment)}
         onEdit={() => onEdit(equipment)}
         onDelete={() => onDelete(equipment.id)}
+        disableActions={disableActions}
+        disableActionsTooltip={disableActionsTooltip}
         onError={handleError}
       />
     );
@@ -135,6 +139,8 @@ EquipmentCard.propTypes = {
   onView: PropTypes.func.isRequired,
   fileCount: PropTypes.number,
   fileCountLoading: PropTypes.bool,
+  disableActions: PropTypes.bool,
+  disableActionsTooltip: PropTypes.string,
   onError: PropTypes.func,
 };
 

--- a/frontend/src/components/medical/equipment/EquipmentViewModal.jsx
+++ b/frontend/src/components/medical/equipment/EquipmentViewModal.jsx
@@ -11,6 +11,7 @@ import {
   SimpleGrid,
   Title,
   Paper,
+  Tooltip,
 } from '@mantine/core';
 import { IconEdit } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
@@ -27,6 +28,8 @@ const EquipmentViewModal = ({
   equipment,
   onEdit,
   practitioners = [],
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -206,9 +209,13 @@ const EquipmentViewModal = ({
           <Button variant="default" onClick={onClose}>
             {t('shared:labels.close', 'Close')}
           </Button>
-          <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />}>
-            {t('shared:labels.edit', 'Edit')}
-          </Button>
+          <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+            <span>
+              <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />} disabled={disableEdit}>
+                {t('shared:labels.edit', 'Edit')}
+              </Button>
+            </span>
+          </Tooltip>
         </Group>
       </Stack>
     </Modal>
@@ -240,6 +247,8 @@ EquipmentViewModal.propTypes = {
     }),
   }),
   onEdit: PropTypes.func.isRequired,
+  disableEdit: PropTypes.bool,
+  disableEditTooltip: PropTypes.string,
   practitioners: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number,

--- a/frontend/src/components/medical/family-history/FamilyHistoryCard.jsx
+++ b/frontend/src/components/medical/family-history/FamilyHistoryCard.jsx
@@ -182,7 +182,7 @@ const FamilyHistoryCard = ({
       e.stopPropagation();
     }
     try {
-      if (member.is_shared) {
+      if (disableActions || member.is_shared) {
         return;
       }
       onAddCondition(member);
@@ -197,7 +197,7 @@ const FamilyHistoryCard = ({
       e.stopPropagation();
     }
     try {
-      if (member.is_shared) {
+      if (disableActions || member.is_shared) {
         return;
       }
       onEditCondition(member, condition);
@@ -212,7 +212,7 @@ const FamilyHistoryCard = ({
       e.stopPropagation();
     }
     try {
-      if (member.is_shared) {
+      if (disableActions || member.is_shared) {
         return;
       }
       onDeleteCondition(member.id, conditionId);
@@ -227,7 +227,7 @@ const FamilyHistoryCard = ({
       e.stopPropagation();
     }
     try {
-      if (member.is_shared) {
+      if (disableActions || member.is_shared) {
         return;
       }
       onShare(member);
@@ -330,7 +330,7 @@ const FamilyHistoryCard = ({
           <Divider mb="md" />
           <Group justify="space-between" mb="md">
             <Text fw={500}>{t('shared:labels.medicalConditions', 'Medical Conditions')}</Text>
-            {!member.is_shared && (
+            {!member.is_shared && !disableActions && (
               <Button
                 size="xs"
                 variant="filled"
@@ -394,7 +394,7 @@ const FamilyHistoryCard = ({
                       )}
                     </div>
 
-                    {!member.is_shared && (
+                    {!member.is_shared && !disableActions && (
                       <Group gap="xs">
                         <Button
                           size="xs"
@@ -432,7 +432,7 @@ const FamilyHistoryCard = ({
             </ActionIcon>
           </Menu.Target>
           <Menu.Dropdown>
-            {!member.is_shared && (
+            {!member.is_shared && !disableActions && (
               <>
                 <Menu.Item
                   leftSection={<IconShare size={14} />}

--- a/frontend/src/components/medical/family-history/FamilyHistoryCard.jsx
+++ b/frontend/src/components/medical/family-history/FamilyHistoryCard.jsx
@@ -58,6 +58,8 @@ const FamilyHistoryCard = ({
   bulkSelectionMode = false,
   isSelected = false,
   onBulkToggle,
+  disableActions = false,
+  disableActionsTooltip,
   onError
 }) => {
   const { t } = useTranslation(['common', 'shared']);
@@ -489,6 +491,8 @@ const FamilyHistoryCard = ({
           onEdit={!member.is_shared ? handleEditClick : undefined}
           onDelete={!member.is_shared ? handleDeleteClick : undefined}
           onError={handleError}
+          disableActions={disableActions}
+          disableActionsTooltip={disableActionsTooltip}
           disableCardClick={bulkSelectionMode}
         >
           {conditionsContent}

--- a/frontend/src/components/medical/family-history/FamilyHistoryViewModal.jsx
+++ b/frontend/src/components/medical/family-history/FamilyHistoryViewModal.jsx
@@ -111,9 +111,11 @@ const FamilyHistoryViewModal = ({
 
   const handleEdit = () => {
     try {
-      if (member.is_shared) {
-        logger.warn('Attempted to edit shared family member from view modal', {
+      if (isReadOnly) {
+        logger.warn('Attempted to edit read-only family member from view modal', {
           memberId: member.id,
+          isShared: member.is_shared,
+          disableEdit,
           component: 'FamilyHistoryViewModal'
         });
         return;
@@ -127,7 +129,7 @@ const FamilyHistoryViewModal = ({
 
   const handleAddCondition = () => {
     try {
-      if (member.is_shared) {
+      if (isReadOnly) {
         return;
       }
       onAddCondition();
@@ -138,7 +140,7 @@ const FamilyHistoryViewModal = ({
 
   const handleEditCondition = (condition) => {
     try {
-      if (member.is_shared) {
+      if (isReadOnly) {
         return;
       }
       onEditCondition(condition);
@@ -149,7 +151,7 @@ const FamilyHistoryViewModal = ({
 
   const handleDeleteCondition = (conditionId) => {
     try {
-      if (member.is_shared) {
+      if (isReadOnly) {
         return;
       }
       onDeleteCondition(member.id, conditionId);
@@ -157,6 +159,8 @@ const FamilyHistoryViewModal = ({
       handleError(error, 'delete_condition');
     }
   };
+
+  const isReadOnly = disableEdit || member?.is_shared;
 
   if (!isOpen || !member) {
     return null;
@@ -216,19 +220,19 @@ const FamilyHistoryViewModal = ({
                 <ActionIcon
                   variant="light"
                   onClick={handleEdit}
-                  disabled={member.is_shared}
+                  disabled={isReadOnly}
                   title={
-                    member.is_shared
+                    isReadOnly
                       ? t('familyHistory.viewModal.cannotEditShared', 'Cannot edit shared family member')
                       : t('familyHistory.viewModal.editMember', 'Edit family member')
                   }
                   aria-label={
-                    member.is_shared
+                    isReadOnly
                       ? t('familyHistory.viewModal.cannotEditShared', 'Cannot edit shared family member')
                       : t('familyHistory.viewModal.editMember', 'Edit family member')
                   }
                   style={
-                    member.is_shared
+                    isReadOnly
                       ? CARD_STYLES.disabledAction
                       : {}
                   }
@@ -289,19 +293,19 @@ const FamilyHistoryViewModal = ({
                 variant="filled"
                 leftSection={<IconStethoscope size={16} />}
                 onClick={handleAddCondition}
-                disabled={member.is_shared}
+                disabled={isReadOnly}
                 title={
-                  member.is_shared
+                  isReadOnly
                     ? t('familyHistory.viewModal.cannotAddConditionsShared', 'Cannot add conditions to shared family member')
                     : t('familyHistory.viewModal.addCondition', 'Add medical condition')
                 }
                 aria-label={
-                  member.is_shared
+                  isReadOnly
                     ? t('familyHistory.viewModal.cannotAddConditionsShared', 'Cannot add conditions to shared family member')
                     : t('familyHistory.viewModal.addCondition', 'Add medical condition')
                 }
                 style={
-                  member.is_shared
+                  isReadOnly
                     ? CARD_STYLES.disabledAction
                     : {}
                 }
@@ -356,19 +360,19 @@ const FamilyHistoryViewModal = ({
                           size="xs"
                           variant="filled"
                           onClick={() => handleEditCondition(condition)}
-                          disabled={member.is_shared}
+                          disabled={isReadOnly}
                           title={
-                            member.is_shared
+                            isReadOnly
                               ? t('familyHistory.viewModal.cannotEditConditionsShared', 'Cannot edit conditions of shared family member')
                               : t('familyHistory.viewModal.editCondition', 'Edit condition')
                           }
                           aria-label={
-                            member.is_shared
+                            isReadOnly
                               ? t('familyHistory.viewModal.cannotEditConditionsShared', 'Cannot edit conditions of shared family member')
                               : t('familyHistory.viewModal.editCondition', 'Edit condition')
                           }
                           style={
-                            member.is_shared
+                            isReadOnly
                               ? CARD_STYLES.disabledAction
                               : {}
                           }
@@ -380,19 +384,19 @@ const FamilyHistoryViewModal = ({
                           variant="filled"
                           color="red"
                           onClick={() => handleDeleteCondition(condition.id)}
-                          disabled={member.is_shared}
+                          disabled={isReadOnly}
                           title={
-                            member.is_shared
+                            isReadOnly
                               ? t('familyHistory.viewModal.cannotDeleteConditionsShared', 'Cannot delete conditions of shared family member')
                               : t('familyHistory.viewModal.deleteCondition', 'Delete condition')
                           }
                           aria-label={
-                            member.is_shared
+                            isReadOnly
                               ? t('familyHistory.viewModal.cannotDeleteConditionsShared', 'Cannot delete conditions of shared family member')
                               : t('familyHistory.viewModal.deleteCondition', 'Delete condition')
                           }
                           style={
-                            member.is_shared
+                            isReadOnly
                               ? CARD_STYLES.disabledAction
                               : {}
                           }
@@ -431,7 +435,7 @@ const FamilyHistoryViewModal = ({
             <Button variant="default" onClick={onClose}>
               {t('shared:labels.close', 'Close')}
             </Button>
-            {!member.is_shared && (
+            {!isReadOnly && (
               <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
                 <span>
                   <Button

--- a/frontend/src/components/medical/family-history/FamilyHistoryViewModal.jsx
+++ b/frontend/src/components/medical/family-history/FamilyHistoryViewModal.jsx
@@ -11,6 +11,7 @@ import {
   ActionIcon,
   Title,
   Paper,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconEdit,
@@ -47,7 +48,9 @@ const FamilyHistoryViewModal = ({
   onAddCondition,
   onEditCondition,
   onDeleteCondition,
-  onError
+  onError,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { colorScheme } = useMantineColorScheme();
@@ -429,13 +432,18 @@ const FamilyHistoryViewModal = ({
               {t('shared:labels.close', 'Close')}
             </Button>
             {!member.is_shared && (
-              <Button
-                variant="filled"
-                onClick={handleEdit}
-                leftSection={<IconEdit size={16} />}
-              >
-                {t('familyHistory.viewModal.editFamilyMember', 'Edit Family Member')}
-              </Button>
+              <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+                <span>
+                  <Button
+                    variant="filled"
+                    onClick={handleEdit}
+                    leftSection={<IconEdit size={16} />}
+                    disabled={disableEdit}
+                  >
+                    {t('familyHistory.viewModal.editFamilyMember', 'Edit Family Member')}
+                  </Button>
+                </span>
+              </Tooltip>
             )}
           </Group>
         </Stack>

--- a/frontend/src/components/medical/immunizations/ImmunizationCard.jsx
+++ b/frontend/src/components/medical/immunizations/ImmunizationCard.jsx
@@ -15,6 +15,8 @@ const ImmunizationCard = ({
   navigate,
   fileCount = 0,
   fileCountLoading = false,
+  disableActions = false,
+  disableActionsTooltip,
   onError
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -148,6 +150,8 @@ const ImmunizationCard = ({
         onView={() => onView(immunization)}
         onEdit={() => onEdit(immunization)}
         onDelete={() => onDelete(immunization.id)}
+        disableActions={disableActions}
+        disableActionsTooltip={disableActionsTooltip}
         onError={handleError}
       />
     );

--- a/frontend/src/components/medical/immunizations/ImmunizationViewModal.jsx
+++ b/frontend/src/components/medical/immunizations/ImmunizationViewModal.jsx
@@ -11,6 +11,7 @@ import {
   SimpleGrid,
   Title,
   Paper,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -34,7 +35,9 @@ const ImmunizationViewModal = ({
   onEdit,
   practitioners = [],
   navigate,
-  onError
+  onError,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -283,9 +286,13 @@ const ImmunizationViewModal = ({
           <Button variant="default" onClick={onClose}>
             {t('shared:labels.close', 'Close')}
           </Button>
-          <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />}>
-            {t('shared:labels.edit', 'Edit')}
-          </Button>
+          <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+            <span>
+              <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />} disabled={disableEdit}>
+                {t('shared:labels.edit', 'Edit')}
+              </Button>
+            </span>
+          </Tooltip>
         </Group>
       </Stack>
     </Modal>

--- a/frontend/src/components/medical/injuries/InjuryCard.jsx
+++ b/frontend/src/components/medical/injuries/InjuryCard.jsx
@@ -23,6 +23,8 @@ const InjuryCard = ({
   navigate,
   fileCount = 0,
   fileCountLoading = false,
+  disableActions = false,
+  disableActionsTooltip,
   onError,
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -212,6 +214,8 @@ const InjuryCard = ({
         onView={() => onView(injury)}
         onEdit={() => onEdit(injury)}
         onDelete={() => onDelete(injury.id)}
+        disableActions={disableActions}
+        disableActionsTooltip={disableActionsTooltip}
         onError={handleError}
       >
         {customContent}

--- a/frontend/src/components/medical/injuries/InjuryViewModal.jsx
+++ b/frontend/src/components/medical/injuries/InjuryViewModal.jsx
@@ -11,6 +11,7 @@ import {
   Grid,
   Paper,
   Divider,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -33,6 +34,8 @@ const InjuryViewModal = ({
   practitioners = [],
   injuryTypes = [],
   navigate,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
   const { formatLongDate } = useDateFormat();
@@ -302,9 +305,13 @@ const InjuryViewModal = ({
           <Button variant="subtle" onClick={onClose}>
             {t('shared:labels.close', 'Close')}
           </Button>
-          <Button leftSection={<IconEdit size={16} />} onClick={() => onEdit(injury)}>
-            {t('shared:labels.edit', 'Edit')}
-          </Button>
+          <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+            <span>
+              <Button leftSection={<IconEdit size={16} />} onClick={() => onEdit(injury)} disabled={disableEdit}>
+                {t('shared:labels.edit', 'Edit')}
+              </Button>
+            </span>
+          </Tooltip>
         </Group>
       </Stack>
     </Modal>

--- a/frontend/src/components/medical/insurance/InsuranceCard.jsx
+++ b/frontend/src/components/medical/insurance/InsuranceCard.jsx
@@ -254,25 +254,29 @@ const InsuranceCard = ({
             {t('buttons.view', 'View')}
           </Button>
           <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
-            <Button
-              variant="filled"
-              size="xs"
-              disabled={disableActions}
-              onClick={() => onEdit(insurance)}
-            >
-              {t('shared:labels.edit', 'Edit')}
-            </Button>
+            <span>
+              <Button
+                variant="filled"
+                size="xs"
+                disabled={disableActions}
+                onClick={() => onEdit(insurance)}
+              >
+                {t('shared:labels.edit', 'Edit')}
+              </Button>
+            </span>
           </Tooltip>
           <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
-            <Button
-              variant="filled"
-              color="red"
-              size="xs"
-              disabled={disableActions}
-              onClick={() => onDelete(insurance)}
-            >
-              {t('buttons.delete', 'Delete')}
-            </Button>
+            <span>
+              <Button
+                variant="filled"
+                color="red"
+                size="xs"
+                disabled={disableActions}
+                onClick={() => onDelete(insurance)}
+              >
+                {t('buttons.delete', 'Delete')}
+              </Button>
+            </span>
           </Tooltip>
         </Group>
       </Stack>

--- a/frontend/src/components/medical/insurance/InsuranceCard.jsx
+++ b/frontend/src/components/medical/insurance/InsuranceCard.jsx
@@ -254,7 +254,7 @@ const InsuranceCard = ({
             {t('buttons.view', 'View')}
           </Button>
           <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
-            <span>
+            <span onClick={e => e.stopPropagation()}>
               <Button
                 variant="filled"
                 size="xs"
@@ -266,7 +266,7 @@ const InsuranceCard = ({
             </span>
           </Tooltip>
           <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
-            <span>
+            <span onClick={e => e.stopPropagation()}>
               <Button
                 variant="filled"
                 color="red"

--- a/frontend/src/components/medical/insurance/InsuranceCard.jsx
+++ b/frontend/src/components/medical/insurance/InsuranceCard.jsx
@@ -7,6 +7,7 @@ import {
   Stack,
   Button,
   Divider,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconStarFilled,
@@ -25,7 +26,9 @@ const InsuranceCard = ({
   onSetPrimary,
   onView,
   fileCount = 0,
-  fileCountLoading = false
+  fileCountLoading = false,
+  disableActions = false,
+  disableActionsTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatLongDate } = useDateFormat();
@@ -250,21 +253,27 @@ const InsuranceCard = ({
           >
             {t('buttons.view', 'View')}
           </Button>
-          <Button
-            variant="filled"
-            size="xs"
-            onClick={() => onEdit(insurance)}
-          >
-            {t('shared:labels.edit', 'Edit')}
-          </Button>
-          <Button
-            variant="filled"
-            color="red"
-            size="xs"
-            onClick={() => onDelete(insurance)}
-          >
-            {t('buttons.delete', 'Delete')}
-          </Button>
+          <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
+            <Button
+              variant="filled"
+              size="xs"
+              disabled={disableActions}
+              onClick={() => onEdit(insurance)}
+            >
+              {t('shared:labels.edit', 'Edit')}
+            </Button>
+          </Tooltip>
+          <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
+            <Button
+              variant="filled"
+              color="red"
+              size="xs"
+              disabled={disableActions}
+              onClick={() => onDelete(insurance)}
+            >
+              {t('buttons.delete', 'Delete')}
+            </Button>
+          </Tooltip>
         </Group>
       </Stack>
     </Card>

--- a/frontend/src/components/medical/insurance/InsuranceViewModal.jsx
+++ b/frontend/src/components/medical/insurance/InsuranceViewModal.jsx
@@ -17,6 +17,7 @@ import {
   Box,
   SimpleGrid,
   Paper,
+  Tooltip,
 } from '@mantine/core';
 import { IconEdit, IconPrinter, IconStar, IconInfoCircle, IconShield, IconPhone, IconFileText } from '@tabler/icons-react';
 import { useDateFormat } from '../../../hooks/useDateFormat';
@@ -32,7 +33,9 @@ const InsuranceViewModal = ({
   onEdit,
   onPrint,
   onSetPrimary,
-  onFileUploadComplete
+  onFileUploadComplete,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -367,15 +370,20 @@ const InsuranceViewModal = ({
             <Button variant="outline" onClick={onClose}>
               {t('shared:labels.close', 'Close')}
             </Button>
-            <Button
-              leftSection={<IconEdit size={16} />}
-              onClick={() => {
-                onClose();
-                onEdit && onEdit(insurance);
-              }}
-            >
-              {t('shared:labels.edit', 'Edit')}
-            </Button>
+            <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+              <span>
+                <Button
+                  leftSection={<IconEdit size={16} />}
+                  onClick={() => {
+                    onClose();
+                    onEdit && onEdit(insurance);
+                  }}
+                  disabled={disableEdit}
+                >
+                  {t('shared:labels.edit', 'Edit')}
+                </Button>
+              </span>
+            </Tooltip>
           </Group>
         </Group>
       </Stack>

--- a/frontend/src/components/medical/labresults/LabResultCard.jsx
+++ b/frontend/src/components/medical/labresults/LabResultCard.jsx
@@ -17,6 +17,8 @@ const LabResultCard = React.memo(({
   fileCountLoading,
   practitioners,
   navigate,
+  disableActions = false,
+  disableActionsTooltip,
   onError
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -120,6 +122,8 @@ const LabResultCard = React.memo(({
         onEdit={() => onEdit(labResult)}
         onDelete={() => onDelete(labResult)}
         entityType="lab-result"
+        disableActions={disableActions}
+        disableActionsTooltip={disableActionsTooltip}
         onError={handleError}
       />
     );
@@ -139,6 +143,8 @@ const LabResultCard = React.memo(({
     prevProps.labResult.completed_date === nextProps.labResult.completed_date &&
     prevProps.fileCount === nextProps.fileCount &&
     prevProps.fileCountLoading === nextProps.fileCountLoading &&
+    prevProps.disableActions === nextProps.disableActions &&
+    prevProps.disableActionsTooltip === nextProps.disableActionsTooltip &&
     prevProps.onEdit === nextProps.onEdit &&
     prevProps.onDelete === nextProps.onDelete &&
     prevProps.onView === nextProps.onView

--- a/frontend/src/components/medical/labresults/LabResultViewModal.jsx
+++ b/frontend/src/components/medical/labresults/LabResultViewModal.jsx
@@ -13,6 +13,7 @@ import {
   Tabs,
   Badge,
   Box,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -51,6 +52,8 @@ const LabResultViewModal = ({
   encounters,
   labResultEncounters,
   fetchLabResultEncounters,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -271,7 +274,7 @@ const LabResultViewModal = ({
                 <TestComponentsTab
                   key={`test-components-${labResult.id}`}
                   labResultId={labResult.id}
-                  isViewMode={false}
+                  isViewMode={disableEdit}
                   onError={handleTestComponentsError}
                   onLabResultUpdated={onLabResultUpdated}
                 />
@@ -306,7 +309,7 @@ const LabResultViewModal = ({
                     encounters={encounters}
                     fetchLabResultEncounters={fetchLabResultEncounters}
                     navigate={navigate}
-                    isViewMode={false}
+                    isViewMode={disableEdit}
                   />
                 </Box>
               </Tabs.Panel>
@@ -373,14 +376,19 @@ const LabResultViewModal = ({
             <Button variant="outline" onClick={onClose}>
               {t('shared:labels.close', 'Close')}
             </Button>
-            <Button
-              onClick={() => {
-                onClose();
-                onEdit(labResult);
-              }}
-            >
-              {t('labresults:modal.editLabResult', 'Edit Lab Result')}
-            </Button>
+            <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+              <span>
+                <Button
+                  onClick={() => {
+                    onClose();
+                    onEdit(labResult);
+                  }}
+                  disabled={disableEdit}
+                >
+                  {t('labresults:modal.editLabResult', 'Edit Lab Result')}
+                </Button>
+              </span>
+            </Tooltip>
           </Group>
         </Stack>
       </Modal>

--- a/frontend/src/components/medical/medications/MedicationCard.jsx
+++ b/frontend/src/components/medical/medications/MedicationCard.jsx
@@ -7,6 +7,7 @@ import {
   Group,
   Stack,
   Text,
+  Tooltip,
 } from '@mantine/core';
 import { navigateToEntity } from '../../../utils/linkNavigation';
 import { createCardClickHandler } from '../../../utils/helpers';
@@ -35,6 +36,8 @@ const MedicationCard = ({
   navigate,
   fileCount = 0,
   fileCountLoading = false,
+  disableActions = false,
+  disableActionsTooltip,
   onError,
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -233,21 +236,27 @@ const MedicationCard = ({
           >
             {t('common:buttons.view')}
           </Button>
-          <Button
-            variant="filled"
-            size="xs"
-            onClick={(e) => { e.stopPropagation(); onEdit(medication); }}
-          >
-            {t('shared:labels.edit')}
-          </Button>
-          <Button
-            variant="filled"
-            color="red"
-            size="xs"
-            onClick={(e) => { e.stopPropagation(); onDelete(medication.id); }}
-          >
-            {t('common:buttons.delete')}
-          </Button>
+          <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
+            <Button
+              variant="filled"
+              size="xs"
+              disabled={disableActions}
+              onClick={(e) => { e.stopPropagation(); onEdit(medication); }}
+            >
+              {t('shared:labels.edit')}
+            </Button>
+          </Tooltip>
+          <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
+            <Button
+              variant="filled"
+              color="red"
+              size="xs"
+              disabled={disableActions}
+              onClick={(e) => { e.stopPropagation(); onDelete(medication.id); }}
+            >
+              {t('common:buttons.delete')}
+            </Button>
+          </Tooltip>
         </Group>
       </Stack>
     </Card>

--- a/frontend/src/components/medical/medications/MedicationCard.jsx
+++ b/frontend/src/components/medical/medications/MedicationCard.jsx
@@ -237,7 +237,7 @@ const MedicationCard = ({
             {t('common:buttons.view')}
           </Button>
           <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
-            <span>
+            <span onClick={e => e.stopPropagation()}>
               <Button
                 variant="filled"
                 size="xs"
@@ -249,7 +249,7 @@ const MedicationCard = ({
             </span>
           </Tooltip>
           <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
-            <span>
+            <span onClick={e => e.stopPropagation()}>
               <Button
                 variant="filled"
                 color="red"

--- a/frontend/src/components/medical/medications/MedicationCard.jsx
+++ b/frontend/src/components/medical/medications/MedicationCard.jsx
@@ -237,25 +237,29 @@ const MedicationCard = ({
             {t('common:buttons.view')}
           </Button>
           <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
-            <Button
-              variant="filled"
-              size="xs"
-              disabled={disableActions}
-              onClick={(e) => { e.stopPropagation(); onEdit(medication); }}
-            >
-              {t('shared:labels.edit')}
-            </Button>
+            <span>
+              <Button
+                variant="filled"
+                size="xs"
+                disabled={disableActions}
+                onClick={(e) => { e.stopPropagation(); onEdit(medication); }}
+              >
+                {t('shared:labels.edit')}
+              </Button>
+            </span>
           </Tooltip>
           <Tooltip label={disableActionsTooltip} disabled={!disableActions || !disableActionsTooltip}>
-            <Button
-              variant="filled"
-              color="red"
-              size="xs"
-              disabled={disableActions}
-              onClick={(e) => { e.stopPropagation(); onDelete(medication.id); }}
-            >
-              {t('common:buttons.delete')}
-            </Button>
+            <span>
+              <Button
+                variant="filled"
+                color="red"
+                size="xs"
+                disabled={disableActions}
+                onClick={(e) => { e.stopPropagation(); onDelete(medication.id); }}
+              >
+                {t('common:buttons.delete')}
+              </Button>
+            </span>
           </Tooltip>
         </Group>
       </Stack>

--- a/frontend/src/components/medical/medications/MedicationViewModal.jsx
+++ b/frontend/src/components/medical/medications/MedicationViewModal.jsx
@@ -12,6 +12,7 @@ import {
   Box,
   SimpleGrid,
   Paper,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -39,6 +40,8 @@ const MedicationViewModal = ({
   onFileUploadComplete,
   practitioners = [],
   conditions = [],
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -391,17 +394,22 @@ const MedicationViewModal = ({
 
         {/* Action Buttons */}
         <Group justify="flex-end" mt="md">
-          <Button
-            variant="light"
-            onClick={() => {
-              onClose();
-              setTimeout(() => {
-                onEdit(medication);
-              }, 100);
-            }}
-          >
-            {t('medications.modal.editMedication', 'Edit Medication')}
-          </Button>
+          <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+            <span>
+              <Button
+                variant="light"
+                onClick={() => {
+                  onClose();
+                  setTimeout(() => {
+                    onEdit(medication);
+                  }, 100);
+                }}
+                disabled={disableEdit}
+              >
+                {t('medications.modal.editMedication', 'Edit Medication')}
+              </Button>
+            </span>
+          </Tooltip>
           <Button variant="filled" onClick={onClose}>
             {t('shared:labels.close', 'Close')}
           </Button>

--- a/frontend/src/components/medical/procedures/ProcedureCard.jsx
+++ b/frontend/src/components/medical/procedures/ProcedureCard.jsx
@@ -16,6 +16,8 @@ const ProcedureCard = ({
   fileCountLoading,
   practitioners,
   navigate,
+  disableActions = false,
+  disableActionsTooltip,
   onError
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -129,6 +131,8 @@ const ProcedureCard = ({
         onEdit={() => onEdit(procedure)}
         onDelete={() => onDelete(procedure)}
         entityType="procedure"
+        disableActions={disableActions}
+        disableActionsTooltip={disableActionsTooltip}
         onError={handleError}
       />
     );

--- a/frontend/src/components/medical/procedures/ProcedureViewModal.jsx
+++ b/frontend/src/components/medical/procedures/ProcedureViewModal.jsx
@@ -11,6 +11,7 @@ import {
   Box,
   SimpleGrid,
   Paper,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -36,7 +37,9 @@ const ProcedureViewModal = ({
   practitioners = [],
   navigate,
   onFileUploadComplete,
-  onError
+  onError,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -335,9 +338,13 @@ const ProcedureViewModal = ({
             <Button variant="default" onClick={onClose}>
               {t('shared:labels.close', 'Close')}
             </Button>
-            <Button variant="filled" onClick={handleEditClick} leftSection={<IconEdit size={16} />}>
-              {t('shared:labels.edit', 'Edit')}
-            </Button>
+            <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+              <span>
+                <Button variant="filled" onClick={handleEditClick} leftSection={<IconEdit size={16} />} disabled={disableEdit}>
+                  {t('shared:labels.edit', 'Edit')}
+                </Button>
+              </span>
+            </Tooltip>
           </Group>
         </Stack>
       </Modal>

--- a/frontend/src/components/medical/symptoms/SymptomViewModal.jsx
+++ b/frontend/src/components/medical/symptoms/SymptomViewModal.jsx
@@ -14,6 +14,7 @@ import {
   Loader,
   Center,
   Table,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -45,6 +46,8 @@ const SymptomViewModal = ({
   onLogEpisode,
   onEditOccurrence,
   onRefresh,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -531,17 +534,22 @@ const SymptomViewModal = ({
             </Button>
           )}
           {onEdit && (
-            <Button
-              variant="light"
-              onClick={() => {
-                onClose();
-                setTimeout(() => {
-                  onEdit(symptom);
-                }, 100);
-              }}
-            >
-              {t('symptoms.viewModal.editSymptom', 'Edit Symptom')}
-            </Button>
+            <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+              <span>
+                <Button
+                  variant="light"
+                  onClick={() => {
+                    onClose();
+                    setTimeout(() => {
+                      onEdit(symptom);
+                    }, 100);
+                  }}
+                  disabled={disableEdit}
+                >
+                  {t('symptoms.viewModal.editSymptom', 'Edit Symptom')}
+                </Button>
+              </span>
+            </Tooltip>
           )}
           {onLogEpisode && (
             <Button

--- a/frontend/src/components/medical/symptoms/SymptomViewModal.jsx
+++ b/frontend/src/components/medical/symptoms/SymptomViewModal.jsx
@@ -324,7 +324,7 @@ const SymptomViewModal = ({
               <Stack gap="md">
                 <Group justify="space-between">
                   <Title order={4}>{t('symptoms.viewModal.episodeHistory', 'Episode History')}</Title>
-                  {onLogEpisode && (
+                  {onLogEpisode && !disableEdit && (
                     <Button
                       size="xs"
                       leftSection={<IconNote size={14} />}
@@ -349,7 +349,7 @@ const SymptomViewModal = ({
                       <Text size="sm" c="dimmed">
                         {t('symptoms.viewModal.noEpisodesYet', 'No episodes logged yet')}
                       </Text>
-                      {onLogEpisode && (
+                      {onLogEpisode && !disableEdit && (
                         <Button
                           size="sm"
                           variant="light"
@@ -444,7 +444,7 @@ const SymptomViewModal = ({
                           </Stack>
 
                           <Group gap="xs">
-                            {onEditOccurrence && (
+                            {onEditOccurrence && !disableEdit && (
                               <Button
                                 size="xs"
                                 variant="light"
@@ -457,15 +457,17 @@ const SymptomViewModal = ({
                                 {t('shared:labels.edit', 'Edit')}
                               </Button>
                             )}
-                            <Button
-                              size="xs"
-                              variant="light"
-                              color="red"
-                              leftSection={<IconTrash size={14} />}
-                              onClick={() => handleDeleteOccurrence(occurrence.id)}
-                            >
-                              {t('buttons.delete', 'Delete')}
-                            </Button>
+                            {!disableEdit && (
+                              <Button
+                                size="xs"
+                                variant="light"
+                                color="red"
+                                leftSection={<IconTrash size={14} />}
+                                onClick={() => handleDeleteOccurrence(occurrence.id)}
+                              >
+                                {t('buttons.delete', 'Delete')}
+                              </Button>
+                            )}
                           </Group>
                         </Group>
                       </Paper>
@@ -519,7 +521,7 @@ const SymptomViewModal = ({
 
         {/* Action Buttons */}
         <Group justify="flex-end" mt="md">
-          {onDelete && (
+          {onDelete && !disableEdit && (
             <Button
               variant="light"
               color="red"
@@ -551,7 +553,7 @@ const SymptomViewModal = ({
               </span>
             </Tooltip>
           )}
-          {onLogEpisode && (
+          {onLogEpisode && !disableEdit && (
             <Button
               variant="filled"
               color="green"

--- a/frontend/src/components/medical/treatments/TreatmentCard.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentCard.jsx
@@ -16,6 +16,8 @@ const TreatmentCard = ({
   navigate,
   fileCount = 0,
   fileCountLoading = false,
+  disableActions = false,
+  disableActionsTooltip,
   onError
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -166,6 +168,8 @@ const TreatmentCard = ({
         onView={() => onView(treatment)}
         onEdit={() => onEdit(treatment)}
         onDelete={() => onDelete(treatment.id)}
+        disableActions={disableActions}
+        disableActionsTooltip={disableActionsTooltip}
         onError={handleError}
       >
         {customContent}

--- a/frontend/src/components/medical/treatments/TreatmentViewModal.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentViewModal.jsx
@@ -11,6 +11,7 @@ import {
   SimpleGrid,
   Title,
   Paper,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -47,6 +48,8 @@ const TreatmentViewModal = ({
   onLabResultClick,
   onEquipmentClick,
   onError,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -445,9 +448,13 @@ const TreatmentViewModal = ({
           <Button variant="default" onClick={onClose}>
             {t('shared:labels.close', 'Close')}
           </Button>
-          <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />}>
-            {t('shared:labels.edit', 'Edit')}
-          </Button>
+          <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+            <span>
+              <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />} disabled={disableEdit}>
+                {t('shared:labels.edit', 'Edit')}
+              </Button>
+            </span>
+          </Tooltip>
         </Group>
       </Stack>
     </Modal>

--- a/frontend/src/components/medical/visits/VisitCard.jsx
+++ b/frontend/src/components/medical/visits/VisitCard.jsx
@@ -17,6 +17,8 @@ const VisitCard = ({
   practitioners,
   conditions,
   navigate,
+  disableActions = false,
+  disableActionsTooltip,
   onError
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -245,6 +247,8 @@ const VisitCard = ({
         onEdit={() => onEdit(visit)}
         onDelete={() => onDelete(visit)}
         entityType="visit"
+        disableActions={disableActions}
+        disableActionsTooltip={disableActionsTooltip}
         onError={handleError}
       >
         {additionalContent}

--- a/frontend/src/components/medical/visits/VisitViewModal.jsx
+++ b/frontend/src/components/medical/visits/VisitViewModal.jsx
@@ -14,6 +14,7 @@ import {
   Tabs,
   Box,
   SimpleGrid,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconInfoCircle,
@@ -45,6 +46,8 @@ const VisitViewModal = ({
   labResults,
   encounterLabResults,
   fetchEncounterLabResults,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate } = useDateFormat();
@@ -350,7 +353,7 @@ const VisitViewModal = ({
                     labResults={labResults}
                     fetchEncounterLabResults={fetchEncounterLabResults}
                     navigate={navigate}
-                    isViewMode={false}
+                    isViewMode={disableEdit}
                   />
                 </Box>
               </Tabs.Panel>
@@ -420,18 +423,23 @@ const VisitViewModal = ({
 
           {/* Action Buttons */}
           <Group justify="flex-end" mt="md">
-            <Button
-              variant="light"
-              onClick={() => {
-                onClose();
-                // Small delay to ensure view modal is closed before opening edit modal
-                setTimeout(() => {
-                  onEdit(visit);
-                }, 100);
-              }}
-            >
-              {t('visits.viewModal.editVisit', 'Edit Visit')}
-            </Button>
+            <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+              <span>
+                <Button
+                  variant="light"
+                  onClick={() => {
+                    onClose();
+                    // Small delay to ensure view modal is closed before opening edit modal
+                    setTimeout(() => {
+                      onEdit(visit);
+                    }, 100);
+                  }}
+                  disabled={disableEdit}
+                >
+                  {t('visits.viewModal.editVisit', 'Edit Visit')}
+                </Button>
+              </span>
+            </Tooltip>
             <Button variant="filled" onClick={onClose}>
               {t('shared:labels.close', 'Close')}
             </Button>

--- a/frontend/src/components/medical/vital/VitalViewModal.jsx
+++ b/frontend/src/components/medical/vital/VitalViewModal.jsx
@@ -14,6 +14,7 @@ import {
   Title,
   Card,
   Box,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconEdit,
@@ -48,6 +49,8 @@ const VitalViewModal = ({
   onEdit,
   practitioners = [],
   navigate,
+  disableEdit = false,
+  disableEditTooltip,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { formatDate, formatDateTime } = useDateFormat();
@@ -344,9 +347,13 @@ const VitalViewModal = ({
           <Button variant="default" onClick={onClose}>
             {t('shared:labels.close', 'Close')}
           </Button>
-          <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />}>
-            {t('shared:labels.edit', 'Edit')}
-          </Button>
+          <Tooltip label={disableEditTooltip} disabled={!disableEdit || !disableEditTooltip}>
+            <span>
+              <Button variant="filled" onClick={handleEdit} leftSection={<IconEdit size={16} />} disabled={disableEdit}>
+                {t('shared:labels.edit', 'Edit')}
+              </Button>
+            </span>
+          </Tooltip>
         </Group>
       </Stack>
     </Modal>

--- a/frontend/src/components/shared/MedicalPageActions.jsx
+++ b/frontend/src/components/shared/MedicalPageActions.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { Group, Button } from '@mantine/core';
+import { Group, Button, Tooltip } from '@mantine/core';
 import ViewToggle from './ViewToggle';
 
 /**
@@ -81,30 +81,37 @@ function MedicalPageActions({
     <Group justify="space-between" align={align} mb={mb}>
       <Group gap={buttonGap}>
         {primaryVisible && primaryAction && (
-          <Button
-            variant={primaryAction.variant || 'filled'}
-            size={primaryAction.size || 'md'}
-            color={primaryAction.color}
-            leftSection={primaryAction.leftSection}
-            onClick={primaryAction.onClick}
-            disabled={primaryAction.disabled}
-          >
-            {primaryAction.label}
-          </Button>
+          <Tooltip label={primaryAction.tooltip} disabled={!primaryAction.disabled || !primaryAction.tooltip}>
+            <span>
+              <Button
+                variant={primaryAction.variant || 'filled'}
+                size={primaryAction.size || 'md'}
+                color={primaryAction.color}
+                leftSection={primaryAction.leftSection}
+                onClick={primaryAction.onClick}
+                disabled={primaryAction.disabled}
+              >
+                {primaryAction.label}
+              </Button>
+            </span>
+          </Tooltip>
         )}
 
         {visibleSecondaryActions.map((action, index) => (
-          <Button
-            key={action.key || `secondary-${index}`}
-            variant={action.variant || 'light'}
-            size={action.size || 'md'}
-            color={action.color}
-            leftSection={action.leftSection}
-            onClick={action.onClick}
-            disabled={action.disabled}
-          >
-            {action.label}
-          </Button>
+          <Tooltip key={action.key || `secondary-${index}`} label={action.tooltip} disabled={!action.disabled || !action.tooltip}>
+            <span>
+              <Button
+                variant={action.variant || 'light'}
+                size={action.size || 'md'}
+                color={action.color}
+                leftSection={action.leftSection}
+                onClick={action.onClick}
+                disabled={action.disabled}
+              >
+                {action.label}
+              </Button>
+            </span>
+          </Tooltip>
         ))}
 
         {children}
@@ -138,6 +145,8 @@ const actionShape = PropTypes.shape({
   color: PropTypes.string,
   /** Whether the button is disabled */
   disabled: PropTypes.bool,
+  /** Tooltip text shown when button is disabled */
+  tooltip: PropTypes.string,
   /** Whether the action is visible (defaults to true) */
   visible: PropTypes.bool,
   /** Unique key for the action (used for secondary actions) */

--- a/frontend/src/components/shared/MedicalPageActions.test.jsx
+++ b/frontend/src/components/shared/MedicalPageActions.test.jsx
@@ -11,6 +11,7 @@ vi.mock('@mantine/core', () => ({
       {children}
     </button>
   ),
+  Tooltip: ({ children }) => children,
 }));
 
 // Mock ViewToggle component

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -46,3 +46,6 @@ export { usePersistedViewMode } from './usePersistedViewMode';
 
 // Toggle persistence hooks
 export { usePersistedToggle } from './usePersistedToggle';
+
+// Patient permission hooks
+export { usePatientPermissions } from './usePatientPermissions';

--- a/frontend/src/hooks/usePatientPermissions.js
+++ b/frontend/src/hooks/usePatientPermissions.js
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCurrentPatient } from './useGlobalData';
+import { useAuth } from '../contexts/AuthContext';
+
+/**
+ * Hook to determine the current user's permission level for the active patient.
+ *
+ * Returns permission flags based on whether the patient is owned or shared,
+ * and what permission level the share grants.
+ *
+ * @returns {{ isOwner: boolean, permissionLevel: string, canCreate: boolean, canEdit: boolean, canDelete: boolean, isViewOnly: boolean, viewOnlyTooltip: string|undefined }}
+ */
+export function usePatientPermissions() {
+  const { patient } = useCurrentPatient(false);
+  const { user } = useAuth();
+  const { t } = useTranslation('shared');
+
+  return useMemo(() => {
+    const isOwner = patient?.owner_user_id === user?.id;
+    const permissionLevel = isOwner ? 'full' : (patient?.permission_level || 'view');
+    const isViewOnly = permissionLevel === 'view' && !isOwner;
+    const viewOnlyTooltip = isViewOnly ? t('permissions.viewOnly') : undefined;
+
+    return {
+      isOwner,
+      permissionLevel,
+      canCreate: !isViewOnly,
+      canEdit: !isViewOnly,
+      canDelete: !isViewOnly,
+      isViewOnly,
+      viewOnlyTooltip,
+    };
+  }, [patient?.owner_user_id, patient?.permission_level, user?.id, t]);
+}

--- a/frontend/src/hooks/usePatientPermissions.js
+++ b/frontend/src/hooks/usePatientPermissions.js
@@ -17,8 +17,11 @@ export function usePatientPermissions() {
   const { t } = useTranslation('shared');
 
   return useMemo(() => {
-    const isOwner = patient?.owner_user_id === user?.id;
-    const permissionLevel = isOwner ? 'full' : (patient?.permission_level || 'view');
+    if (!patient || !user) {
+      return { isOwner: false, permissionLevel: 'view', canCreate: false, canEdit: false, canDelete: false, isViewOnly: true, viewOnlyTooltip: undefined };
+    }
+    const isOwner = patient.owner_user_id === user.id;
+    const permissionLevel = isOwner ? 'full' : (patient.permission_level || 'view');
     const isViewOnly = permissionLevel === 'view' && !isOwner;
     const viewOnlyTooltip = isViewOnly ? t('permissions.viewOnly') : undefined;
 

--- a/frontend/src/pages/medical/Allergies.jsx
+++ b/frontend/src/pages/medical/Allergies.jsx
@@ -37,11 +37,13 @@ import { withResponsive } from '../../hoc/withResponsive';
 import { useResponsive } from '../../hooks/useResponsive';
 import logger from '../../services/logger';
 import { useFormSubmissionWithUploads } from '../../hooks/useFormSubmissionWithUploads';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 
 const Allergies = () => {
   const navigate = useNavigate();
   const { t } = useTranslation(['medical', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const responsive = useResponsive();
   const [viewMode, setViewMode] = usePersistedViewMode('allergies');
@@ -347,6 +349,8 @@ const Allergies = () => {
             onClick: handleAddAllergy,
             leftSection: <IconPlus size={16} />,
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
@@ -406,6 +410,8 @@ const Allergies = () => {
                   fileCount={fileCounts[allergy.id] || 0}
                   fileCountLoading={fileCountsLoading[allergy.id] || false}
                   onError={setError}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                 />
               )}
             />
@@ -415,6 +421,9 @@ const Allergies = () => {
                 persistKey="allergies"
                 data={paginatedAllergies}
                 pagination={false}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   { header: t('allergies.allergen.label'), accessor: 'allergen', priority: 'high', width: 150 },
                   { header: t('allergies.reaction.label'), accessor: 'reaction', priority: 'high', width: 180 },
@@ -457,6 +466,8 @@ const Allergies = () => {
           medications={medications}
           navigate={navigate}
           onError={setError}
+          disableEdit={isViewOnly}
+          disableEditTooltip={viewOnlyTooltip}
         />
       </Stack>
     </Container>

--- a/frontend/src/pages/medical/Conditions.jsx
+++ b/frontend/src/pages/medical/Conditions.jsx
@@ -43,9 +43,11 @@ import {
   ConditionViewModal,
   ConditionFormWrapper,
 } from '../../components/medical/conditions';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const Conditions = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const navigate = useNavigate();
   const responsive = useResponsive();
@@ -454,6 +456,8 @@ const Conditions = () => {
             onClick: handleAddCondition,
             leftSection: <IconPlus size={16} />,
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
@@ -514,6 +518,8 @@ const Conditions = () => {
                   navigate={navigate}
                   fileCount={fileCounts[condition.id] || 0}
                   fileCountLoading={fileCountsLoading[condition.id] || false}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                 />
               )}
             />
@@ -523,6 +529,9 @@ const Conditions = () => {
                 persistKey="conditions"
                 data={paginatedConditions}
                 pagination={false}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   { header: t('shared:labels.condition', 'Condition'), accessor: 'diagnosis', priority: 'high', width: 200 },
                   { header: t('shared:fields.severity', 'Severity'), accessor: 'severity', priority: 'high', width: 120 },
@@ -568,6 +577,8 @@ const Conditions = () => {
           conditionMedications={conditionMedications}
           fetchConditionMedications={fetchConditionMedications}
           navigate={navigate}
+          disableEdit={isViewOnly}
+          disableEditTooltip={viewOnlyTooltip}
         />
       </Stack>
     </Container>

--- a/frontend/src/pages/medical/EmergencyContacts.jsx
+++ b/frontend/src/pages/medical/EmergencyContacts.jsx
@@ -41,10 +41,12 @@ import PaginationControls from '../../components/shared/PaginationControls';
 import MantineEmergencyContactForm from '../../components/medical/MantineEmergencyContactForm';
 import { useTranslation } from 'react-i18next';
 import { phoneTelHref } from '../../utils/phoneUtils';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 import '../../styles/shared/MedicalPageShared.css';
 
 const EmergencyContacts = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const [viewMode, setViewMode] = usePersistedViewMode('emergency-contacts');
   const { page, setPage, pageSize, handlePageSizeChange, paginateData, totalPages, resetPage, clampPage, PAGE_SIZE_OPTIONS } = usePagination();
   const navigate = useNavigate();
@@ -278,6 +280,8 @@ const EmergencyContacts = () => {
             onClick: handleAddContact,
             leftSection: <IconPlus size={16} />,
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
@@ -486,6 +490,9 @@ const EmergencyContacts = () => {
                 persistKey="emergency-contacts"
                 data={paginatedContacts}
                 pagination={false}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   { header: t('shared:labels.name'), accessor: 'name', priority: 'high', width: 200 },
                   { header: t('shared:labels.relationship'), accessor: 'relationship', priority: 'high', width: 150 },

--- a/frontend/src/pages/medical/EmergencyContacts.jsx
+++ b/frontend/src/pages/medical/EmergencyContacts.jsx
@@ -467,6 +467,7 @@ const EmergencyContacts = () => {
                       <Button
                         variant="filled"
                         size="xs"
+                        disabled={isViewOnly}
                         onClick={() => handleEditContact(contact)}
                       >
                         {t('shared:labels.edit')}
@@ -475,6 +476,7 @@ const EmergencyContacts = () => {
                         variant="filled"
                         color="red"
                         size="xs"
+                        disabled={isViewOnly}
                         onClick={() => handleDeleteContact(contact.id)}
                       >
                         {t('buttons.delete')}
@@ -746,6 +748,7 @@ const EmergencyContacts = () => {
               <Button
                 variant="filled"
                 size="xs"
+                disabled={isViewOnly}
                 onClick={() => {
                   handleCloseViewModal();
                   handleEditContact(viewingContact);

--- a/frontend/src/pages/medical/FamilyHistory.jsx
+++ b/frontend/src/pages/medical/FamilyHistory.jsx
@@ -56,11 +56,13 @@ import {
 import { notifications } from '@mantine/notifications';
 import { useDisclosure } from '@mantine/hooks';
 import { useTranslation } from 'react-i18next';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 // Removed style constants - now handled in extracted components
 
 const FamilyHistory = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const navigate = useNavigate();
   const location = useLocation();
   const responsive = useResponsive();
@@ -971,6 +973,8 @@ const FamilyHistory = () => {
             leftSection: <IconUserPlus size={16} />,
             visible: activeTab === 'my-family',
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           secondaryActions={[
             {
@@ -1092,6 +1096,9 @@ const FamilyHistory = () => {
               <ResponsiveTable
                 persistKey="family-history-conditions"
                 data={flattenedConditions}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   { header: t('familyHistory.table.familyMember', 'Family Member'), accessor: 'familyMemberName', priority: 'high', width: 150 },
                   { header: t('shared:labels.relationship', 'Relationship'), accessor: 'relationship', priority: 'high', width: 120 },
@@ -1185,6 +1192,8 @@ const FamilyHistory = () => {
                         isSelected={selectedMembersForBulkSharing.includes(member.id)}
                         onBulkToggle={handleBulkMemberToggle}
                         onError={setError}
+                        disableActions={isViewOnly}
+                        disableActionsTooltip={viewOnlyTooltip}
                       />
                     )}
                   />
@@ -1211,6 +1220,9 @@ const FamilyHistory = () => {
               <ResponsiveTable
                 persistKey="family-history-shared"
                 data={flattenedSharedConditions}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   { header: t('familyHistory.table.familyMember', 'Family Member'), accessor: 'familyMemberName', priority: 'high', width: 150 },
                   { header: t('shared:labels.relationship', 'Relationship'), accessor: 'relationship', priority: 'high', width: 120 },
@@ -1290,6 +1302,8 @@ const FamilyHistory = () => {
                           onEditCondition={handleEditCondition}
                           onDeleteCondition={handleDeleteCondition}
                           onShare={handleShareMember}
+                          disableActions={isViewOnly}
+                          disableActionsTooltip={viewOnlyTooltip}
                           expandedMembers={{
                             has: (id) => expandedMembers.has(`shared-${id}`),
                           }}
@@ -1362,6 +1376,8 @@ const FamilyHistory = () => {
         onEditCondition={handleEditConditionFromView}
         onDeleteCondition={handleDeleteCondition}
         onError={setError}
+        disableEdit={isViewOnly}
+        disableEditTooltip={viewOnlyTooltip}
       />
 
       {/* Invitation Manager Modal */}

--- a/frontend/src/pages/medical/FamilyHistory.jsx
+++ b/frontend/src/pages/medical/FamilyHistory.jsx
@@ -1087,6 +1087,7 @@ const FamilyHistory = () => {
                 leftSection={<IconUserPlus size={16} />}
                 onClick={handleAddMember}
                 variant="filled"
+                disabled={isViewOnly}
               >
                 {t('familyHistory.emptyState.addFirstMember', 'Add Your First Family Member')}
               </Button>

--- a/frontend/src/pages/medical/Immunization.jsx
+++ b/frontend/src/pages/medical/Immunization.jsx
@@ -49,9 +49,11 @@ import {
   ImmunizationViewModal,
   ImmunizationFormWrapper,
 } from '../../components/medical/immunizations';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const Immunization = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const [viewMode, setViewMode] = usePersistedViewMode('immunizations');
   const { page, setPage, pageSize, handlePageSizeChange, paginateData, totalPages, resetPage, clampPage, PAGE_SIZE_OPTIONS } = usePagination();
@@ -361,6 +363,8 @@ const Immunization = () => {
             onClick: handleAddImmunization,
             leftSection: <IconPlus size={16} />,
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
@@ -401,6 +405,8 @@ const Immunization = () => {
           onEdit={handleEditImmunization}
           practitioners={practitioners}
           navigate={navigate}
+          disableEdit={isViewOnly}
+          disableEditTooltip={viewOnlyTooltip}
         />
 
         {/* Content */}
@@ -425,6 +431,8 @@ const Immunization = () => {
                   navigate={navigate}
                   fileCount={fileCounts[immunization.id] || 0}
                   fileCountLoading={fileCountsLoading[immunization.id] || false}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                 />
               )}
             />
@@ -434,6 +442,9 @@ const Immunization = () => {
                 persistKey="immunizations"
                 data={paginatedImmunizations}
                 pagination={false}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   { header: t('shared:fields.vaccineName', 'Vaccine Name'), accessor: 'vaccine_name', priority: 'high', width: 200 },
                   {

--- a/frontend/src/pages/medical/Injuries.jsx
+++ b/frontend/src/pages/medical/Injuries.jsx
@@ -36,10 +36,12 @@ import { useResponsive } from '../../hooks/useResponsive';
 import { usePersistedViewMode } from '../../hooks/usePersistedViewMode';
 import { usePagination } from '../../hooks/usePagination';
 import logger from '../../services/logger';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const Injuries = () => {
   const navigate = useNavigate();
   const { t } = useTranslation(['medical', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const responsive = useResponsive();
   const [viewMode, setViewMode] = usePersistedViewMode('injuries');
@@ -379,6 +381,8 @@ const Injuries = () => {
             onClick: handleAddInjury,
             leftSection: <IconPlus size={16} />,
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
@@ -441,6 +445,8 @@ const Injuries = () => {
                   fileCount={fileCounts[injury.id] || 0}
                   fileCountLoading={fileCountsLoading[injury.id] || false}
                   onError={setError}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                 />
               )}
             />
@@ -450,6 +456,9 @@ const Injuries = () => {
                 persistKey="injuries"
                 data={paginatedInjuries}
                 pagination={false}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   { header: t('injuries.injuryName.label', 'Injury Name'), accessor: 'injury_name', priority: 'high', width: 180 },
                   { header: t('injuries.bodyPart.label', 'Body Part'), accessor: 'body_part', priority: 'high', width: 120 },
@@ -484,6 +493,8 @@ const Injuries = () => {
           practitioners={practitioners}
           injuryTypes={injuryTypes}
           navigate={navigate}
+          disableEdit={isViewOnly}
+          disableEditTooltip={viewOnlyTooltip}
         />
       </Stack>
     </Container>

--- a/frontend/src/pages/medical/Insurance.jsx
+++ b/frontend/src/pages/medical/Insurance.jsx
@@ -45,6 +45,7 @@ import AnimatedCardGrid from '../../components/shared/AnimatedCardGrid';
 import PaginationControls from '../../components/shared/PaginationControls';
 import { useFormSubmissionWithUploads } from '../../hooks/useFormSubmissionWithUploads';
 import { useTranslation } from 'react-i18next';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 import {
   Badge,
   Button,
@@ -60,6 +61,7 @@ import {
 
 const Insurance = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const navigate = useNavigate();
   const responsive = useResponsive();
@@ -473,6 +475,8 @@ const Insurance = () => {
             label: t('insurance.actions.addNew', '+ Add New Insurance'),
             onClick: handleAddNew,
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
@@ -511,6 +515,8 @@ const Insurance = () => {
                   onView={handleViewInsurance}
                   fileCount={fileCounts[insurance.id] || 0}
                   fileCountLoading={fileCountsLoading[insurance.id] || false}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                 />
               )}
             />
@@ -520,6 +526,9 @@ const Insurance = () => {
               persistKey="insurance"
               data={paginatedInsurances}
               pagination={false}
+              disableEdit={isViewOnly}
+              disableDelete={isViewOnly}
+              disableActionsTooltip={viewOnlyTooltip}
               columns={[
                 { header: 'Type', accessor: 'insurance_type', priority: 'high', width: 100 },
                 { header: 'Company', accessor: 'company_name', priority: 'high', width: 180 },
@@ -591,6 +600,8 @@ const Insurance = () => {
         onClose={handleCloseViewModal}
         insurance={viewingInsurance}
         onEdit={handleEdit}
+        disableEdit={isViewOnly}
+        disableEditTooltip={viewOnlyTooltip}
         onPrint={(insurance) => {
           printInsuranceRecord(
             insurance,

--- a/frontend/src/pages/medical/LabResults.jsx
+++ b/frontend/src/pages/medical/LabResults.jsx
@@ -48,9 +48,11 @@ import {
   Paper,
 } from '@mantine/core';
 import { IconFileUpload } from '@tabler/icons-react';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const LabResults = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const navigate = useNavigate();
   const location = useLocation();
@@ -674,6 +676,8 @@ const LabResults = () => {
               fileCount={fileCounts[result.id] || 0}
               fileCountLoading={fileCountsLoading[result.id] || false}
               navigate={navigate}
+              disableActions={isViewOnly}
+              disableActionsTooltip={viewOnlyTooltip}
             />
           )}
         />
@@ -686,6 +690,9 @@ const LabResults = () => {
           persistKey="lab-results"
           data={paginatedLabResults}
           pagination={false}
+          disableEdit={isViewOnly}
+          disableDelete={isViewOnly}
+          disableActionsTooltip={viewOnlyTooltip}
           columns={[
             { header: t('shared:fields.testName', 'Test Name'), accessor: 'test_name', priority: 'high', width: 200 },
             { header: t('shared:labels.category', 'Category'), accessor: 'test_category', priority: 'low', width: 150 },
@@ -752,6 +759,8 @@ const LabResults = () => {
               label: t('labresults:addNew', '+ Add New Lab Result'),
               onClick: handleAddLabResult,
               size: 'sm',
+              disabled: isViewOnly,
+              tooltip: viewOnlyTooltip,
             }}
             secondaryActions={[
               {
@@ -824,6 +833,8 @@ const LabResults = () => {
         labResult={viewingLabResult}
         onEdit={handleEditLabResult}
         practitioners={practitioners}
+        disableEdit={isViewOnly}
+        disableEditTooltip={viewOnlyTooltip}
         conditions={conditions}
         labResultConditions={labResultConditions}
         fetchLabResultConditions={fetchLabResultConditions}

--- a/frontend/src/pages/medical/MedicalEquipment.jsx
+++ b/frontend/src/pages/medical/MedicalEquipment.jsx
@@ -23,6 +23,7 @@ import {
   EQUIPMENT_TYPE_OPTIONS,
   EQUIPMENT_STATUS_OPTIONS,
 } from '../../constants/equipmentConstants';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 import {
   Button,
   Stack,
@@ -112,6 +113,7 @@ const useSimpleDataManagement = (data, config) => {
 
 const MedicalEquipment = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const [viewMode, setViewMode] = usePersistedViewMode('medical-equipment');
   const { page, setPage, pageSize, handlePageSizeChange, paginateData, totalPages, resetPage, clampPage, PAGE_SIZE_OPTIONS } = usePagination();
 
@@ -283,6 +285,8 @@ const MedicalEquipment = () => {
               label: t('equipment.addEquipment', '+ Add Equipment'),
               onClick: handleAddEquipment,
               size: 'sm',
+              disabled: isViewOnly,
+              tooltip: viewOnlyTooltip,
             }}
             viewMode={viewMode}
             onViewModeChange={setViewMode}
@@ -317,6 +321,8 @@ const MedicalEquipment = () => {
                   onEdit={handleEditEquipment}
                   onDelete={handleDeleteEquipment}
                   onView={handleViewEquipment}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                   onError={(error) => {
                     logger.error('EquipmentCard error', {
                       equipmentId: equip.id,
@@ -352,6 +358,8 @@ const MedicalEquipment = () => {
         equipment={viewingEquipment}
         onEdit={handleEditEquipment}
         practitioners={practitioners}
+        disableEdit={isViewOnly}
+        disableEditTooltip={viewOnlyTooltip}
       />
     </>
   );

--- a/frontend/src/pages/medical/Medication.jsx
+++ b/frontend/src/pages/medical/Medication.jsx
@@ -59,9 +59,11 @@ import {
 } from '../../constants/medicationTypes';
 import { useFormSubmissionWithUploads } from '../../hooks/useFormSubmissionWithUploads';
 import logger from '../../services/logger';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const Medication = () => {
   const { t } = useTranslation(['common', 'medical', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const navigate = useNavigate();
   const responsive = useResponsive();
@@ -516,6 +518,8 @@ const Medication = () => {
             onClick: handleAddMedication,
             leftSection: <IconPlus size={16} />,
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
@@ -702,6 +706,8 @@ const Medication = () => {
                   fileCount={fileCounts[medication.id] || 0}
                   fileCountLoading={fileCountsLoading[medication.id] || false}
                   onError={setError}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                 />
               )}
             />
@@ -711,6 +717,9 @@ const Medication = () => {
                 persistKey="medications"
                 data={paginatedMedications}
                 pagination={false}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   {
                     header: 'Medication Name',
@@ -806,6 +815,8 @@ const Medication = () => {
           onError={setError}
           practitioners={practitioners}
           conditions={conditions}
+          disableEdit={isViewOnly}
+          disableEditTooltip={viewOnlyTooltip}
         />
       </Stack>
     </Container>

--- a/frontend/src/pages/medical/Procedures.jsx
+++ b/frontend/src/pages/medical/Procedures.jsx
@@ -405,7 +405,7 @@ const Procedures = () => {
               filteredMessage={t('shared:emptyStates.adjustSearch', 'Try adjusting your search or filter criteria.')}
               noDataMessage={t('procedures.startAdding', 'Start by adding your first procedure.')}
               actionButton={
-                <Button variant="filled" onClick={handleAddProcedure}>
+                <Button variant="filled" onClick={handleAddProcedure} disabled={isViewOnly}>
                   {t('procedures.addFirstProcedure', 'Add Your First Procedure')}
                 </Button>
               }

--- a/frontend/src/pages/medical/Procedures.jsx
+++ b/frontend/src/pages/medical/Procedures.jsx
@@ -36,6 +36,7 @@ import ProcedureCard from '../../components/medical/procedures/ProcedureCard';
 import ProcedureViewModal from '../../components/medical/procedures/ProcedureViewModal';
 import ProcedureFormWrapper from '../../components/medical/procedures/ProcedureFormWrapper';
 import { useFormSubmissionWithUploads } from '../../hooks/useFormSubmissionWithUploads';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 import {
   Button,
   Stack,
@@ -66,6 +67,7 @@ const INITIAL_FORM_DATA = {
 
 const Procedures = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const navigate = useNavigate();
   const responsive = useResponsive();
@@ -383,6 +385,8 @@ const Procedures = () => {
               label: t('procedures.addProcedure', '+ Add Procedure'),
               onClick: handleAddProcedure,
               size: 'sm',
+              disabled: isViewOnly,
+              tooltip: viewOnlyTooltip,
             }}
             viewMode={viewMode}
             onViewModeChange={setViewMode}
@@ -420,6 +424,8 @@ const Procedures = () => {
                   fileCount={fileCounts[procedure.id] || 0}
                   fileCountLoading={fileCountsLoading[procedure.id] || false}
                   navigate={navigate}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                 />
               )}
             />
@@ -429,6 +435,9 @@ const Procedures = () => {
                 persistKey="procedures"
                 data={paginatedProcedures}
                 pagination={false}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   { header: t('shared:fields.procedureName'), accessor: 'procedure_name', priority: 'high', width: 200 },
                   { header: t('shared:labels.type'), accessor: 'procedure_type', priority: 'medium', width: 120 },
@@ -491,6 +500,8 @@ const Procedures = () => {
         onEdit={handleEditProcedure}
         practitioners={practitioners}
         navigate={navigate}
+        disableEdit={isViewOnly}
+        disableEditTooltip={viewOnlyTooltip}
         onFileUploadComplete={(success) => {
           if (success && viewingProcedure) {
             refreshFileCount(viewingProcedure.id);

--- a/frontend/src/pages/medical/Symptoms.jsx
+++ b/frontend/src/pages/medical/Symptoms.jsx
@@ -41,9 +41,11 @@ import { SYMPTOM_STATUS_COLORS } from '../../constants/symptomEnums';
 import { useDateFormat } from '../../hooks/useDateFormat';
 import { usePagination } from '../../hooks/usePagination';
 import PaginationControls from '../../components/shared/PaginationControls';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const Symptoms = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const { page, setPage, pageSize, handlePageSizeChange, paginateData, totalPages, clampPage, PAGE_SIZE_OPTIONS } = usePagination();
 
@@ -482,6 +484,8 @@ const Symptoms = () => {
           onClick: handleAddSymptom,
           leftSection: <IconPlus size={16} />,
           size: 'sm',
+          disabled: isViewOnly,
+          tooltip: viewOnlyTooltip,
         }}
         showViewToggle={false}
         mb={0}
@@ -668,6 +672,8 @@ const Symptoms = () => {
         onLogEpisode={handleLogEpisode}
         onEditOccurrence={handleEditOccurrence}
         onRefresh={fetchSymptoms}
+        disableEdit={isViewOnly}
+        disableEditTooltip={viewOnlyTooltip}
       />
 
       {/* Symptom Definition Form Modal */}

--- a/frontend/src/pages/medical/Symptoms.jsx
+++ b/frontend/src/pages/medical/Symptoms.jsx
@@ -614,6 +614,7 @@ const Symptoms = () => {
                         variant="filled"
                         color="green"
                         leftSection={<IconNote size={14} />}
+                        disabled={isViewOnly}
                         onClick={() => handleLogEpisode(symptom)}
                       >
                         {t('symptoms.logEpisode', 'Log Episode')}
@@ -630,6 +631,7 @@ const Symptoms = () => {
                         size="xs"
                         variant="light"
                         leftSection={<IconEdit size={14} />}
+                        disabled={isViewOnly}
                         onClick={() => handleEditSymptom(symptom)}
                       >
                         {t('shared:labels.edit', 'Edit')}
@@ -639,6 +641,7 @@ const Symptoms = () => {
                         variant="light"
                         color="red"
                         leftSection={<IconTrash size={14} />}
+                        disabled={isViewOnly}
                         onClick={() => handleDeleteSymptom(symptom.id)}
                       >
                         {t('buttons.delete', 'Delete')}

--- a/frontend/src/pages/medical/Treatments.jsx
+++ b/frontend/src/pages/medical/Treatments.jsx
@@ -39,9 +39,11 @@ import {
   Paper,
 } from '@mantine/core';
 import MedicalPageAlerts from '../../components/shared/MedicalPageAlerts';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const Treatments = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const navigate = useNavigate();
   const responsive = useResponsive();
@@ -430,6 +432,8 @@ const Treatments = () => {
               label: t('treatments.addTreatment', '+ Add Treatment'),
               onClick: handleAddTreatment,
               size: 'sm',
+              disabled: isViewOnly,
+              tooltip: viewOnlyTooltip,
             }}
             viewMode={viewMode}
             onViewModeChange={setViewMode}
@@ -468,6 +472,8 @@ const Treatments = () => {
                   navigate={navigate}
                   fileCount={fileCounts[treatment.id] || 0}
                   fileCountLoading={fileCountsLoading[treatment.id] || false}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                   onError={(error) => {
                     logger.error('TreatmentCard error', {
                       treatmentId: treatment.id,
@@ -484,6 +490,9 @@ const Treatments = () => {
               persistKey="treatments"
               data={paginatedTreatments}
               pagination={false}
+              disableEdit={isViewOnly}
+              disableDelete={isViewOnly}
+              disableActionsTooltip={viewOnlyTooltip}
               columns={[
                   { header: 'Treatment', accessor: 'treatment_name', priority: 'high', width: 200 },
                   { header: 'Type', accessor: 'treatment_type', priority: 'medium', width: 120 },
@@ -580,6 +589,8 @@ const Treatments = () => {
         onLabResultClick={handleLabResultClick}
         onEquipmentClick={handleEquipmentClick}
         navigate={navigate}
+        disableEdit={isViewOnly}
+        disableEditTooltip={viewOnlyTooltip}
       />
     </>
   );

--- a/frontend/src/pages/medical/Visits.jsx
+++ b/frontend/src/pages/medical/Visits.jsx
@@ -40,9 +40,11 @@ import { useFormSubmissionWithUploads } from '../../hooks/useFormSubmissionWithU
 import VisitCard from '../../components/medical/visits/VisitCard';
 import VisitViewModal from '../../components/medical/visits/VisitViewModal';
 import VisitFormWrapper from '../../components/medical/visits/VisitFormWrapper';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const Visits = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { formatDate } = useDateFormat();
   const [viewMode, setViewMode] = usePersistedViewMode('visits');
   const { page, setPage, pageSize, handlePageSizeChange, paginateData, totalPages, resetPage, clampPage, PAGE_SIZE_OPTIONS } = usePagination();
@@ -538,6 +540,8 @@ const Visits = () => {
             onClick: handleAddVisit,
             leftSection: <IconPlus size={16} />,
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
@@ -570,6 +574,8 @@ const Visits = () => {
                   fileCount={fileCounts[visit.id] || 0}
                   fileCountLoading={fileCountsLoading[visit.id] || false}
                   navigate={navigate}
+                  disableActions={isViewOnly}
+                  disableActionsTooltip={viewOnlyTooltip}
                 />
               )}
             />
@@ -579,6 +585,9 @@ const Visits = () => {
                 persistKey="visits"
                 data={paginatedVisits}
                 pagination={false}
+                disableEdit={isViewOnly}
+                disableDelete={isViewOnly}
+                disableActionsTooltip={viewOnlyTooltip}
                 columns={[
                   { header: t('visits.table.visitDate', 'Visit Date'), accessor: 'date', priority: 'high', width: 120 },
                   { header: t('shared:labels.reason', 'Reason'), accessor: 'reason', priority: 'high', width: 150 },
@@ -661,6 +670,8 @@ const Visits = () => {
         conditions={conditions}
         navigate={navigate}
         isBlocking={isBlocking}
+        disableEdit={isViewOnly}
+        disableEditTooltip={viewOnlyTooltip}
         onFileUploadComplete={(success) => {
           if (success && viewingVisit) {
             refreshFileCount(viewingVisit.id);

--- a/frontend/src/pages/medical/Vitals.jsx
+++ b/frontend/src/pages/medical/Vitals.jsx
@@ -61,9 +61,11 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { VITAL_FILTER_TYPES } from '../../constants/vitalFilters';
 import { useUserPreferences } from '../../contexts/UserPreferencesContext';
 import { convertForDisplay, unitLabels } from '../../utils/unitConversion';
+import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const Vitals = () => {
   const { t } = useTranslation(['common', 'shared']);
+  const { isViewOnly, viewOnlyTooltip } = usePatientPermissions();
   const { unitSystem } = useUserPreferences();
 
   // Quick stats card configurations with Mantine icons and filter mappings
@@ -522,6 +524,8 @@ const Vitals = () => {
             onClick: handleAddNew,
             leftSection: <IconPlus size={16} />,
             size: 'sm',
+            disabled: isViewOnly,
+            tooltip: viewOnlyTooltip,
           }}
           secondaryActions={[{
             label: t('vitals:import.title', 'Import Vitals'),
@@ -658,6 +662,8 @@ const Vitals = () => {
           onEdit={handleEdit}
           practitioners={practitioners}
           navigate={navigate}
+          disableEdit={isViewOnly}
+          disableEditTooltip={viewOnlyTooltip}
         />
 
         {/* Vitals Import Modal */}

--- a/frontend/src/pages/medical/__tests__/Conditions.integration.test.jsx
+++ b/frontend/src/pages/medical/__tests__/Conditions.integration.test.jsx
@@ -37,7 +37,19 @@ vi.mock('../../../hooks/useDataManagement', () => {
 });
 vi.mock('../../../hooks/useGlobalData', () => ({
   useGlobalData: () => ({ patients: [], loading: false }),
+  useCurrentPatient: () => ({ patient: { id: 1, owner_user_id: 1, permission_level: 'full' }, loading: false }),
   useCacheManager: () => ({ invalidatePatientList: vi.fn() }),
+}));
+vi.mock('../../../hooks/usePatientPermissions', () => ({
+  usePatientPermissions: () => ({
+    isOwner: true,
+    permissionLevel: 'full',
+    canCreate: true,
+    canEdit: true,
+    canDelete: true,
+    isViewOnly: false,
+    viewOnlyTooltip: undefined,
+  }),
 }));
 vi.mock('../../../hooks/usePersistedViewMode', () => ({
   usePersistedViewMode,

--- a/frontend/src/pages/medical/__tests__/EmergencyContacts.integration.test.jsx
+++ b/frontend/src/pages/medical/__tests__/EmergencyContacts.integration.test.jsx
@@ -38,6 +38,20 @@ vi.mock('../../../hooks/usePersistedViewMode', () => ({ usePersistedViewMode }))
 vi.mock('../../../hooks/useResponsive', () => ({
   useResponsive: () => ({ isMobile: false, isTablet: false, isDesktop: true }),
 }));
+vi.mock('../../../hooks/useGlobalData', () => ({
+  useCurrentPatient: () => ({ patient: { id: 1, owner_user_id: 1, permission_level: 'full' }, loading: false }),
+}));
+vi.mock('../../../hooks/usePatientPermissions', () => ({
+  usePatientPermissions: () => ({
+    isOwner: true,
+    permissionLevel: 'full',
+    canCreate: true,
+    canEdit: true,
+    canDelete: true,
+    isViewOnly: false,
+    viewOnlyTooltip: undefined,
+  }),
+}));
 
 // --- Utility / service mocks ---
 vi.mock('../../../services/logger', () => ({

--- a/frontend/src/pages/medical/__tests__/LabResults.integration.test.jsx
+++ b/frontend/src/pages/medical/__tests__/LabResults.integration.test.jsx
@@ -49,6 +49,18 @@ vi.mock('../../../hooks/useGlobalData', () => ({
     ],
     loading: false,
   }),
+  useCurrentPatient: () => ({ patient: { id: 1, owner_user_id: 1, permission_level: 'full' }, loading: false }),
+}));
+vi.mock('../../../hooks/usePatientPermissions', () => ({
+  usePatientPermissions: () => ({
+    isOwner: true,
+    permissionLevel: 'full',
+    canCreate: true,
+    canEdit: true,
+    canDelete: true,
+    isViewOnly: false,
+    viewOnlyTooltip: undefined,
+  }),
 }));
 vi.mock('../../../hooks/useFormSubmissionWithUploads', () => ({
   useFormSubmissionWithUploads: () => ({

--- a/frontend/src/pages/medical/__tests__/Medication.integration.test.jsx
+++ b/frontend/src/pages/medical/__tests__/Medication.integration.test.jsx
@@ -52,6 +52,18 @@ vi.mock('../../../hooks/useGlobalData', () => ({
       { id: 2, name: 'Walgreens - Downtown' },
     ]},
   }),
+  useCurrentPatient: () => ({ patient: { id: 1, owner_user_id: 1, permission_level: 'full' }, loading: false }),
+}));
+vi.mock('../../../hooks/usePatientPermissions', () => ({
+  usePatientPermissions: () => ({
+    isOwner: true,
+    permissionLevel: 'full',
+    canCreate: true,
+    canEdit: true,
+    canDelete: true,
+    isViewOnly: false,
+    viewOnlyTooltip: undefined,
+  }),
 }));
 
 // --- Service mocks ---

--- a/frontend/src/pages/medical/__tests__/Procedures.integration.test.jsx
+++ b/frontend/src/pages/medical/__tests__/Procedures.integration.test.jsx
@@ -77,7 +77,21 @@ vi.mock('../../../hooks/useDataManagement', () => ({ useDataManagement, default:
 vi.mock('../../../hooks/useEntityFileCounts', () => ({ useEntityFileCounts }));
 vi.mock('../../../hooks/useViewModalNavigation', () => ({ useViewModalNavigation, default: useViewModalNavigation }));
 vi.mock('../../../hooks/usePersistedViewMode', () => ({ usePersistedViewMode }));
-vi.mock('../../../hooks/useGlobalData', () => ({ usePractitioners }));
+vi.mock('../../../hooks/useGlobalData', () => ({
+  usePractitioners,
+  useCurrentPatient: () => ({ patient: { id: 1, owner_user_id: 1, permission_level: 'full' }, loading: false }),
+}));
+vi.mock('../../../hooks/usePatientPermissions', () => ({
+  usePatientPermissions: () => ({
+    isOwner: true,
+    permissionLevel: 'full',
+    canCreate: true,
+    canEdit: true,
+    canDelete: true,
+    isViewOnly: false,
+    viewOnlyTooltip: undefined,
+  }),
+}));
 vi.mock('../../../hooks/useDateFormat', () => ({ useDateFormat }));
 vi.mock('../../../hooks/useResponsive', () => ({ useResponsive, default: useResponsive }));
 vi.mock('../../../hooks/useFormSubmissionWithUploads', () => ({ useFormSubmissionWithUploads }));

--- a/frontend/src/pages/medical/__tests__/Symptoms.translations.test.jsx
+++ b/frontend/src/pages/medical/__tests__/Symptoms.translations.test.jsx
@@ -54,6 +54,18 @@ vi.mock('../../../services/api/symptomApi', () => ({
 
 vi.mock('../../../hooks/useGlobalData', () => ({
   usePatientWithStaticData: () => stablePatientData,
+  useCurrentPatient: () => ({ patient: { id: 1, owner_user_id: 1, permission_level: 'full' }, loading: false }),
+}));
+vi.mock('../../../hooks/usePatientPermissions', () => ({
+  usePatientPermissions: () => ({
+    isOwner: true,
+    permissionLevel: 'full',
+    canCreate: true,
+    canEdit: true,
+    canDelete: true,
+    isViewOnly: false,
+    viewOnlyTooltip: undefined,
+  }),
 }));
 
 vi.mock('../../../hooks/useViewModalNavigation', () => ({


### PR DESCRIPTION
This pull request significantly improves and standardizes patient record access control throughout the API endpoints, supporting both owned and shared patient records and ensuring proper permission checks for sensitive operations. The main changes include updating dependency injections to provide the full `User` object and active patient context, replacing direct patient ownership checks with a more flexible `verify_patient_ownership` function, and enhancing permission checks for editing patient-related entities.

**Access Control Enhancements:**

* The `get_current_user_patient_id` dependency now allows access not just to owned patients, but also to patients shared with the user, using the `PatientAccessService` to check permissions. [[1]](diffhunk://#diff-a20068345295483bcc6bf6cdeb643eaed6fbddfdea25780683abfb492cbf37c1L558-L561) [[2]](diffhunk://#diff-a20068345295483bcc6bf6cdeb643eaed6fbddfdea25780683abfb492cbf37c1R569-R583)
* All endpoints dealing with patient-related entities (allergies, conditions, encounters, etc.) now inject both the `current_user` object and `current_user_patient_id`, providing richer user context for downstream permission checks. [[1]](diffhunk://#diff-5ad8179468831dab6d686f00e38839a4a5b064d6f5782615695db2057f8e002eR42-R43) [[2]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250R54-R55) [[3]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR50-R51) [[4]](diffhunk://#diff-a56b9a1d618fba1d575b9b3b36e01de38fe38030d933cba9f4426d93390a61b0R41-R55) and others)

**Standardized Permission Checks:**

* Ownership and access checks are now consistently performed using the `verify_patient_ownership` function, which supports both owned and shared records and can enforce specific permissions (e.g., "view" or "edit"). This replaces previous direct patient ID comparisons and custom logic. [[1]](diffhunk://#diff-5ad8179468831dab6d686f00e38839a4a5b064d6f5782615695db2057f8e002eL172-R177) [[2]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L176-R183) [[3]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L243-R240) [[4]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L358-R345) [[5]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR131-R139) [[6]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR275-R281) [[7]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR317-R328) [[8]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR367-R378) [[9]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR406-R412) [[10]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR435-R441) [[11]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L669-R644)
* Emergency contact creation now explicitly verifies the user has "edit" permission on the target patient, not just "view" access, before allowing the operation.

**Relationship Consistency Checks:**

* When linking medications or lab results to conditions or encounters, the code now verifies that the related entities belong to the same patient (not just the current user's active patient), preventing cross-patient data relationships. [[1]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L276-R260) [[2]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L391-R365) [[3]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR317-R328) [[4]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR367-R378)

**Dependency Injection Improvements:**

* All relevant endpoints now consistently inject both `current_user` and `current_user_patient_id` for downstream use, improving clarity and reducing redundant queries. [[1]](diffhunk://#diff-5ad8179468831dab6d686f00e38839a4a5b064d6f5782615695db2057f8e002eR42-R43) [[2]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250R54-R55) [[3]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR50-R51) [[4]](diffhunk://#diff-a56b9a1d618fba1d575b9b3b36e01de38fe38030d933cba9f4426d93390a61b0R41-R55) and others)

These changes collectively make access control more robust, flexible, and maintainable across the API.

**References:**
[[1]](diffhunk://#diff-a20068345295483bcc6bf6cdeb643eaed6fbddfdea25780683abfb492cbf37c1L558-L561) [[2]](diffhunk://#diff-a20068345295483bcc6bf6cdeb643eaed6fbddfdea25780683abfb492cbf37c1R569-R583) [[3]](diffhunk://#diff-5ad8179468831dab6d686f00e38839a4a5b064d6f5782615695db2057f8e002eR42-R43) [[4]](diffhunk://#diff-5ad8179468831dab6d686f00e38839a4a5b064d6f5782615695db2057f8e002eR56-R57) [[5]](diffhunk://#diff-5ad8179468831dab6d686f00e38839a4a5b064d6f5782615695db2057f8e002eR166) [[6]](diffhunk://#diff-5ad8179468831dab6d686f00e38839a4a5b064d6f5782615695db2057f8e002eL172-R177) [[7]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250R54-R55) [[8]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250R66-R67) [[9]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250R161) [[10]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L176-R183) [[11]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250R218) [[12]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L243-R240) [[13]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L276-R260) [[14]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250R315) [[15]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L358-R345) [[16]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L391-R365) [[17]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250R633) [[18]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L669-R644) [[19]](diffhunk://#diff-a56b9a1d618fba1d575b9b3b36e01de38fe38030d933cba9f4426d93390a61b0R41-R55) [[20]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR50-R51) [[21]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR62-R63) [[22]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR131-R139) [[23]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR275-R281) [[24]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR317-R328) [[25]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR367-R378) [[26]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR406-R412) [[27]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deR435-R441)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View-only patient access: UI disables create/edit/delete across pages and shows explanatory tooltips; permission level surfaced in API responses and via a new patient-permission hook.

* **Refactor**
  * Centralized and strengthened authorization checks to handle both owned and shared patient records.

* **Localization**
  * Added "view-only" translation keys in multiple locales.

* **Tests**
  * Updated test mocks to include patient/permission context for integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->