### PR TITLE
fix: normalize empty canonical_test_name to None and update trend grouping logic

### DIFF
--- a/app/crud/lab_test_component.py
+++ b/app/crud/lab_test_component.py
@@ -211,8 +211,12 @@ class CRUDLabTestComponent(
         Get all test components for a patient by test name (case-insensitive).
 
         Exclusive matching ensures each component appears in only one trend:
-        - Components WITH canonical_test_name: match only on canonical_test_name
-        - Components WITHOUT canonical_test_name: match only on exact test_name (normalized)
+        - Components with a non-empty canonical_test_name: match only on canonical_test_name
+        - Components with NULL or empty canonical_test_name: match only on exact test_name (normalized)
+
+        Empty string is treated as equivalent to NULL here. The sync service
+        (test_library_sync) writes "" to mark components it processed without
+        finding a library match; those components should still group by test_name.
 
         Unit filter semantics:
         - None: no unit filter (legacy behavior, all units merged).
@@ -232,11 +236,15 @@ class CRUDLabTestComponent(
                     or_(
                         and_(
                             self.model.canonical_test_name.isnot(None),
+                            self.model.canonical_test_name != "",
                             func.lower(self.model.canonical_test_name)
                             == func.lower(test_name),
                         ),
                         and_(
-                            self.model.canonical_test_name.is_(None),
+                            or_(
+                                self.model.canonical_test_name.is_(None),
+                                self.model.canonical_test_name == "",
+                            ),
                             func.lower(func.rtrim(self.model.test_name, ",;: "))
                             == func.lower(test_name),
                         ),

--- a/app/crud/lab_test_component.py
+++ b/app/crud/lab_test_component.py
@@ -212,11 +212,12 @@ class CRUDLabTestComponent(
 
         Exclusive matching ensures each component appears in only one trend:
         - Components with a non-empty canonical_test_name: match only on canonical_test_name
-        - Components with NULL or empty canonical_test_name: match only on exact test_name (normalized)
+        - Components with NULL, empty, or whitespace-only canonical_test_name: match only on exact test_name (normalized)
 
-        Empty string is treated as equivalent to NULL here. The sync service
-        (test_library_sync) writes "" to mark components it processed without
-        finding a library match; those components should still group by test_name.
+        Empty / whitespace-only canonical_test_name is treated as equivalent to
+        NULL here. The sync service (test_library_sync) writes "" to mark
+        components it processed without finding a library match; those
+        components should still group by test_name.
 
         Unit filter semantics:
         - None: no unit filter (legacy behavior, all units merged).
@@ -236,14 +237,14 @@ class CRUDLabTestComponent(
                     or_(
                         and_(
                             self.model.canonical_test_name.isnot(None),
-                            self.model.canonical_test_name != "",
-                            func.lower(self.model.canonical_test_name)
-                            == func.lower(test_name),
+                            func.trim(self.model.canonical_test_name) != "",
+                            func.lower(func.trim(self.model.canonical_test_name))
+                            == func.lower(func.trim(test_name)),
                         ),
                         and_(
                             or_(
                                 self.model.canonical_test_name.is_(None),
-                                self.model.canonical_test_name == "",
+                                func.trim(self.model.canonical_test_name) == "",
                             ),
                             func.lower(func.rtrim(self.model.test_name, ",;: "))
                             == func.lower(test_name),

--- a/app/schemas/lab_test_component.py
+++ b/app/schemas/lab_test_component.py
@@ -394,6 +394,25 @@ class LabTestComponentUpdate(BaseModel):
             return normalized
         return v
 
+    @field_validator("canonical_test_name")
+    @classmethod
+    def validate_canonical_test_name(cls, v):
+        """Mirror the Create-side validator: strip, treat empty as None.
+
+        Without this, an edit form submitting "" overwrites NULL and breaks
+        the trend grouping query that checks ``canonical_test_name IS NULL``.
+        """
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not stripped:
+            return None
+        if len(stripped) > LAB_TEST_COMPONENT_LIMITS["MAX_TEST_NAME_LENGTH"]:
+            raise ValueError(
+                f"Canonical test name must be less than {LAB_TEST_COMPONENT_LIMITS['MAX_TEST_NAME_LENGTH']} characters"
+            )
+        return stripped
+
     @model_validator(mode="after")
     def validate_ref_range(self):
         """Validate that ref_range_max is greater than ref_range_min"""

--- a/app/schemas/lab_test_component.py
+++ b/app/schemas/lab_test_component.py
@@ -397,11 +397,7 @@ class LabTestComponentUpdate(BaseModel):
     @field_validator("canonical_test_name")
     @classmethod
     def validate_canonical_test_name(cls, v):
-        """Mirror the Create-side validator: strip, treat empty as None.
-
-        Without this, an edit form submitting "" overwrites NULL and breaks
-        the trend grouping query that checks ``canonical_test_name IS NULL``.
-        """
+        """Normalize empty/whitespace to None — grouping query treats only NULL as 'unlinked'."""
         if v is None:
             return None
         stripped = v.strip()

--- a/app/services/trend_data_fetcher.py
+++ b/app/services/trend_data_fetcher.py
@@ -302,9 +302,7 @@ class TrendDataFetcher:
         representative raw value (MAX) from the group so conventional casing
         (e.g. the capital L in 'mg/L') is preserved.
         """
-        # nullif treats empty-string canonical_test_name as NULL so components
-        # marked as "processed but unmatched" (see test_library_sync) still
-        # group under their raw test_name.
+        # Treat empty canonical_test_name as NULL (sync service uses "" for "no library match").
         name_expr = func.coalesce(
             func.nullif(LabTestComponent.canonical_test_name, ""),
             LabTestComponent.test_name,

--- a/app/services/trend_data_fetcher.py
+++ b/app/services/trend_data_fetcher.py
@@ -302,8 +302,11 @@ class TrendDataFetcher:
         representative raw value (MAX) from the group so conventional casing
         (e.g. the capital L in 'mg/L') is preserved.
         """
+        # nullif treats empty-string canonical_test_name as NULL so components
+        # marked as "processed but unmatched" (see test_library_sync) still
+        # group under their raw test_name.
         name_expr = func.coalesce(
-            LabTestComponent.canonical_test_name,
+            func.nullif(LabTestComponent.canonical_test_name, ""),
             LabTestComponent.test_name,
         )
         unit_group_expr = func.lower(
@@ -379,11 +382,15 @@ class TrendDataFetcher:
                     or_(
                         and_(
                             LabTestComponent.canonical_test_name.isnot(None),
+                            LabTestComponent.canonical_test_name != "",
                             func.lower(LabTestComponent.canonical_test_name)
                             == func.lower(test_name),
                         ),
                         and_(
-                            LabTestComponent.canonical_test_name.is_(None),
+                            or_(
+                                LabTestComponent.canonical_test_name.is_(None),
+                                LabTestComponent.canonical_test_name == "",
+                            ),
                             func.lower(func.rtrim(LabTestComponent.test_name, ",;: "))
                             == func.lower(test_name),
                         ),

--- a/app/services/trend_data_fetcher.py
+++ b/app/services/trend_data_fetcher.py
@@ -302,9 +302,9 @@ class TrendDataFetcher:
         representative raw value (MAX) from the group so conventional casing
         (e.g. the capital L in 'mg/L') is preserved.
         """
-        # Treat empty canonical_test_name as NULL (sync service uses "" for "no library match").
+        # Treat empty / whitespace-only canonical_test_name as NULL (sync service uses "" for "no library match").
         name_expr = func.coalesce(
-            func.nullif(LabTestComponent.canonical_test_name, ""),
+            func.nullif(func.trim(LabTestComponent.canonical_test_name), ""),
             LabTestComponent.test_name,
         )
         unit_group_expr = func.lower(
@@ -380,14 +380,14 @@ class TrendDataFetcher:
                     or_(
                         and_(
                             LabTestComponent.canonical_test_name.isnot(None),
-                            LabTestComponent.canonical_test_name != "",
-                            func.lower(LabTestComponent.canonical_test_name)
-                            == func.lower(test_name),
+                            func.trim(LabTestComponent.canonical_test_name) != "",
+                            func.lower(func.trim(LabTestComponent.canonical_test_name))
+                            == func.lower(func.trim(test_name)),
                         ),
                         and_(
                             or_(
                                 LabTestComponent.canonical_test_name.is_(None),
-                                LabTestComponent.canonical_test_name == "",
+                                func.trim(LabTestComponent.canonical_test_name) == "",
                             ),
                             func.lower(func.rtrim(LabTestComponent.test_name, ",;: "))
                             == func.lower(test_name),

--- a/tests/crud/test_lab_test_component.py
+++ b/tests/crud/test_lab_test_component.py
@@ -777,3 +777,122 @@ class TestUnitScopedTrending:
         assert set(by_unit) == {"mg/L", "mmol/L"}
         assert by_unit["mg/L"].reading_count == 2
         assert by_unit["mmol/L"].reading_count == 1
+
+
+class TestCanonicalTestNameEmptyStringFallback:
+    """
+    Components with canonical_test_name equal to "" must behave the same as
+    NULL in the trend-grouping query — both should fall back to matching on
+    raw test_name. The sync service intentionally writes "" to mark
+    "processed but unmatched" (see app/services/test_library_sync.py), and
+    the TestComponentEditModal previously submitted "" on save.
+
+    Pre-fix regression: an edited custom-named component had canonical="" and
+    was excluded from its own trend, breaking the chart and delinking it from
+    sibling components with canonical=NULL.
+    """
+
+    @pytest.fixture
+    def test_patient(self, db_session: Session, test_user):
+        patient_data = PatientCreate(
+            first_name="Canon",
+            last_name="Tester",
+            birth_date=date(1990, 1, 1),
+            gender="F",
+            address="Canonical Ave",
+        )
+        return patient_crud.create_for_user(
+            db_session, user_id=test_user.id, patient_data=patient_data
+        )
+
+    @pytest.fixture
+    def seeded_custom_and_canonical(self, db_session: Session, test_patient):
+        """Seed three components sharing test_name='MyCustomTest' in distinct states.
+
+        - null_comp: canonical_test_name = NULL (newly created, never synced)
+        - empty_comp: canonical_test_name = "" (processed, no library match;
+          also the state produced by the edit modal pre-fix)
+        - linked_comp: canonical_test_name = "Hemoglobin" (linked to standard)
+        """
+        lab = lab_result_crud.create(
+            db_session,
+            obj_in=LabResultCreate(
+                patient_id=test_patient.id,
+                test_name="Custom Panel",
+                test_category="blood work",
+                status="completed",
+                completed_date=date(2026, 1, 10),
+            ),
+        )
+        null_comp = lab_test_component_crud.create(
+            db_session,
+            obj_in=LabTestComponentCreate(
+                lab_result_id=lab.id,
+                test_name="MyCustomTest",
+                value=10.0,
+                unit="mg/dL",
+            ),
+        )
+        empty_comp = lab_test_component_crud.create(
+            db_session,
+            obj_in=LabTestComponentCreate(
+                lab_result_id=lab.id,
+                test_name="MyCustomTest",
+                value=20.0,
+                unit="mg/dL",
+            ),
+        )
+        # Bypass the schema validator to simulate the sync service writing ""
+        # directly to the column (the schema now normalizes "" -> None, so we
+        # can't produce this state via the ORM's update path).
+        db_session.query(LabTestComponent).filter(
+            LabTestComponent.id == empty_comp.id
+        ).update({LabTestComponent.canonical_test_name: ""})
+        db_session.commit()
+        db_session.refresh(empty_comp)
+        assert empty_comp.canonical_test_name == ""
+
+        linked_comp = lab_test_component_crud.create(
+            db_session,
+            obj_in=LabTestComponentCreate(
+                lab_result_id=lab.id,
+                test_name="MyCustomTest",  # Same raw name as the other two
+                value=14.0,
+                unit="g/dL",
+                canonical_test_name="Hemoglobin",
+            ),
+        )
+        return {
+            "patient": test_patient,
+            "null": null_comp,
+            "empty": empty_comp,
+            "linked": linked_comp,
+        }
+
+    def test_query_for_custom_name_includes_null_and_empty(
+        self, db_session: Session, seeded_custom_and_canonical
+    ):
+        """Querying by the custom test_name returns both the NULL and the
+        empty-canonical components, excluding the one linked elsewhere."""
+        rows = lab_test_component_crud.get_by_patient_and_test_name(
+            db_session,
+            patient_id=seeded_custom_and_canonical["patient"].id,
+            test_name="MyCustomTest",
+        )
+        returned_ids = {r.id for r in rows}
+        assert seeded_custom_and_canonical["null"].id in returned_ids
+        assert seeded_custom_and_canonical["empty"].id in returned_ids
+        assert seeded_custom_and_canonical["linked"].id not in returned_ids
+
+    def test_query_for_canonical_name_excludes_fallback_rows(
+        self, db_session: Session, seeded_custom_and_canonical
+    ):
+        """Querying by the canonical name returns only the linked component,
+        not the NULL/empty ones that share the same raw test_name."""
+        rows = lab_test_component_crud.get_by_patient_and_test_name(
+            db_session,
+            patient_id=seeded_custom_and_canonical["patient"].id,
+            test_name="Hemoglobin",
+        )
+        returned_ids = {r.id for r in rows}
+        assert returned_ids == {seeded_custom_and_canonical["linked"].id}

--- a/tests/crud/test_lab_test_component.py
+++ b/tests/crud/test_lab_test_component.py
@@ -894,3 +894,20 @@ class TestCanonicalTestNameEmptyStringFallback:
         )
         returned_ids = {r.id for r in rows}
         assert returned_ids == {seeded_custom_and_canonical["linked"].id}
+
+    def test_whitespace_only_canonical_treated_as_empty(
+        self, db_session: Session, seeded_custom_and_canonical
+    ):
+        """Whitespace-only canonical_test_name falls back to test_name matching,
+        same as NULL / "". Defends against direct DB writes that bypass validators."""
+        db_session.query(LabTestComponent).filter(
+            LabTestComponent.id == seeded_custom_and_canonical["empty"].id
+        ).update({LabTestComponent.canonical_test_name: "   "})
+        db_session.commit()
+
+        rows = lab_test_component_crud.get_by_patient_and_test_name(
+            db_session,
+            patient_id=seeded_custom_and_canonical["patient"].id,
+            test_name="MyCustomTest",
+        )
+        assert seeded_custom_and_canonical["empty"].id in {r.id for r in rows}

--- a/tests/crud/test_lab_test_component.py
+++ b/tests/crud/test_lab_test_component.py
@@ -842,9 +842,7 @@ class TestCanonicalTestNameEmptyStringFallback:
                 unit="mg/dL",
             ),
         )
-        # Bypass the schema validator to simulate the sync service writing ""
-        # directly to the column (the schema now normalizes "" -> None, so we
-        # can't produce this state via the ORM's update path).
+        # Raw UPDATE: schema normalizes "" -> None, so we must bypass it to simulate sync state.
         db_session.query(LabTestComponent).filter(
             LabTestComponent.id == empty_comp.id
         ).update({LabTestComponent.canonical_test_name: ""})

--- a/tests/unit/test_lab_test_component_schema.py
+++ b/tests/unit/test_lab_test_component_schema.py
@@ -481,3 +481,34 @@ class TestUpdateCrossFieldValidation:
         """Updating value (not clearing) without result_type is fine."""
         update = LabTestComponentUpdate(value=42.0)
         assert update.value == 42.0
+
+
+class TestUpdateCanonicalTestNameNormalization:
+    """Empty / whitespace canonical_test_name must normalize to None on update.
+
+    Regression: the TestComponentEditModal always submits
+    ``canonical_test_name: ''`` when the user hasn't linked to a standard test.
+    Without this validator, the DB stored "" and the trend-grouping query
+    excluded the row from its own trend, delinking it from sibling components.
+    """
+
+    def test_empty_string_normalized_to_none(self):
+        update = LabTestComponentUpdate(canonical_test_name="")
+        assert update.canonical_test_name is None
+
+    def test_whitespace_only_normalized_to_none(self):
+        update = LabTestComponentUpdate(canonical_test_name="   ")
+        assert update.canonical_test_name is None
+
+    def test_none_stays_none(self):
+        update = LabTestComponentUpdate(canonical_test_name=None)
+        assert update.canonical_test_name is None
+
+    def test_valid_value_preserved_and_stripped(self):
+        update = LabTestComponentUpdate(canonical_test_name="  Hemoglobin  ")
+        assert update.canonical_test_name == "Hemoglobin"
+
+    def test_unset_field_stays_unset(self):
+        """If the caller doesn't include the field, exclude_unset still skips it."""
+        update = LabTestComponentUpdate(value=10.0)
+        assert "canonical_test_name" not in update.model_dump(exclude_unset=True)


### PR DESCRIPTION
## Summary

This pull request addresses a key bug in how lab test components are grouped for trend analysis when their `canonical_test_name` is an empty string (`""`). Previously, components with `canonical_test_name=""` were excluded from trends that should have included them, breaking data grouping and charts. The changes ensure that both empty string and `NULL` values for `canonical_test_name` are treated equivalently—falling back to matching on the raw `test_name`. The update also adds validation to normalize empty or whitespace-only canonical names to `None`, and expands tests to cover these cases.

**Trend grouping and matching logic improvements:**

* Updated queries in `lab_test_component.py` and `trend_data_fetcher.py` to treat empty-string `canonical_test_name` the same as `NULL`, ensuring components marked as "processed but unmatched" are still grouped by their raw `test_name`. This prevents them from being excluded from their own trends. [[1]](diffhunk://#diff-1d0f41d98084fc56295e96f2d3b36e5aecaa8e590e09a679467599b8e218f6bbL214-R219) [[2]](diffhunk://#diff-1d0f41d98084fc56295e96f2d3b36e5aecaa8e590e09a679467599b8e218f6bbR239-R247) [[3]](diffhunk://#diff-027313021ecc389091f2694991df3816bcaff03d8d3e84c56a167266bb620bc2R305-R309) [[4]](diffhunk://#diff-027313021ecc389091f2694991df3816bcaff03d8d3e84c56a167266bb620bc2R385-R393)

**Schema validation and normalization:**

* Added a validator to the `LabTestComponentUpdate` schema to strip whitespace and convert empty or whitespace-only `canonical_test_name` values to `None`, preventing the database from storing empty strings and maintaining consistent grouping behavior.

**Testing and regression coverage:**

* Introduced new regression tests to verify that components with `canonical_test_name=""` are included in trend queries as expected, and that the schema normalizes empty or whitespace-only canonical names to `None` on update. [[1]](diffhunk://#diff-654280ce197c9029ea647b47c57ba1793280af179cedbbe2c4e077e4dd69cf73R780-R898) [[2]](diffhunk://#diff-e8ac39d11c7cb6de1de84e8004043ff3aee7e56bb858f4ddc83e0a29c10e3bd7R484-R514)

## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing



## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently treat empty or whitespace-only canonical test names as missing, improving matching and grouping for lab test names in queries and trend analysis.

* **New Features**
  * Update-side validation normalizes or clears canonical test name edits and enforces a maximum length.

* **Tests**
  * Added regression and unit tests covering name normalization and matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->