### PR TITLE
fix: persistent admin settings correction

### DIFF
--- a/app/api/v1/admin/backup.py
+++ b/app/api/v1/admin/backup.py
@@ -637,19 +637,23 @@ async def update_retention_settings(
 ):
     """Update admin settings including retention and user management."""
     try:
-        updated_settings = {}
+        # Phase 1: validate every submitted field before any side effects.
+        # Staging changes first keeps the endpoint atomic: if any field fails
+        # validation, no earlier field gets persisted to system_settings.
+        pending: list[tuple[str, str, object, str]] = []
 
         if settings_update.backup_retention_days is not None:
             if settings_update.backup_retention_days < 1:
                 raise HTTPException(
                     status_code=400, detail="Backup retention days must be at least 1"
                 )
-            settings.BACKUP_RETENTION_DAYS = settings_update.backup_retention_days
-            persist_setting(
-                db, KEY_BACKUP_RETENTION_DAYS, settings_update.backup_retention_days
-            )
-            updated_settings["backup_retention_days"] = (
-                settings_update.backup_retention_days
+            pending.append(
+                (
+                    "BACKUP_RETENTION_DAYS",
+                    KEY_BACKUP_RETENTION_DAYS,
+                    settings_update.backup_retention_days,
+                    "backup_retention_days",
+                )
             )
 
         if settings_update.trash_retention_days is not None:
@@ -657,12 +661,13 @@ async def update_retention_settings(
                 raise HTTPException(
                     status_code=400, detail="Trash retention days must be at least 1"
                 )
-            settings.TRASH_RETENTION_DAYS = settings_update.trash_retention_days
-            persist_setting(
-                db, KEY_TRASH_RETENTION_DAYS, settings_update.trash_retention_days
-            )
-            updated_settings["trash_retention_days"] = (
-                settings_update.trash_retention_days
+            pending.append(
+                (
+                    "TRASH_RETENTION_DAYS",
+                    KEY_TRASH_RETENTION_DAYS,
+                    settings_update.trash_retention_days,
+                    "trash_retention_days",
+                )
             )
 
         if settings_update.backup_min_count is not None:
@@ -670,7 +675,6 @@ async def update_retention_settings(
                 raise HTTPException(
                     status_code=400, detail="Minimum backup count must be at least 1"
                 )
-            # Validate that min count is not greater than max count
             current_max = (
                 settings_update.backup_max_count
                 if settings_update.backup_max_count is not None
@@ -681,16 +685,20 @@ async def update_retention_settings(
                     status_code=400,
                     detail="Minimum backup count must be less than or equal to maximum backup count",
                 )
-            settings.BACKUP_MIN_COUNT = settings_update.backup_min_count
-            persist_setting(db, KEY_BACKUP_MIN_COUNT, settings_update.backup_min_count)
-            updated_settings["backup_min_count"] = settings_update.backup_min_count
+            pending.append(
+                (
+                    "BACKUP_MIN_COUNT",
+                    KEY_BACKUP_MIN_COUNT,
+                    settings_update.backup_min_count,
+                    "backup_min_count",
+                )
+            )
 
         if settings_update.backup_max_count is not None:
             if settings_update.backup_max_count < 1:
                 raise HTTPException(
                     status_code=400, detail="Maximum backup count must be at least 1"
                 )
-            # Validate that max count is greater than or equal to min count
             current_min = (
                 settings_update.backup_min_count
                 if settings_update.backup_min_count is not None
@@ -701,20 +709,33 @@ async def update_retention_settings(
                     status_code=400,
                     detail="Maximum backup count must be greater than or equal to minimum backup count",
                 )
-            settings.BACKUP_MAX_COUNT = settings_update.backup_max_count
-            persist_setting(db, KEY_BACKUP_MAX_COUNT, settings_update.backup_max_count)
-            updated_settings["backup_max_count"] = settings_update.backup_max_count
+            pending.append(
+                (
+                    "BACKUP_MAX_COUNT",
+                    KEY_BACKUP_MAX_COUNT,
+                    settings_update.backup_max_count,
+                    "backup_max_count",
+                )
+            )
 
         if settings_update.allow_user_registration is not None:
-            settings.ALLOW_USER_REGISTRATION = settings_update.allow_user_registration
-            persist_setting(
-                db,
-                KEY_ALLOW_USER_REGISTRATION,
-                settings_update.allow_user_registration,
+            pending.append(
+                (
+                    "ALLOW_USER_REGISTRATION",
+                    KEY_ALLOW_USER_REGISTRATION,
+                    settings_update.allow_user_registration,
+                    "allow_user_registration",
+                )
             )
-            updated_settings["allow_user_registration"] = (
-                settings_update.allow_user_registration
-            )
+
+        # Phase 2: apply — every entry in `pending` has already been validated.
+        updated_settings = {}
+        for attr, key, value, response_name in pending:
+            setattr(settings, attr, value)
+            persist_setting(db, key, value)
+            updated_settings[response_name] = value
+
+        if settings_update.allow_user_registration is not None:
             log_security_event(
                 logger,
                 "user_registration_toggled",

--- a/app/api/v1/admin/backup.py
+++ b/app/api/v1/admin/backup.py
@@ -21,6 +21,14 @@ from app.core.logging.helpers import (
     log_endpoint_error,
     log_security_event,
 )
+from app.core.persisted_settings import (
+    KEY_ALLOW_USER_REGISTRATION,
+    KEY_BACKUP_MAX_COUNT,
+    KEY_BACKUP_MIN_COUNT,
+    KEY_BACKUP_RETENTION_DAYS,
+    KEY_TRASH_RETENTION_DAYS,
+    persist_setting,
+)
 from app.models.models import User
 from app.services.backup_scheduler_service import (
     TIME_FORMAT_RE,
@@ -625,6 +633,7 @@ async def update_retention_settings(
     settings_update: RetentionSettingsUpdate,
     request: Request,
     current_user: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
 ):
     """Update admin settings including retention and user management."""
     try:
@@ -636,6 +645,9 @@ async def update_retention_settings(
                     status_code=400, detail="Backup retention days must be at least 1"
                 )
             settings.BACKUP_RETENTION_DAYS = settings_update.backup_retention_days
+            persist_setting(
+                db, KEY_BACKUP_RETENTION_DAYS, settings_update.backup_retention_days
+            )
             updated_settings["backup_retention_days"] = (
                 settings_update.backup_retention_days
             )
@@ -646,6 +658,9 @@ async def update_retention_settings(
                     status_code=400, detail="Trash retention days must be at least 1"
                 )
             settings.TRASH_RETENTION_DAYS = settings_update.trash_retention_days
+            persist_setting(
+                db, KEY_TRASH_RETENTION_DAYS, settings_update.trash_retention_days
+            )
             updated_settings["trash_retention_days"] = (
                 settings_update.trash_retention_days
             )
@@ -667,6 +682,7 @@ async def update_retention_settings(
                     detail="Minimum backup count must be less than or equal to maximum backup count",
                 )
             settings.BACKUP_MIN_COUNT = settings_update.backup_min_count
+            persist_setting(db, KEY_BACKUP_MIN_COUNT, settings_update.backup_min_count)
             updated_settings["backup_min_count"] = settings_update.backup_min_count
 
         if settings_update.backup_max_count is not None:
@@ -686,10 +702,16 @@ async def update_retention_settings(
                     detail="Maximum backup count must be greater than or equal to minimum backup count",
                 )
             settings.BACKUP_MAX_COUNT = settings_update.backup_max_count
+            persist_setting(db, KEY_BACKUP_MAX_COUNT, settings_update.backup_max_count)
             updated_settings["backup_max_count"] = settings_update.backup_max_count
 
         if settings_update.allow_user_registration is not None:
             settings.ALLOW_USER_REGISTRATION = settings_update.allow_user_registration
+            persist_setting(
+                db,
+                KEY_ALLOW_USER_REGISTRATION,
+                settings_update.allow_user_registration,
+            )
             updated_settings["allow_user_registration"] = (
                 settings_update.allow_user_registration
             )

--- a/app/api/v1/admin/backup.py
+++ b/app/api/v1/admin/backup.py
@@ -728,11 +728,21 @@ async def update_retention_settings(
                 )
             )
 
-        # Phase 2: apply — every entry in `pending` has already been validated.
+        # Phase 2: persist — stage every row in a single transaction so a
+        # mid-loop failure can't leave system_settings half-written or drift
+        # from the in-memory `settings` object.
+        try:
+            for _, key, value, _ in pending:
+                persist_setting(db, key, value, commit=False)
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+
+        # Phase 3: mirror to in-memory only after the DB transaction committed.
         updated_settings = {}
         for attr, key, value, response_name in pending:
             setattr(settings, attr, value)
-            persist_setting(db, key, value)
             updated_settings[response_name] = value
 
         if settings_update.allow_user_registration is not None:

--- a/app/core/persisted_settings.py
+++ b/app/core/persisted_settings.py
@@ -11,7 +11,7 @@ value is written to the DB, the DB wins on subsequent startups via
 """
 
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from sqlalchemy.orm import Session
 
@@ -43,12 +43,22 @@ def _serialize_bool(value: bool) -> str:
     return "true" if value else "false"
 
 
+def _require_positive_int(value: int) -> None:
+    if value < 1:
+        raise ValueError(f"must be >= 1, got {value}")
+
+
 @dataclass(frozen=True)
 class PersistedSetting:
     key: str
     attr: str
     parse: Callable[[str], Any]
     serialize: Callable[[Any], str]
+    # Optional semantic check applied after `parse` succeeds. Raise ValueError
+    # to reject the DB value (the in-memory default is kept instead). Used to
+    # defend `load_persisted_settings` against invalid rows that somehow
+    # bypassed API-level validation.
+    validate: Optional[Callable[[Any], None]] = None
 
 
 PERSISTED_SETTINGS: dict[str, PersistedSetting] = {
@@ -65,24 +75,28 @@ PERSISTED_SETTINGS: dict[str, PersistedSetting] = {
             attr="BACKUP_RETENTION_DAYS",
             parse=int,
             serialize=str,
+            validate=_require_positive_int,
         ),
         PersistedSetting(
             key=KEY_TRASH_RETENTION_DAYS,
             attr="TRASH_RETENTION_DAYS",
             parse=int,
             serialize=str,
+            validate=_require_positive_int,
         ),
         PersistedSetting(
             key=KEY_BACKUP_MIN_COUNT,
             attr="BACKUP_MIN_COUNT",
             parse=int,
             serialize=str,
+            validate=_require_positive_int,
         ),
         PersistedSetting(
             key=KEY_BACKUP_MAX_COUNT,
             attr="BACKUP_MAX_COUNT",
             parse=int,
             serialize=str,
+            validate=_require_positive_int,
         ),
     )
 }
@@ -111,6 +125,20 @@ def load_persisted_settings(db: Session) -> None:
                 },
             )
             continue
+        if entry.validate is not None:
+            try:
+                entry.validate(parsed)
+            except ValueError as exc:
+                logger.warning(
+                    "Skipping semantically invalid persisted setting",
+                    extra={
+                        LogFields.CATEGORY: "app",
+                        LogFields.EVENT: "persisted_setting_invalid",
+                        "setting_key": entry.key,
+                        LogFields.ERROR: str(exc),
+                    },
+                )
+                continue
         setattr(settings, entry.attr, parsed)
         logger.info(
             "Loaded persisted admin setting",
@@ -122,14 +150,17 @@ def load_persisted_settings(db: Session) -> None:
         )
 
 
-def persist_setting(db: Session, key: str, value: Any) -> None:
+def persist_setting(
+    db: Session, key: str, value: Any, commit: bool = True
+) -> None:
     """Persist a runtime-configurable setting to `system_settings`.
 
     Caller is responsible for updating the in-memory `settings.X` attribute;
-    this function only writes to the DB.
+    this function only writes to the DB. Pass `commit=False` to stage the
+    write as part of a larger transaction the caller commits itself.
     """
     try:
         entry = PERSISTED_SETTINGS[key]
     except KeyError as exc:
         raise KeyError(f"Unknown persisted setting key: {key}") from exc
-    system_setting.set_setting(db, key, entry.serialize(value))
+    system_setting.set_setting(db, key, entry.serialize(value), commit=commit)

--- a/app/core/persisted_settings.py
+++ b/app/core/persisted_settings.py
@@ -1,0 +1,130 @@
+"""
+Runtime-persisted admin settings.
+
+Registry of `Settings` attributes that admins can modify via the admin API
+and that must survive process restarts. Values are stored as strings in the
+`system_settings` table, one row per setting.
+
+Env vars in `app.core.config` still act as the first-boot default; once a
+value is written to the DB, the DB wins on subsequent startups via
+`load_persisted_settings`.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.logging.config import get_logger
+from app.core.logging.constants import LogFields
+from app.crud.system_setting import system_setting
+
+logger = get_logger(__name__, "app")
+
+
+KEY_ALLOW_USER_REGISTRATION = "allow_user_registration"
+KEY_BACKUP_RETENTION_DAYS = "backup_retention_days"
+KEY_TRASH_RETENTION_DAYS = "trash_retention_days"
+KEY_BACKUP_MIN_COUNT = "backup_min_count"
+KEY_BACKUP_MAX_COUNT = "backup_max_count"
+
+
+def _parse_bool(raw: str) -> bool:
+    return raw.strip().lower() == "true"
+
+
+def _serialize_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+@dataclass(frozen=True)
+class PersistedSetting:
+    key: str
+    attr: str
+    parse: Callable[[str], Any]
+    serialize: Callable[[Any], str]
+
+
+PERSISTED_SETTINGS: dict[str, PersistedSetting] = {
+    entry.key: entry
+    for entry in (
+        PersistedSetting(
+            key=KEY_ALLOW_USER_REGISTRATION,
+            attr="ALLOW_USER_REGISTRATION",
+            parse=_parse_bool,
+            serialize=_serialize_bool,
+        ),
+        PersistedSetting(
+            key=KEY_BACKUP_RETENTION_DAYS,
+            attr="BACKUP_RETENTION_DAYS",
+            parse=int,
+            serialize=str,
+        ),
+        PersistedSetting(
+            key=KEY_TRASH_RETENTION_DAYS,
+            attr="TRASH_RETENTION_DAYS",
+            parse=int,
+            serialize=str,
+        ),
+        PersistedSetting(
+            key=KEY_BACKUP_MIN_COUNT,
+            attr="BACKUP_MIN_COUNT",
+            parse=int,
+            serialize=str,
+        ),
+        PersistedSetting(
+            key=KEY_BACKUP_MAX_COUNT,
+            attr="BACKUP_MAX_COUNT",
+            parse=int,
+            serialize=str,
+        ),
+    )
+}
+
+
+def load_persisted_settings(db: Session) -> None:
+    """Override runtime config attributes with values from `system_settings`.
+
+    Malformed stored values are logged and skipped; the in-memory default
+    (populated from the env var when `Settings` was instantiated) is kept.
+    """
+    for entry in PERSISTED_SETTINGS.values():
+        raw = system_setting.get_setting(db, entry.key)
+        if raw is None:
+            continue
+        try:
+            parsed = entry.parse(raw)
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                "Skipping malformed persisted setting",
+                extra={
+                    LogFields.CATEGORY: "app",
+                    LogFields.EVENT: "persisted_setting_invalid",
+                    "setting_key": entry.key,
+                    LogFields.ERROR: str(exc),
+                },
+            )
+            continue
+        setattr(settings, entry.attr, parsed)
+        logger.info(
+            "Loaded persisted admin setting",
+            extra={
+                LogFields.CATEGORY: "app",
+                LogFields.EVENT: "persisted_setting_loaded",
+                "setting_key": entry.key,
+            },
+        )
+
+
+def persist_setting(db: Session, key: str, value: Any) -> None:
+    """Persist a runtime-configurable setting to `system_settings`.
+
+    Caller is responsible for updating the in-memory `settings.X` attribute;
+    this function only writes to the DB.
+    """
+    try:
+        entry = PERSISTED_SETTINGS[key]
+    except KeyError as exc:
+        raise KeyError(f"Unknown persisted setting key: {key}") from exc
+    system_setting.set_setting(db, key, entry.serialize(value))

--- a/app/core/persisted_settings.py
+++ b/app/core/persisted_settings.py
@@ -31,7 +31,12 @@ KEY_BACKUP_MAX_COUNT = "backup_max_count"
 
 
 def _parse_bool(raw: str) -> bool:
-    return raw.strip().lower() == "true"
+    normalized = raw.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise ValueError(f"Expected 'true' or 'false', got {raw!r}")
 
 
 def _serialize_bool(value: bool) -> str:

--- a/app/core/startup.py
+++ b/app/core/startup.py
@@ -123,6 +123,22 @@ async def startup_event():
     # Run data migrations (after users/database setup is complete)
     run_startup_data_migrations()
 
+    # Load admin-toggleable settings persisted in system_settings (e.g.
+    # allow_user_registration, backup/trash retention). The env-var defaults
+    # from app.core.config.Settings were already loaded at import time; any
+    # persisted value overrides them here.
+    try:
+        from app.core.persisted_settings import load_persisted_settings
+
+        db = SessionLocal()
+        try:
+            load_persisted_settings(db)
+        finally:
+            db.close()
+    except Exception as e:
+        logger.warning(f"Could not load persisted admin settings: {e}")
+        # Non-fatal - app falls back to env-var defaults already in memory
+
     # Initialize standardized tests from LOINC
     try:
         from app.core.utils.test_initialization import ensure_tests_initialized

--- a/app/crud/system_setting.py
+++ b/app/crud/system_setting.py
@@ -22,7 +22,9 @@ class CRUDSystemSetting:
         setting = db.query(SystemSetting).filter(SystemSetting.key == key).first()
         return setting.value if setting else None
 
-    def set_setting(self, db: Session, key: str, value: str) -> SystemSetting:
+    def set_setting(
+        self, db: Session, key: str, value: str, commit: bool = True
+    ) -> SystemSetting:
         """
         Set a system setting value. Creates new or updates existing.
 
@@ -30,6 +32,9 @@ class CRUDSystemSetting:
             db: Database session
             key: Setting key
             value: Setting value
+            commit: If True (default) commit immediately. Set False to stage
+                the write inside a larger transaction; the caller is then
+                responsible for `db.commit()` / `db.rollback()`.
 
         Returns:
             SystemSetting object
@@ -44,8 +49,11 @@ class CRUDSystemSetting:
             setting = SystemSetting(key=key, value=value)
             db.add(setting)
 
-        db.commit()
-        db.refresh(setting)
+        if commit:
+            db.commit()
+            db.refresh(setting)
+        else:
+            db.flush()
         return setting
 
     def delete_setting(self, db: Session, key: str) -> bool:

--- a/tests/api/test_retention_settings_persistence.py
+++ b/tests/api/test_retention_settings_persistence.py
@@ -1,0 +1,144 @@
+"""Tests that admin retention/registration settings persist across restarts.
+
+Regression coverage for the bug where toggling "New User Registration" in
+the admin UI reverted on app restart: the endpoint used to mutate only the
+in-memory `settings` object. It now also writes to `system_settings`, and
+startup rehydrates `settings` from that table via `load_persisted_settings`.
+"""
+
+import pytest
+
+from app.core.config import settings
+from app.core.persisted_settings import (
+    KEY_ALLOW_USER_REGISTRATION,
+    KEY_BACKUP_MAX_COUNT,
+    KEY_BACKUP_MIN_COUNT,
+    KEY_BACKUP_RETENTION_DAYS,
+    KEY_TRASH_RETENTION_DAYS,
+    load_persisted_settings,
+    persist_setting,
+)
+from app.crud.system_setting import system_setting
+
+
+RETENTION_URL = "/api/v1/admin/backups/settings/retention"
+
+
+@pytest.fixture
+def restore_settings():
+    """Snapshot and restore the mutable Settings attributes touched in tests."""
+    snapshot = {
+        "ALLOW_USER_REGISTRATION": settings.ALLOW_USER_REGISTRATION,
+        "BACKUP_RETENTION_DAYS": settings.BACKUP_RETENTION_DAYS,
+        "TRASH_RETENTION_DAYS": settings.TRASH_RETENTION_DAYS,
+        "BACKUP_MIN_COUNT": settings.BACKUP_MIN_COUNT,
+        "BACKUP_MAX_COUNT": settings.BACKUP_MAX_COUNT,
+    }
+    try:
+        yield
+    finally:
+        for attr, value in snapshot.items():
+            setattr(settings, attr, value)
+
+
+class TestEndpointPersistsToDb:
+    """POST /api/v1/admin/backups/settings/retention writes to system_settings."""
+
+    def test_disabling_registration_persists(
+        self, admin_client, db_session, restore_settings
+    ):
+        response = admin_client.post(
+            RETENTION_URL, json={"allow_user_registration": False}
+        )
+        assert response.status_code == 200
+
+        assert (
+            system_setting.get_setting(db_session, KEY_ALLOW_USER_REGISTRATION)
+            == "false"
+        )
+        assert settings.ALLOW_USER_REGISTRATION is False
+
+    def test_enabling_registration_persists(
+        self, admin_client, db_session, restore_settings
+    ):
+        settings.ALLOW_USER_REGISTRATION = False
+        response = admin_client.post(
+            RETENTION_URL, json={"allow_user_registration": True}
+        )
+        assert response.status_code == 200
+
+        assert (
+            system_setting.get_setting(db_session, KEY_ALLOW_USER_REGISTRATION)
+            == "true"
+        )
+        assert settings.ALLOW_USER_REGISTRATION is True
+
+    def test_retention_days_persist(self, admin_client, db_session, restore_settings):
+        response = admin_client.post(
+            RETENTION_URL,
+            json={"backup_retention_days": 45, "trash_retention_days": 14},
+        )
+        assert response.status_code == 200
+
+        assert system_setting.get_setting(db_session, KEY_BACKUP_RETENTION_DAYS) == "45"
+        assert system_setting.get_setting(db_session, KEY_TRASH_RETENTION_DAYS) == "14"
+        assert settings.BACKUP_RETENTION_DAYS == 45
+        assert settings.TRASH_RETENTION_DAYS == 14
+
+    def test_backup_counts_persist(self, admin_client, db_session, restore_settings):
+        response = admin_client.post(
+            RETENTION_URL,
+            json={"backup_min_count": 2, "backup_max_count": 20},
+        )
+        assert response.status_code == 200
+
+        assert system_setting.get_setting(db_session, KEY_BACKUP_MIN_COUNT) == "2"
+        assert system_setting.get_setting(db_session, KEY_BACKUP_MAX_COUNT) == "20"
+        assert settings.BACKUP_MIN_COUNT == 2
+        assert settings.BACKUP_MAX_COUNT == 20
+
+    def test_invalid_retention_does_not_persist(
+        self, admin_client, db_session, restore_settings
+    ):
+        """400 validation failures must not leave a row behind."""
+        response = admin_client.post(RETENTION_URL, json={"backup_retention_days": 0})
+        assert response.status_code == 400
+        assert system_setting.get_setting(db_session, KEY_BACKUP_RETENTION_DAYS) is None
+
+
+class TestLoadPersistedSettings:
+    """load_persisted_settings() rehydrates the in-memory Settings on startup."""
+
+    def test_overrides_defaults(self, db_session, restore_settings):
+        persist_setting(db_session, KEY_ALLOW_USER_REGISTRATION, False)
+        persist_setting(db_session, KEY_BACKUP_RETENTION_DAYS, 99)
+
+        settings.ALLOW_USER_REGISTRATION = True
+        settings.BACKUP_RETENTION_DAYS = 1
+
+        load_persisted_settings(db_session)
+
+        assert settings.ALLOW_USER_REGISTRATION is False
+        assert settings.BACKUP_RETENTION_DAYS == 99
+
+    def test_noop_when_table_empty(self, db_session, restore_settings):
+        settings.ALLOW_USER_REGISTRATION = True
+        settings.BACKUP_RETENTION_DAYS = 7
+
+        load_persisted_settings(db_session)
+
+        assert settings.ALLOW_USER_REGISTRATION is True
+        assert settings.BACKUP_RETENTION_DAYS == 7
+
+    def test_malformed_value_is_skipped(self, db_session, restore_settings):
+        """Bad stored data must not crash startup."""
+        system_setting.set_setting(db_session, KEY_BACKUP_RETENTION_DAYS, "not-an-int")
+        settings.BACKUP_RETENTION_DAYS = 30
+
+        load_persisted_settings(db_session)
+
+        assert settings.BACKUP_RETENTION_DAYS == 30
+
+    def test_persist_setting_rejects_unknown_key(self, db_session, restore_settings):
+        with pytest.raises(KeyError):
+            persist_setting(db_session, "not_a_real_setting", "value")

--- a/tests/api/test_retention_settings_persistence.py
+++ b/tests/api/test_retention_settings_persistence.py
@@ -105,6 +105,30 @@ class TestEndpointPersistsToDb:
         assert response.status_code == 400
         assert system_setting.get_setting(db_session, KEY_BACKUP_RETENTION_DAYS) is None
 
+    def test_wrong_type_for_bool_rejected(
+        self, admin_client, db_session, restore_settings
+    ):
+        """Pydantic rejects non-bool for allow_user_registration; nothing persisted."""
+        response = admin_client.post(
+            RETENTION_URL, json={"allow_user_registration": "not-a-bool"}
+        )
+        assert response.status_code == 422
+        assert (
+            system_setting.get_setting(db_session, KEY_ALLOW_USER_REGISTRATION) is None
+        )
+
+    def test_mid_update_validation_failure_is_atomic(
+        self, admin_client, db_session, restore_settings
+    ):
+        """A valid field plus a later invalid field must not partially persist."""
+        response = admin_client.post(
+            RETENTION_URL,
+            json={"backup_retention_days": 7, "backup_min_count": 0},
+        )
+        assert response.status_code == 400
+        assert system_setting.get_setting(db_session, KEY_BACKUP_RETENTION_DAYS) is None
+        assert system_setting.get_setting(db_session, KEY_BACKUP_MIN_COUNT) is None
+
 
 class TestLoadPersistedSettings:
     """load_persisted_settings() rehydrates the in-memory Settings on startup."""
@@ -130,7 +154,7 @@ class TestLoadPersistedSettings:
         assert settings.ALLOW_USER_REGISTRATION is True
         assert settings.BACKUP_RETENTION_DAYS == 7
 
-    def test_malformed_value_is_skipped(self, db_session, restore_settings):
+    def test_malformed_int_is_skipped(self, db_session, restore_settings):
         """Bad stored data must not crash startup."""
         system_setting.set_setting(db_session, KEY_BACKUP_RETENTION_DAYS, "not-an-int")
         settings.BACKUP_RETENTION_DAYS = 30
@@ -138,6 +162,15 @@ class TestLoadPersistedSettings:
         load_persisted_settings(db_session)
 
         assert settings.BACKUP_RETENTION_DAYS == 30
+
+    def test_malformed_bool_is_skipped(self, db_session, restore_settings):
+        """Bool parser rejects non-'true'/'false' strings; the prior default is kept."""
+        system_setting.set_setting(db_session, KEY_ALLOW_USER_REGISTRATION, "nope")
+        settings.ALLOW_USER_REGISTRATION = True
+
+        load_persisted_settings(db_session)
+
+        assert settings.ALLOW_USER_REGISTRATION is True
 
     def test_persist_setting_rejects_unknown_key(self, db_session, restore_settings):
         with pytest.raises(KeyError):

--- a/tests/api/test_retention_settings_persistence.py
+++ b/tests/api/test_retention_settings_persistence.py
@@ -129,6 +129,38 @@ class TestEndpointPersistsToDb:
         assert system_setting.get_setting(db_session, KEY_BACKUP_RETENTION_DAYS) is None
         assert system_setting.get_setting(db_session, KEY_BACKUP_MIN_COUNT) is None
 
+    def test_mid_loop_db_failure_rolls_back_all_rows(
+        self, admin_client, db_session, restore_settings, monkeypatch
+    ):
+        """A DB-level failure after the first row must not commit earlier rows
+        and must not mutate in-memory `settings` for any row."""
+        from app.api.v1.admin import backup as backup_module
+
+        call_count = {"n": 0}
+        real_persist = backup_module.persist_setting
+
+        def flaky_persist(db, key, value, commit=True):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("simulated DB failure")
+            return real_persist(db, key, value, commit=commit)
+
+        monkeypatch.setattr(backup_module, "persist_setting", flaky_persist)
+
+        before_retention = settings.BACKUP_RETENTION_DAYS
+        before_trash = settings.TRASH_RETENTION_DAYS
+
+        response = admin_client.post(
+            RETENTION_URL,
+            json={"backup_retention_days": 77, "trash_retention_days": 33},
+        )
+        assert response.status_code == 500
+
+        assert system_setting.get_setting(db_session, KEY_BACKUP_RETENTION_DAYS) is None
+        assert system_setting.get_setting(db_session, KEY_TRASH_RETENTION_DAYS) is None
+        assert settings.BACKUP_RETENTION_DAYS == before_retention
+        assert settings.TRASH_RETENTION_DAYS == before_trash
+
 
 class TestLoadPersistedSettings:
     """load_persisted_settings() rehydrates the in-memory Settings on startup."""
@@ -171,6 +203,18 @@ class TestLoadPersistedSettings:
         load_persisted_settings(db_session)
 
         assert settings.ALLOW_USER_REGISTRATION is True
+
+    def test_semantically_invalid_int_is_skipped(
+        self, db_session, restore_settings
+    ):
+        """A parseable-but-invalid row (e.g. BACKUP_RETENTION_DAYS=0) must be
+        ignored at startup so corrupt values can't override the default."""
+        system_setting.set_setting(db_session, KEY_BACKUP_RETENTION_DAYS, "0")
+        settings.BACKUP_RETENTION_DAYS = 30
+
+        load_persisted_settings(db_session)
+
+        assert settings.BACKUP_RETENTION_DAYS == 30
 
     def test_persist_setting_rejects_unknown_key(self, db_session, restore_settings):
         with pytest.raises(KeyError):


### PR DESCRIPTION
## Summary

This pull request introduces robust persistence for admin-configurable settings, ensuring that changes made via the admin API (such as backup retention policies and user registration toggles) are saved to the database and survive application restarts. It adds a new persistence mechanism, updates the relevant API endpoint to use it, and includes comprehensive regression tests to prevent future issues with settings reverting on restart.

**Persistence of Admin Settings:**

* Added `app/core/persisted_settings.py` to manage runtime-persisted admin settings, including serialization, deserialization, and loading/saving to the `system_settings` table. This ensures settings like `ALLOW_USER_REGISTRATION` and retention policies are preserved across restarts.
* On app startup, `load_persisted_settings` is called to override in-memory defaults with any persisted values from the database, providing seamless restoration of admin preferences.

**API Endpoint Enhancements:**

* Updated the `update_retention_settings` endpoint in `app/api/v1/admin/backup.py` to persist changes to the database using the new persistence mechanism whenever an admin modifies relevant settings. [[1]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebR24-R31) [[2]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebR636) [[3]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebR648-R650) [[4]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebR661-R663) [[5]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebR685) [[6]](diffhunk://#diff-233fcf9d2a7665421de761d750772da335770ed47b11c8209e51aad1b68a6aebR705-R714)

**Testing and Reliability:**

* Added `tests/api/test_retention_settings_persistence.py` with regression tests to ensure settings persist as expected, including tests for correct persistence, restoration on startup, and handling of invalid or malformed data.

## Related issue

#835 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

<!-- How did you verify this works? Manual steps, screenshots, or test names. -->

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin settings (backup retention, trash retention, backup counts, user registration) now persist across restarts and are restored at startup; startup logs but continues if restore fails.

* **Bug Fixes**
  * Updates to settings are applied transactionally: mixed valid/invalid payloads or persistence errors no longer leave partial changes.

* **Tests**
  * Added tests for persistence, rehydration, validation, error handling, and atomic update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->