### PR TITLE
fix(i18n): corrected date formatting with localization mix up

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 // Import i18n configuration (initialized in index.js)
 import './i18n';
+import { useTranslation } from 'react-i18next';
 
 // Mantine
 import { MantineProvider } from '@mantine/core';
@@ -19,6 +20,19 @@ import { Notifications } from '@mantine/notifications';
 import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';
 import '@mantine/notifications/styles.css';
+
+// dayjs locale imports for Mantine date picker calendar month names
+import 'dayjs/locale/fr';
+import 'dayjs/locale/de';
+import 'dayjs/locale/es';
+import 'dayjs/locale/it';
+import 'dayjs/locale/pt';
+import 'dayjs/locale/ru';
+import 'dayjs/locale/sv';
+import 'dayjs/locale/nl';
+import 'dayjs/locale/pl';
+import 'dayjs/locale/th';
+import 'dayjs/locale/zh';
 
 import { theme, cssVariablesResolver } from './theme';
 
@@ -304,11 +318,14 @@ function WhatsNewTrigger() {
 // so both CSS variables and Mantine switch in the same render - no flash.
 function ThemedMantineProvider({ children }) {
   const { theme: colorScheme } = useTheme();
+  // useSuspense: false — we only read i18n.language here, not translated strings,
+  // so there's no reason to suspend this high-tree component during language changes.
+  const { i18n } = useTranslation(undefined, { useSuspense: false });
   return (
     <MantineProvider theme={theme} forceColorScheme={colorScheme} cssVariablesResolver={cssVariablesResolver}>
       <Notifications />
       <ResponsiveProvider>
-        <DatesProvider settings={{}}>
+        <DatesProvider settings={{ locale: i18n.language }}>
           {children}
         </DatesProvider>
       </ResponsiveProvider>

--- a/frontend/src/hooks/useDateFormat.js
+++ b/frontend/src/hooks/useDateFormat.js
@@ -4,6 +4,7 @@
  */
 
 import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useUserPreferences } from '../contexts/UserPreferencesContext';
 import {
   formatDateWithPreference,
@@ -18,7 +19,7 @@ import {
   formatDateTimeForInputWithPreference,
   getDateTimePlaceholder,
 } from '../utils/dateUtils';
-import { DATE_FORMAT_OPTIONS, DEFAULT_DATE_FORMAT } from '../utils/constants';
+import { DATE_FORMAT_OPTIONS, DEFAULT_DATE_FORMAT, getIntlLocale } from '../utils/constants';
 
 /**
  * Hook that provides date formatting functions using user's preferred format
@@ -26,7 +27,12 @@ import { DATE_FORMAT_OPTIONS, DEFAULT_DATE_FORMAT } from '../utils/constants';
  */
 export const useDateFormat = () => {
   const { dateFormat } = useUserPreferences();
+  // useSuspense: false — we only read i18n.language for locale mapping, not translated strings,
+  // so this hook should not trigger Suspense boundaries during language changes.
+  const { i18n } = useTranslation(undefined, { useSuspense: false });
   const effectiveFormat = dateFormat || DEFAULT_DATE_FORMAT;
+
+  const displayLocale = getIntlLocale(i18n.language);
 
   const formatDate = useCallback(
     (dateValue, options = {}) => {
@@ -58,9 +64,9 @@ export const useDateFormat = () => {
 
   const formatLongDate = useCallback(
     (dateValue, longMonth = false) => {
-      return formatDateLong(dateValue, effectiveFormat, longMonth);
+      return formatDateLong(dateValue, effectiveFormat, { longMonth, displayLocale });
     },
-    [effectiveFormat]
+    [effectiveFormat, displayLocale]
   );
 
   const locale = useMemo(

--- a/frontend/src/hooks/useDateFormat.test.jsx
+++ b/frontend/src/hooks/useDateFormat.test.jsx
@@ -17,9 +17,9 @@ vi.mock('../utils/dateFormatUtils', () => ({
     if (!dateValue) return 'N/A';
     return `formatted-${formatCode}-${dateValue}`;
   }),
-  formatDateLong: vi.fn((dateValue, formatCode, longMonth) => {
+  formatDateLong: vi.fn((dateValue, formatCode, { longMonth, displayLocale } = {}) => {
     if (!dateValue) return 'N/A';
-    return `long-${formatCode}-${dateValue}`;
+    return `long-${formatCode}-${dateValue}-${displayLocale || 'no-locale'}`;
   }),
   formatDateTimeWithPreference: vi.fn((dateValue, formatCode, options) => {
     if (!dateValue) return 'N/A';
@@ -47,6 +47,14 @@ vi.mock('../utils/dateFormatUtils', () => ({
   }),
 }));
 
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en' },
+    t: key => key,
+  }),
+}));
+
 // Mock constants
 vi.mock('../utils/constants', () => ({
   DATE_FORMAT_OPTIONS: {
@@ -55,6 +63,10 @@ vi.mock('../utils/constants', () => ({
     ymd: { code: 'ymd', label: 'YYYY-MM-DD (ISO)', locale: 'sv-SE', pattern: 'YYYY-MM-DD' },
   },
   DEFAULT_DATE_FORMAT: 'mdy',
+  getIntlLocale: langCode => {
+    const map = { en: 'en-US', de: 'de-DE', fr: 'fr-FR' };
+    return map[langCode] || 'en-US';
+  },
 }));
 
 // Mock dateUtils
@@ -121,7 +133,8 @@ describe('useDateFormat', () => {
     const { result } = renderHook(() => useDateFormat());
 
     const formatted = result.current.formatLongDate('2026-01-25');
-    expect(formatted).toBe('long-mdy-2026-01-25');
+    // Should pass displayLocale derived from i18n language ('en' -> 'en-US')
+    expect(formatted).toBe('long-mdy-2026-01-25-en-US');
   });
 
   test('dateFormat returns the effective format from context', () => {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -132,3 +132,23 @@ export const DATE_FORMAT_OPTIONS = {
 };
 
 export const DEFAULT_DATE_FORMAT = 'mdy';
+
+// Map i18n language codes to Intl locale strings for month/day name localization.
+// Date FORMAT (mdy/dmy/ymd) controls ordering; this map controls month NAME language.
+export const I18N_TO_INTL_LOCALE = {
+  en: 'en-US',
+  fr: 'fr-FR',
+  de: 'de-DE',
+  es: 'es-ES',
+  it: 'it-IT',
+  pt: 'pt-BR',
+  ru: 'ru-RU',
+  sv: 'sv-SE',
+  nl: 'nl-NL',
+  pl: 'pl-PL',
+  th: 'th-TH',
+  zh: 'zh-CN',
+};
+
+export const getIntlLocale = langCode =>
+  I18N_TO_INTL_LOCALE[langCode] || 'en-US';

--- a/frontend/src/utils/dateFormatUtils.js
+++ b/frontend/src/utils/dateFormatUtils.js
@@ -91,17 +91,21 @@ export const formatDateWithPreference = (
  * Format a date for display with month name (e.g., "Jan 25, 2026")
  * @param {string|Date|null} dateValue - The date to format
  * @param {string} formatCode - User's preferred format code
- * @param {boolean} longMonth - Use full month name instead of abbreviation
+ * @param {Object} options - Formatting options
+ * @param {boolean} options.longMonth - Use full month name instead of abbreviation
+ * @param {string|null} options.displayLocale - Intl locale for month names (e.g. 'en-US', 'de-DE'),
+ *   overrides the format-derived locale so month names match the UI language instead of the date
+ *   ordering locale (which may be sv-SE for YMD format)
  * @returns {string} Formatted date string
  */
 export const formatDateLong = (
   dateValue,
   formatCode = DEFAULT_DATE_FORMAT,
-  longMonth = false
+  { longMonth = false, displayLocale = null } = {}
 ) => {
   if (!dateValue) return 'N/A';
 
-  const locale = getLocaleForFormat(formatCode);
+  const locale = displayLocale || getLocaleForFormat(formatCode);
 
   try {
     let date;

--- a/frontend/src/utils/dateFormatUtils.test.js
+++ b/frontend/src/utils/dateFormatUtils.test.js
@@ -148,11 +148,12 @@ describe('dateFormatUtils', () => {
       expect(result).toMatch(/Okt/);
     });
 
-    test('falls back to format locale when displayLocale is null', () => {
-      // Without displayLocale, ymd format uses sv-SE (backward compatible)
-      const result = formatDateLong('2026-10-25', 'ymd');
-      expect(result).toBeDefined();
-      expect(result).not.toBe('N/A');
+    test('falls back to format locale (sv-SE for ymd) when displayLocale is absent', () => {
+      // When displayLocale is not provided, ymd format should fall back to sv-SE,
+      // producing output identical to an explicit sv-SE displayLocale.
+      const omitted = formatDateLong('2026-10-25', 'ymd');
+      const explicit = formatDateLong('2026-10-25', 'ymd', { displayLocale: 'sv-SE' });
+      expect(omitted).toBe(explicit);
     });
   });
 

--- a/frontend/src/utils/dateFormatUtils.test.js
+++ b/frontend/src/utils/dateFormatUtils.test.js
@@ -124,7 +124,7 @@ describe('dateFormatUtils', () => {
     });
 
     test('formats date with long month name when longMonth is true', () => {
-      const result = formatDateLong('2026-01-25', 'mdy', true);
+      const result = formatDateLong('2026-01-25', 'mdy', { longMonth: true });
       // Should have "January" instead of "Jan"
       expect(result).toMatch(/January/);
     });
@@ -134,6 +134,25 @@ describe('dateFormatUtils', () => {
       const result = formatDateLong('2026-01-25', 'mdy');
       // Should show 25, not 24 (which would happen with UTC conversion)
       expect(result).toMatch(/25/);
+    });
+
+    test('uses displayLocale for month names when provided', () => {
+      // With en-US displayLocale, October should be "Oct" not "okt" (Swedish)
+      const result = formatDateLong('2026-10-25', 'ymd', { displayLocale: 'en-US' });
+      expect(result).toMatch(/Oct/);
+      expect(result).not.toMatch(/okt/i);
+    });
+
+    test('uses German month names with de-DE displayLocale', () => {
+      const result = formatDateLong('2026-10-25', 'ymd', { displayLocale: 'de-DE' });
+      expect(result).toMatch(/Okt/);
+    });
+
+    test('falls back to format locale when displayLocale is null', () => {
+      // Without displayLocale, ymd format uses sv-SE (backward compatible)
+      const result = formatDateLong('2026-10-25', 'ymd');
+      expect(result).toBeDefined();
+      expect(result).not.toBe('N/A');
     });
   });
 


### PR DESCRIPTION
This pull request improves date localization in the UI by ensuring that month and day names in formatted dates match the user's selected language, regardless of the date format order. It introduces a mapping from i18n language codes to proper Intl locales, updates date formatting utilities and hooks to use this mapping, and adds or updates related unit tests.

**Internationalization and Locale Handling:**

* Added a mapping (`I18N_TO_INTL_LOCALE` and `getIntlLocale`) in `utils/constants.js` to translate i18n language codes to Intl locale strings for accurate localization of month/day names.
* Updated `App.jsx` and Mantine `DatesProvider` to pass the current i18n language as the calendar locale, and imported all supported Day.js locales for calendar display. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R14) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R24-R36) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R321-R328)

**Date Formatting Utilities and Hooks:**

* Modified `formatDateLong` in `dateFormatUtils.js` to accept an options object with `longMonth` and `displayLocale`, using the display locale for month names if provided.
* Updated `useDateFormat` hook to derive the display locale from the current i18n language and pass it to date formatting functions, ensuring formatted dates in the UI use the correct language. [[1]](diffhunk://#diff-54c66ffa8be31a8a19d3ccc499bcc1330bb207cdf5979866ff1293eebe663767R7) [[2]](diffhunk://#diff-54c66ffa8be31a8a19d3ccc499bcc1330bb207cdf5979866ff1293eebe663767L21-R36) [[3]](diffhunk://#diff-54c66ffa8be31a8a19d3ccc499bcc1330bb207cdf5979866ff1293eebe663767L61-R69)

**Testing and Mocks:**

* Enhanced unit tests and mocks in `useDateFormat.test.jsx` and `dateFormatUtils.test.js` to verify correct locale usage in date formatting, including new tests for various locales and updated mocks for `formatDateLong` and i18n. [[1]](diffhunk://#diff-6e4812774fde6651f5040a23693dad6fa96f59079dbebfea9cb8cb67eb9ff761L20-R22) [[2]](diffhunk://#diff-6e4812774fde6651f5040a23693dad6fa96f59079dbebfea9cb8cb67eb9ff761R50-R57) [[3]](diffhunk://#diff-6e4812774fde6651f5040a23693dad6fa96f59079dbebfea9cb8cb67eb9ff761R66-R69) [[4]](diffhunk://#diff-6e4812774fde6651f5040a23693dad6fa96f59079dbebfea9cb8cb67eb9ff761L124-R137) [[5]](diffhunk://#diff-804cdfc2c0d2232e5bb95d3ad390bcdd7fff8df8a4d6ee1eec0da2dc1c9533a5L127-R127) [[6]](diffhunk://#diff-804cdfc2c0d2232e5bb95d3ad390bcdd7fff8df8a4d6ee1eec0da2dc1c9533a5R138-R156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date pickers and all formatted dates now follow the app language, ensuring month names and calendar UI match your selected locale.
  * Improved long-month formatting to respect locale-specific month names.
  * Added localization support for French, German, Spanish, Italian, Portuguese, Russian, Swedish, Dutch, Polish, Thai, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->