### PR TITLE
fix EU date format in German

### DIFF
--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -60,7 +60,7 @@
   "preferences": {
     "dateFormat": {
       "description": "Wählen Sie, wie Datumsangaben in der gesamten Anwendung angezeigt werden",
-      "dmy": "TT.MM.JJJJ (Europäisch)",
+      "dmy": "TT/MM/JJJJ (Europäisch)",
       "mdy": "MM/TT/JJJJ (US)",
       "title": "Datumsformat",
       "ymd": "JJJJ-MM-TT (ISO)"


### PR DESCRIPTION
There are two European date formats:
DD/MM/YYYY and DD.MM.YYYY
MediKeep uses DD/MM/YYYY but in German it was displayed in the settings as DD.MM.YYYY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated German date format example display in settings for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->