### PR TITLE
fix(786): Fix date input in EU format

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,9 @@ import './i18n';
 // Mantine
 import { MantineProvider } from '@mantine/core';
 import { DatesProvider } from '@mantine/dates';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+dayjs.extend(customParseFormat);
 import { Notifications } from '@mantine/notifications';
 import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';

--- a/frontend/src/components/medical/medications/__tests__/MedicationViewModal.test.jsx
+++ b/frontend/src/components/medical/medications/__tests__/MedicationViewModal.test.jsx
@@ -1,0 +1,110 @@
+import { vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import '@testing-library/jest-dom';
+import MedicationViewModal from '../MedicationViewModal';
+
+vi.mock('../../../../hooks/useDateFormat', () => ({
+  useDateFormat: () => ({
+    formatDate: (date) => {
+      if (!date) return null;
+      const d = new Date(date + 'T00:00:00');
+      return `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
+    },
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, defaultValue) => defaultValue || key,
+  }),
+}));
+
+vi.mock('../../../../hooks/useTagColors', () => ({
+  useTagColors: () => ({ getTagColor: () => 'blue' }),
+}));
+
+vi.mock('../../../../utils/linkNavigation', () => ({
+  navigateToEntity: vi.fn(),
+}));
+
+vi.mock('../../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('../DocumentManagerWithProgress', () => ({ default: () => null }));
+vi.mock('../../shared/DocumentManagerWithProgress', () => ({ default: () => null }));
+vi.mock('../MedicationTreatmentsList', () => ({ default: () => null }));
+vi.mock('../MedicationRelationships', () => ({ default: () => null }));
+vi.mock('../StatusBadge', () => ({ default: ({ status }) => <span>{status}</span> }));
+vi.mock('../../common/ClickableTagBadge', () => ({ ClickableTagBadge: ({ children }) => <span>{children}</span> }));
+
+const MantineWrapper = ({ children }) => <MantineProvider>{children}</MantineProvider>;
+
+describe('MedicationViewModal - alternative_name', () => {
+  const baseMedication = {
+    id: 1,
+    medication_name: 'Acetaminophen',
+    alternative_name: null,
+    medication_type: 'otc',
+    dosage: '500mg',
+    frequency: 'every 6 hours',
+    route: 'oral',
+    indication: 'Pain relief',
+    status: 'active',
+    effective_period_start: null,
+    effective_period_end: null,
+    tags: [],
+    practitioner: null,
+    pharmacy: null,
+  };
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    medication: baseMedication,
+    onEdit: vi.fn(),
+    navigate: vi.fn(),
+    onError: vi.fn(),
+    onFileUploadComplete: vi.fn(),
+    practitioners: [],
+    conditions: [],
+  };
+
+  it('renders alternative name when present', () => {
+    const medication = { ...baseMedication, alternative_name: 'Paracetamol' };
+    render(
+      <MantineWrapper>
+        <MedicationViewModal {...defaultProps} medication={medication} />
+      </MantineWrapper>
+    );
+
+    expect(screen.getByText('Alternative Name')).toBeInTheDocument();
+    expect(screen.getByText('Paracetamol')).toBeInTheDocument();
+  });
+
+  it('shows not specified when alternative name is absent', () => {
+    render(
+      <MantineWrapper>
+        <MedicationViewModal {...defaultProps} />
+      </MantineWrapper>
+    );
+
+    expect(screen.getByText('Alternative Name')).toBeInTheDocument();
+    // Multiple fields show "Not specified" when null — verify at least one is present
+    expect(screen.getAllByText('Not specified').length).toBeGreaterThan(0);
+  });
+
+  it('renders medication name correctly', () => {
+    render(
+      <MantineWrapper>
+        <MedicationViewModal {...defaultProps} />
+      </MantineWrapper>
+    );
+
+    expect(screen.getByText('Medication Name')).toBeInTheDocument();
+    // "Acetaminophen" appears in both the modal title header and the field value
+    expect(screen.getAllByText('Acetaminophen').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -4,6 +4,9 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import { expect, afterEach, afterAll, beforeAll, vi } from 'vitest';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+dayjs.extend(customParseFormat);
 import { configure } from '@testing-library/react';
 
 // i18next mock t() — returns the fallback/default value when provided, otherwise the key.

--- a/frontend/src/utils/dateFormatUtils.test.js
+++ b/frontend/src/utils/dateFormatUtils.test.js
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'vitest';
+import dayjs from 'dayjs';
 import {
   getLocaleForFormat,
   formatDateWithPreference,
@@ -236,5 +237,34 @@ describe('dateFormatUtils', () => {
       const result = formatDateWithPreference('  2026-01-25  ', 'mdy');
       expect(result).toBe('01/25/2026');
     });
+  });
+});
+
+// Regression test: customParseFormat dayjs plugin must be registered (via setupTests.js and App.jsx)
+// so that Mantine's DateInput can parse manually-typed dates using the user's preferred format.
+// Without the plugin, dayjs ignores the valueFormat string and falls back to JS native Date
+// parsing (always US/MM-DD-YYYY), breaking European date input.
+describe('dayjs customParseFormat plugin (regression for European date input bug)', () => {
+  test('parses European date DD/MM/YYYY correctly', () => {
+    const parsed = dayjs('25/01/2026', 'DD/MM/YYYY');
+    expect(parsed.isValid()).toBe(true);
+    expect(parsed.month()).toBe(0); // January (0-indexed)
+    expect(parsed.date()).toBe(25);
+    expect(parsed.year()).toBe(2026);
+  });
+
+  test('parses US date MM/DD/YYYY correctly', () => {
+    const parsed = dayjs('01/25/2026', 'MM/DD/YYYY');
+    expect(parsed.isValid()).toBe(true);
+    expect(parsed.month()).toBe(0); // January (0-indexed)
+    expect(parsed.date()).toBe(25);
+    expect(parsed.year()).toBe(2026);
+  });
+
+  test('distinguishes DD/MM/YYYY from MM/DD/YYYY for ambiguous dates', () => {
+    const eu = dayjs('05/01/2026', 'DD/MM/YYYY');
+    const us = dayjs('05/01/2026', 'MM/DD/YYYY');
+    expect(eu.month()).toBe(0);  // January 5th (European)
+    expect(us.month()).toBe(4);  // May 1st (US)
   });
 });


### PR DESCRIPTION
Mantine's DateInput component uses dayjs under the hood to parse manually-typed dates. Without the customParseFormat dayjs plugin registered, dayjs ignores the valueFormat prop and falls back to native JS Date parsing, which always assumes MM/DD/YYYY —  breaking date entry for users with European locale preferences.
                                                                                                                                    
  Changes:        
  - Register the dayjs/plugin/customParseFormat plugin at app startup (App.jsx) so DateInput correctly parses typed dates in the user's preferred format (e.g. 25/01/2026 for DD/MM/YYYY users)                                                                    
  - Also register the plugin in setupTests.js so test environments match production behaviour
  - Add regression tests to dateFormatUtils.test.js verifying correct EU/US format disambiguation                                   
  - Add MedicationViewModal component tests covering alternative_name field rendering        

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the medication view modal component with coverage for alternative name scenarios
  * Added regression tests validating date format parsing behavior
  * Updated test environment configuration with enhanced date parsing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->