### PR TITLE
fix(820): Keep trend direction consistent

### DIFF
--- a/app/api/v1/endpoints/lab_test_component.py
+++ b/app/api/v1/endpoints/lab_test_component.py
@@ -654,7 +654,7 @@ def _calculate_quantitative_statistics(
     # Trend direction using linear regression slope
     from app.utils.trend_statistics import compute_trend_direction
 
-    trend = compute_trend_direction(values)
+    trend = compute_trend_direction(list(reversed(values)))
 
     # Time in range
     normal_count = sum(1 for c in components if c.status == "normal")

--- a/tests/unit/test_trend_statistics.py
+++ b/tests/unit/test_trend_statistics.py
@@ -185,3 +185,27 @@ class TestQuantitativeStatsUnchanged:
         stats = calculate_trend_statistics([comp])
         assert stats.count == 1
         assert stats.result_type == "quantitative"
+
+    def test_trend_direction_uses_chronological_order(self):
+        """Regression: components arrive newest-first (DESC) but trend must reflect
+        oldest-to-newest direction so that a rising series is 'increasing', not
+        'decreasing' (issue #820)."""
+        # Values ordered newest-first: 30, 20, 10 — actually increasing over time
+        components = [
+            _make_quant(30.0, "normal"),
+            _make_quant(20.0, "normal"),
+            _make_quant(10.0, "normal"),
+        ]
+        stats = calculate_trend_statistics(components)
+        assert stats.trend_direction == "increasing"
+
+    def test_trend_direction_decreasing_newest_first(self):
+        """Regression: a falling series passed newest-first must report 'decreasing'."""
+        # Values ordered newest-first: 10, 20, 30 — actually decreasing over time
+        components = [
+            _make_quant(10.0, "normal"),
+            _make_quant(20.0, "normal"),
+            _make_quant(30.0, "normal"),
+        ]
+        stats = calculate_trend_statistics(components)
+        assert stats.trend_direction == "decreasing"


### PR DESCRIPTION
## Summary

   Fixes a bug where the trend direction (increasing/decreasing) shown in the lab component
   detail view was the reverse of what the overview/catalog displayed. Both views query
   components newest-first (DESC), but the detail view was passing that order directly to
   `compute_trend_direction`, which treated index 0 as the oldest point. Adding
   `list(reversed(values))` makes the detail view consistent with the catalog, which already
   reversed correctly.

   ## Related issue

   Closes #820

   ## Type of change

   - [x] Bug fix
   - [ ] New feature
   - [ ] Refactor / code quality
   - [ ] Documentation
   - [ ] Translation / i18n
   - [ ] Other

   ## Testing

   - Added two regression tests in `tests/unit/test_trend_statistics.py`:
     - `test_trend_direction_uses_chronological_order` — newest-first values `[30, 20, 10]`
   (rising over time) must report `increasing`
     - `test_trend_direction_decreasing_newest_first` — newest-first values `[10, 20, 30]`
   (falling over time) must report `decreasing`
   - All 15 unit tests pass (`pytest tests/unit/test_trend_statistics.py`)

   ## Checklist

   - [x] Tests added or updated (or N/A with reason)
   - [x] `npm run lint` and `npm run build` pass — frontend unchanged, N/A
   - [x] Backend tests pass (`pytest`) if backend code changed
   - [x] No PHI, secrets, or `console.log` left in the diff
   - [x] User-facing strings go through `t()` translations — backend only, N/A
   - [x] Documentation updated if API, schema, or service behavior changed — no API/schema
   changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected trend direction calculations to ensure consistent chronological (oldest-to-newest) ordering is used for quantitative data, regardless of how input data is sequenced.

* **Tests**
  * Added validation tests confirming trend direction calculations produce correct results across different data orderings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->