### PR TITLE
fix: Correct invalid mock test paths

### DIFF
--- a/frontend/src/components/medical/medications/__tests__/MedicationViewModal.test.jsx
+++ b/frontend/src/components/medical/medications/__tests__/MedicationViewModal.test.jsx
@@ -33,12 +33,11 @@ vi.mock('../../../../services/logger', () => ({
   default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
 
-vi.mock('../DocumentManagerWithProgress', () => ({ default: () => null }));
-vi.mock('../../shared/DocumentManagerWithProgress', () => ({ default: () => null }));
+vi.mock('../../../shared/DocumentManagerWithProgress', () => ({ default: () => null }));
 vi.mock('../MedicationTreatmentsList', () => ({ default: () => null }));
-vi.mock('../MedicationRelationships', () => ({ default: () => null }));
+vi.mock('../../MedicationRelationships', () => ({ default: () => null }));
 vi.mock('../StatusBadge', () => ({ default: ({ status }) => <span>{status}</span> }));
-vi.mock('../../common/ClickableTagBadge', () => ({ ClickableTagBadge: ({ children }) => <span>{children}</span> }));
+vi.mock('../../../common/ClickableTagBadge', () => ({ ClickableTagBadge: ({ children }) => <span>{children}</span> }));
 
 const MantineWrapper = ({ children }) => <MantineProvider>{children}</MantineProvider>;
 


### PR DESCRIPTION
Corrected four invalid vi.mock() paths in MedicationViewModal.test.jsx that were silently failing, causing unmocked dependencies  to load during tests:
                                                                                                                                    
  - Removed duplicate/nonexistent ../DocumentManagerWithProgress mock                                                               
  - Fixed DocumentManagerWithProgress path: ../../shared/ → ../../../shared/
  - Fixed MedicationRelationships path: ../ → ../../                                                                                
  - Fixed ClickableTagBadge path: ../../common/ → ../../../common/ (components/common/ not medical/common/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mock module paths in test configurations to align with current project structure and dependency organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->