### PR TITLE
feat(818): Update chart axis values

### DIFF
--- a/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
@@ -42,13 +42,14 @@ const QualitativeChart: React.FC<{ trendData: TrendResponse }> = ({
     return trendData.data_points
       .map(point => {
         const dateStr = point.recorded_date || point.created_at.split('T')[0];
+        const dateOnly = dateStr.split('T')[0];
         const qv = point.qualitative_value || 'unknown';
         // Map to binary: positive/detected = 1, negative/undetected = 0
         const numericValue = qv === 'positive' || qv === 'detected' ? 1 : 0;
 
         return {
           date: dateStr,
-          timestamp: new Date(dateStr + 'T00:00:00').getTime(),
+          timestamp: dateOnly ? new Date(dateOnly + 'T00:00:00').getTime() : 0,
           value: numericValue,
           qualitativeValue: qv,
           status: point.status,
@@ -175,10 +176,11 @@ const TestComponentTrendChart: React.FC<TestComponentTrendChartProps> = ({
       .map(point => {
         // Use recorded_date if available, otherwise use created_at date
         const dateStr = point.recorded_date || point.created_at.split('T')[0];
+        const dateOnly = dateStr.split('T')[0];
 
         return {
           date: dateStr,
-          timestamp: new Date(dateStr + 'T00:00:00').getTime(),
+          timestamp: dateOnly ? new Date(dateOnly + 'T00:00:00').getTime() : 0,
           value: point.value,
           refMin: point.ref_range_min,
           refMax: point.ref_range_max,

--- a/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
@@ -48,6 +48,7 @@ const QualitativeChart: React.FC<{ trendData: TrendResponse }> = ({
 
         return {
           date: dateStr,
+          timestamp: new Date(dateStr + 'T00:00:00').getTime(),
           value: numericValue,
           qualitativeValue: qv,
           status: point.status,
@@ -108,14 +109,25 @@ const QualitativeChart: React.FC<{ trendData: TrendResponse }> = ({
               stroke="var(--color-border-light)"
             />
             <XAxis
-              dataKey="date"
-              type="category"
+              dataKey="timestamp"
+              type="number"
+              scale="time"
+              domain={[
+                (dataMin: number) => dataMin - 86400000,
+                (dataMax: number) => dataMax + 86400000,
+              ]}
               tick={{ fontSize: 12 }}
               angle={-45}
               textAnchor="end"
               height={80}
               stroke="#adb5bd"
-              allowDuplicatedCategory={false}
+              tickFormatter={(ts: number) =>
+                new Date(ts).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                  year: '2-digit',
+                })
+              }
             />
             <YAxis
               dataKey="value"
@@ -166,6 +178,7 @@ const TestComponentTrendChart: React.FC<TestComponentTrendChartProps> = ({
 
         return {
           date: dateStr,
+          timestamp: new Date(dateStr + 'T00:00:00').getTime(),
           value: point.value,
           refMin: point.ref_range_min,
           refMax: point.ref_range_max,
@@ -332,13 +345,26 @@ const TestComponentTrendChart: React.FC<TestComponentTrendChartProps> = ({
             />
 
             <XAxis
-              dataKey="date"
+              dataKey="timestamp"
+              type="number"
+              scale="time"
+              domain={[
+                (dataMin: number) => dataMin - 86400000,
+                (dataMax: number) => dataMax + 86400000,
+              ]}
               tick={{ fontSize: 12 }}
               tickLine={{ stroke: '#adb5bd' }}
               stroke="#adb5bd"
               angle={-45}
               textAnchor="end"
               height={80}
+              tickFormatter={(ts: number) =>
+                new Date(ts).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                  year: '2-digit',
+                })
+              }
             />
 
             <YAxis

--- a/frontend/src/components/medical/vitals/VitalTrendChart.tsx
+++ b/frontend/src/components/medical/vitals/VitalTrendChart.tsx
@@ -121,6 +121,7 @@ const VitalTrendChart: React.FC<VitalTrendChartProps> = ({
 
         return {
           date: dateStr,
+          // recorded_date is always a full UTC datetime ("YYYY-MM-DDTHH:MM:SSZ") from the Pydantic serializer — never date-only
           timestamp: new Date(point.recorded_date).getTime(),
           value: point.value,
           secondaryValue: point.secondary_value,

--- a/frontend/src/components/medical/vitals/VitalTrendChart.tsx
+++ b/frontend/src/components/medical/vitals/VitalTrendChart.tsx
@@ -121,6 +121,7 @@ const VitalTrendChart: React.FC<VitalTrendChartProps> = ({
 
         return {
           date: dateStr,
+          timestamp: new Date(point.recorded_date).getTime(),
           value: point.value,
           secondaryValue: point.secondary_value,
           glucose_context: point.glucose_context,
@@ -158,6 +159,14 @@ const VitalTrendChart: React.FC<VitalTrendChartProps> = ({
       ...aggregatedBounds,
     ]);
   }, [chartData, isAggregated]);
+
+  const periodLabelMap = useMemo(() => {
+    const map = new Map<number, string>();
+    chartData.forEach((d: any) => {
+      if (d.periodLabel) map.set(d.timestamp, d.periodLabel);
+    });
+    return map;
+  }, [chartData]);
 
   const isBloodGlucose = trendData.vital_type === 'blood_glucose';
 
@@ -323,13 +332,33 @@ const VitalTrendChart: React.FC<VitalTrendChartProps> = ({
           />
 
           <XAxis
-            dataKey="date"
+            dataKey="timestamp"
+            type="number"
+            scale="time"
+            domain={[
+              (dataMin: number) => dataMin - 86400000,
+              (dataMax: number) => dataMax + 86400000,
+            ]}
+            ticks={
+              isAggregated
+                ? chartData.map((d: any) => d.timestamp)
+                : undefined
+            }
             tick={{ fontSize: 12 }}
             tickLine={{ stroke: '#adb5bd' }}
             stroke="#adb5bd"
             angle={-45}
             textAnchor="end"
             height={80}
+            tickFormatter={(ts: number) =>
+              isAggregated && periodLabelMap.has(ts)
+                ? periodLabelMap.get(ts)!
+                : new Date(ts).toLocaleDateString(undefined, {
+                    month: 'short',
+                    day: 'numeric',
+                    year: '2-digit',
+                  })
+            }
           />
 
           <YAxis

--- a/frontend/src/utils/vitalDataAggregation.test.ts
+++ b/frontend/src/utils/vitalDataAggregation.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  convertToChartData,
+  AggregatedDataPoint,
+} from './vitalDataAggregation';
+
+const makePoint = (
+  dateISO: string,
+  overrides: Partial<AggregatedDataPoint> = {}
+): AggregatedDataPoint => ({
+  date: dateISO,
+  periodLabel: 'Jan 2024',
+  average: 72,
+  min: 60,
+  max: 85,
+  count: 3,
+  ...overrides,
+});
+
+describe('convertToChartData', () => {
+  it('returns empty array for empty input', () => {
+    expect(convertToChartData([])).toEqual([]);
+  });
+
+  it('includes a numeric timestamp for each point', () => {
+    const points = [makePoint('2024-01-15T00:00:00.000Z')];
+    const result = convertToChartData(points);
+    expect(typeof result[0].timestamp).toBe('number');
+    expect(result[0].timestamp).toBe(new Date('2024-01-15T00:00:00.000Z').getTime());
+  });
+
+  it('timestamp matches the date field', () => {
+    const iso = '2024-06-01T12:00:00.000Z';
+    const result = convertToChartData([makePoint(iso)]);
+    expect(result[0].timestamp).toBe(new Date(iso).getTime());
+    expect(result[0].date).toBe('2024-06-01');
+  });
+
+  it('preserves ordering and maps all fields', () => {
+    const points = [
+      makePoint('2024-01-01T00:00:00.000Z', { average: 70, min: 60, max: 80, count: 2, periodLabel: 'Jan 2024' }),
+      makePoint('2024-02-01T00:00:00.000Z', { average: 75, min: 65, max: 85, count: 4, periodLabel: 'Feb 2024' }),
+    ];
+    const result = convertToChartData(points);
+    expect(result).toHaveLength(2);
+    expect(result[0].value).toBe(70);
+    expect(result[0].min).toBe(60);
+    expect(result[0].max).toBe(80);
+    expect(result[0].count).toBe(2);
+    expect(result[0].periodLabel).toBe('Jan 2024');
+    expect(result[1].value).toBe(75);
+  });
+
+  it('timestamps are ordered oldest-first matching input order', () => {
+    const points = [
+      makePoint('2024-01-01T00:00:00.000Z'),
+      makePoint('2024-06-01T00:00:00.000Z'),
+    ];
+    const result = convertToChartData(points);
+    expect(result[0].timestamp).toBeLessThan(result[1].timestamp);
+  });
+
+  it('handles a single data point without throwing', () => {
+    const points = [makePoint('2024-03-15T00:00:00.000Z')];
+    expect(() => convertToChartData(points)).not.toThrow();
+    expect(convertToChartData(points)).toHaveLength(1);
+  });
+
+  it('maps secondary value fields when present', () => {
+    const points = [
+      makePoint('2024-01-01T00:00:00.000Z', {
+        secondaryAverage: 80,
+        secondaryMin: 70,
+        secondaryMax: 90,
+      }),
+    ];
+    const result = convertToChartData(points);
+    expect(result[0].secondaryValue).toBe(80);
+    expect(result[0].secondaryMin).toBe(70);
+    expect(result[0].secondaryMax).toBe(90);
+  });
+
+  it('secondary value fields are undefined when not provided', () => {
+    const result = convertToChartData([makePoint('2024-01-01T00:00:00.000Z')]);
+    expect(result[0].secondaryValue).toBeUndefined();
+    expect(result[0].secondaryMin).toBeUndefined();
+    expect(result[0].secondaryMax).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/vitalDataAggregation.ts
+++ b/frontend/src/utils/vitalDataAggregation.ts
@@ -277,6 +277,7 @@ export function convertToChartData(aggregatedPoints: AggregatedDataPoint[]): {
   // Data is already sorted oldest-first from aggregateDataPoints
   return aggregatedPoints.map(point => ({
     date: point.date.split('T')[0],
+    // point.date is always a full ISO datetime from Date.toISOString() — never date-only, no UTC-midnight date-shift risk
     timestamp: new Date(point.date).getTime(),
     value: point.average,
     min: point.min,

--- a/frontend/src/utils/vitalDataAggregation.ts
+++ b/frontend/src/utils/vitalDataAggregation.ts
@@ -264,6 +264,7 @@ export function smartAggregateVitalData(
  */
 export function convertToChartData(aggregatedPoints: AggregatedDataPoint[]): {
   date: string;
+  timestamp: number;
   value: number;
   min: number;
   max: number;
@@ -276,6 +277,7 @@ export function convertToChartData(aggregatedPoints: AggregatedDataPoint[]): {
   // Data is already sorted oldest-first from aggregateDataPoints
   return aggregatedPoints.map(point => ({
     date: point.date.split('T')[0],
+    timestamp: new Date(point.date).getTime(),
     value: point.average,
     min: point.min,
     max: point.max,


### PR DESCRIPTION
## Summary

Trend charts for lab results and vitals used a categorical X-axis, spacing every data point equally regardless of actual time between measurements. This PR switches all affected `XAxis` instances to a numeric time scale (`type="number" scale="time"`) so the distance between points reflects real elapsed time.

## Related issue

Closes #818

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing
- 8 new unit tests added in `vitalDataAggregation.test.ts` covering: empty input, timestamp correctness, field mapping, ordering, single-point safety, and secondary value fields
- Edge cases caught during self-review and fixed: single-point axis collapse (±1 day domain padding), aggregated vitals period labels not rendering on axis ticks (forced `ticks` prop), timezone date-shift on `YYYY-MM-DD` lab dates (`T00:00:00` local-midnight fix)

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Medical vitals and lab-result charts now use numeric time-based x-axes, expanded domains (±1 day) for better date positioning, and improved tick formatting to show localized short dates while preserving aggregated period labels.
  * Qualitative chart behavior adjusted to work with time-scale x-axes.

* **Tests**
  * Added automated tests verifying conversion of aggregated data into chart-ready objects, including secondary value mappings and timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->