### PR TITLE
fix: login sso auto retry

### DIFF
--- a/frontend/src/components/auth/Login.test.jsx
+++ b/frontend/src/components/auth/Login.test.jsx
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Login from '../../pages/auth/Login';
 import render from '../../test-utils/render';
 
@@ -101,7 +102,9 @@ describe('Login Component', () => {
 
     test('shows retry notice when SSO config fetch fails (not the SSO button)', async () => {
       // Simulate the service layer's new error contract: fetch failed,
-      // not "backend said SSO is off"
+      // not "backend said SSO is off". The Login page auto-retries with
+      // backoff (~5s total) before surfacing the error, so extend the
+      // findByTestId timeout past the full retry window.
       authService.checkRegistrationEnabled.mockResolvedValue({
         registration_enabled: false,
         error: true,
@@ -113,15 +116,17 @@ describe('Login Component', () => {
 
       render(<Login />);
 
-      // Config-error notice is visible; SSO section is not
-      expect(await screen.findByTestId('config-error')).toBeInTheDocument();
+      // Config-error notice appears only after all retry attempts exhaust.
+      expect(
+        await screen.findByTestId('config-error', {}, { timeout: 8000 })
+      ).toBeInTheDocument();
       expect(screen.queryByTestId('sso-section')).not.toBeInTheDocument();
       // Registration-disabled message should NOT be shown in the error state
       // (we don't actually know whether registration is disabled)
       expect(
         screen.queryByText('login.registrationDisabled')
       ).not.toBeInTheDocument();
-    });
+    }, 10000);
 
     test('does NOT show retry notice when backend genuinely returns SSO disabled', async () => {
       authService.checkRegistrationEnabled.mockResolvedValue({
@@ -157,6 +162,136 @@ describe('Login Component', () => {
       expect(usernameInput).toHaveAttribute('required');
       expect(passwordInput).toHaveAttribute('required');
     });
+
+    test('auto-retries silently when first config fetch fails and shows SSO once recovered', async () => {
+      // First attempt: both fetches report fetch-failure. Second attempt
+      // (after the 500ms backoff): both succeed. The user must never see
+      // the config-error notice during this recovery window.
+      authService.checkRegistrationEnabled
+        .mockResolvedValueOnce({ registration_enabled: false, error: true })
+        .mockResolvedValue({ registration_enabled: true });
+      authService.getSSOConfig
+        .mockResolvedValueOnce({ enabled: false, error: true })
+        .mockResolvedValue({ enabled: true, provider_type: 'google' });
+
+      render(<Login />);
+
+      // Longer timeout to cover the 500ms backoff + async retry.
+      const ssoSection = await screen.findByTestId(
+        'sso-section',
+        {},
+        { timeout: 3000 }
+      );
+      expect(ssoSection).toBeInTheDocument();
+      expect(screen.queryByTestId('config-error')).not.toBeInTheDocument();
+      expect(authService.checkRegistrationEnabled).toHaveBeenCalledTimes(2);
+      expect(authService.getSSOConfig).toHaveBeenCalledTimes(2);
+    });
+
+    test('attempts 4 total fetches (1 initial + 3 retries) before giving up', async () => {
+      // All attempts fail -- the page lands on the config-error state after
+      // the full 5s backoff window. Using real timers here keeps the test
+      // stable against library internals that rely on setInterval polling.
+      authService.checkRegistrationEnabled.mockResolvedValue({
+        registration_enabled: false,
+        error: true,
+      });
+      authService.getSSOConfig.mockResolvedValue({
+        enabled: false,
+        error: true,
+      });
+
+      render(<Login />);
+
+      expect(
+        await screen.findByTestId('config-error', {}, { timeout: 8000 })
+      ).toBeInTheDocument();
+      expect(authService.checkRegistrationEnabled).toHaveBeenCalledTimes(4);
+      expect(authService.getSSOConfig).toHaveBeenCalledTimes(4);
+    }, 10000);
+
+    test('window online event short-circuits pending backoff and re-fetches', async () => {
+      // First attempt fails; subsequent attempts would succeed. Without an
+      // online event we'd wait 500ms for the first retry. Firing online
+      // immediately after the initial failure should cancel the backoff and
+      // trigger the next fetch well inside that window.
+      authService.checkRegistrationEnabled
+        .mockResolvedValueOnce({ registration_enabled: false, error: true })
+        .mockResolvedValue({ registration_enabled: true });
+      authService.getSSOConfig
+        .mockResolvedValueOnce({ enabled: false, error: true })
+        .mockResolvedValue({ enabled: true, provider_type: 'github' });
+
+      render(<Login />);
+
+      // Wait for the first (failing) attempt to complete.
+      await waitFor(() => {
+        expect(authService.getSSOConfig).toHaveBeenCalledTimes(1);
+      });
+
+      // Fire online before the 500ms backoff elapses.
+      window.dispatchEvent(new Event('online'));
+
+      // The SSO section should appear fast -- the online-triggered new
+      // generation runs attempt #1 immediately (delay=0).
+      expect(
+        await screen.findByTestId('sso-section', {}, { timeout: 2000 })
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('config-error')).not.toBeInTheDocument();
+    });
+
+    test('retry button re-runs config load in place (no full page reload)', async () => {
+      const reloadSpy = vi.fn();
+      const originalLocation = window.location;
+      // JSDOM's window.location is read-only; rebuild it with a spied reload.
+      delete window.location;
+      window.location = { ...originalLocation, reload: reloadSpy };
+
+      try {
+        // All retries fail so we land on the config-error state.
+        authService.checkRegistrationEnabled.mockResolvedValue({
+          registration_enabled: false,
+          error: true,
+        });
+        authService.getSSOConfig.mockResolvedValue({
+          enabled: false,
+          error: true,
+        });
+
+        render(<Login />);
+
+        const errorNotice = await screen.findByTestId(
+          'config-error',
+          {},
+          { timeout: 6000 }
+        );
+        expect(errorNotice).toBeInTheDocument();
+        const callsBeforeRetry =
+          authService.checkRegistrationEnabled.mock.calls.length;
+
+        // Swap to a successful response for the retry click.
+        authService.checkRegistrationEnabled.mockResolvedValue({
+          registration_enabled: true,
+        });
+        authService.getSSOConfig.mockResolvedValue({
+          enabled: true,
+          provider_type: 'google',
+        });
+
+        const user = userEvent.setup();
+        await user.click(screen.getByText('login.retry'));
+
+        expect(
+          await screen.findByTestId('sso-section', {}, { timeout: 3000 })
+        ).toBeInTheDocument();
+        expect(
+          authService.checkRegistrationEnabled.mock.calls.length
+        ).toBeGreaterThan(callsBeforeRetry);
+        expect(reloadSpy).not.toHaveBeenCalled();
+      } finally {
+        window.location = originalLocation;
+      }
+    }, 10000);
   });
 
   describe('Component Structure', () => {

--- a/frontend/src/components/auth/Login.test.jsx
+++ b/frontend/src/components/auth/Login.test.jsx
@@ -229,14 +229,25 @@ describe('Login Component', () => {
         expect(authService.getSSOConfig).toHaveBeenCalledTimes(1);
       });
 
-      // Fire online before the 500ms backoff elapses.
+      // Confirm we're still inside the 500ms backoff (no second call yet).
+      // If the backoff elapses on its own, the test would still pass without
+      // the online wiring -- the timing assertion below is what makes it
+      // load-bearing.
+      expect(authService.getSSOConfig).toHaveBeenCalledTimes(1);
+
+      // Fire online before the 500ms backoff elapses, then measure recovery.
+      const t0 = performance.now();
       window.dispatchEvent(new Event('online'));
 
-      // The SSO section should appear fast -- the online-triggered new
-      // generation runs attempt #1 immediately (delay=0).
-      expect(
-        await screen.findByTestId('sso-section', {}, { timeout: 2000 })
-      ).toBeInTheDocument();
+      const ssoSection = await screen.findByTestId(
+        'sso-section',
+        {},
+        { timeout: 2000 }
+      );
+      expect(ssoSection).toBeInTheDocument();
+      // Recovery must be well under the 500ms backoff -- proves online
+      // drove the retry, not the regular timer.
+      expect(performance.now() - t0).toBeLessThan(400);
       expect(screen.queryByTestId('config-error')).not.toBeInTheDocument();
     });
 

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -86,13 +86,17 @@ const Login = () => {
       if (delay > 0) {
         try {
           await new Promise((resolve, reject) => {
-            const timer = setTimeout(resolve, delay);
-            ac.signal.addEventListener('abort', () => {
+            const handleAbort = () => {
               clearTimeout(timer);
               const err = new Error('aborted');
               err.name = 'AbortError';
               reject(err);
-            });
+            };
+            const timer = setTimeout(() => {
+              ac.signal.removeEventListener('abort', handleAbort);
+              resolve();
+            }, delay);
+            ac.signal.addEventListener('abort', handleAbort, { once: true });
           });
         } catch {
           return; // backoff was aborted -- superseded or unmounted
@@ -130,17 +134,27 @@ const Login = () => {
     setConfigLoaded(true);
   }, []);
 
+  // Initial load + unmount cleanup. Kept separate from the online-listener
+  // effect so adding configLoaded/configError as deps there can't accidentally
+  // re-trigger loadConfig (which would loop, since loadConfig writes both).
   useEffect(() => {
     loadConfig();
-    // If the OS reports connectivity is back, short-circuit any in-progress
-    // backoff and re-fetch immediately.
-    const onOnline = () => loadConfig();
-    window.addEventListener('online', onOnline);
     return () => {
-      window.removeEventListener('online', onOnline);
       abortRef.current?.abort();
     };
   }, [loadConfig]);
+
+  // If the OS reports connectivity is back, short-circuit any in-progress
+  // backoff and re-fetch immediately. Skip when config has already loaded
+  // successfully -- otherwise a stray WiFi flap on a working page would
+  // briefly hide the SSO/registration UI and fire two redundant requests.
+  useEffect(() => {
+    const onOnline = () => {
+      if (!configLoaded || configError) loadConfig();
+    };
+    window.addEventListener('online', onOnline);
+    return () => window.removeEventListener('online', onOnline);
+  }, [loadConfig, configLoaded, configError]);
 
   const handleChange = e => {
     clearError(); // Clear any existing errors

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
@@ -58,24 +58,89 @@ const Login = () => {
     });
   }, []);
 
-  // Check registration status and SSO config on mount
-  useEffect(() => {
-    const loadConfig = async () => {
-      const [status, config] = await Promise.all([
-        authService.checkRegistrationEnabled(),
-        authService.getSSOConfig(),
-      ]);
-      setRegistrationEnabled(status.registration_enabled);
-      setRegistrationMessage(status.message || '');
-      setSSOConfig(config);
-      // error:true means the fetch itself failed -- do not confuse that with
-      // "backend returned SSO/registration disabled", which is a valid state
-      setConfigError(status.error === true || config.error === true);
-      setConfigLoaded(true);
-    };
+  // Retry generation counter: a new generation supersedes any pending
+  // backoff timer or in-flight fetch from a previous attempt (e.g. when
+  // `window.online` fires mid-backoff, or the user clicks Retry).
+  const attemptRef = useRef(0);
+  const abortRef = useRef(null);
 
-    loadConfig();
+  // Check registration status and SSO config, with silent exponential-backoff
+  // retry so a transient network blip or cookie-clear race during auto-logout
+  // recovers invisibly. Only shows the Retry button once all attempts exhaust.
+  const loadConfig = useCallback(async () => {
+    attemptRef.current += 1;
+    const thisAttempt = attemptRef.current;
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    // Reset UI to the pre-load state. configLoaded stays false through the
+    // auto-retry window so neither SSO nor the error notice render yet.
+    setConfigLoaded(false);
+    setConfigError(false);
+
+    // First attempt is immediate; three retries at 0.5s, 1.5s, 3s (~5s total).
+    const delays = [0, 500, 1500, 3000];
+    for (const delay of delays) {
+      if (thisAttempt !== attemptRef.current || ac.signal.aborted) return;
+      if (delay > 0) {
+        try {
+          await new Promise((resolve, reject) => {
+            const timer = setTimeout(resolve, delay);
+            ac.signal.addEventListener('abort', () => {
+              clearTimeout(timer);
+              const err = new Error('aborted');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          });
+        } catch {
+          return; // backoff was aborted -- superseded or unmounted
+        }
+      }
+      if (thisAttempt !== attemptRef.current || ac.signal.aborted) return;
+
+      try {
+        const [status, config] = await Promise.all([
+          authService.checkRegistrationEnabled({ signal: ac.signal }),
+          authService.getSSOConfig({ signal: ac.signal }),
+        ]);
+        if (thisAttempt !== attemptRef.current || ac.signal.aborted) return;
+
+        // error:true means the fetch itself failed -- do not confuse that
+        // with "backend returned SSO/registration disabled", which is valid.
+        const failed = status.error === true || config.error === true;
+        if (!failed) {
+          setRegistrationEnabled(status.registration_enabled);
+          setRegistrationMessage(status.message || '');
+          setSSOConfig(config);
+          setConfigError(false);
+          setConfigLoaded(true);
+          return;
+        }
+        // Soft failure -- fall through to next backoff delay.
+      } catch (err) {
+        if (err.name === 'AbortError') return;
+        // Any other unexpected error: treat as soft failure and keep retrying.
+      }
+    }
+
+    if (thisAttempt !== attemptRef.current || ac.signal.aborted) return;
+    setConfigError(true);
+    setConfigLoaded(true);
   }, []);
+
+  useEffect(() => {
+    loadConfig();
+    // If the OS reports connectivity is back, short-circuit any in-progress
+    // backoff and re-fetch immediately.
+    const onOnline = () => loadConfig();
+    window.addEventListener('online', onOnline);
+    return () => {
+      window.removeEventListener('online', onOnline);
+      abortRef.current?.abort();
+    };
+  }, [loadConfig]);
 
   const handleChange = e => {
     clearError(); // Clear any existing errors
@@ -244,7 +309,7 @@ const Login = () => {
             <button
               type="button"
               className={styles.retryBtn}
-              onClick={() => window.location.reload()}
+              onClick={loadConfig}
             >
               {t('login.retry')}
             </button>

--- a/frontend/src/services/auth/simpleAuthService.js
+++ b/frontend/src/services/auth/simpleAuthService.js
@@ -20,6 +20,9 @@ class SimpleAuthService {
     this.userKey = 'user';
   } // Make API request with fallback
   async makeRequest(endpoint, options = {}) {
+    // Pull `signal` out so we can react to AbortError separately from other
+    // fetch errors (don't log, don't fire /health ping on intentional abort).
+    const { signal, ...fetchOptions } = options;
     const urls = [
       `${this.directBackendURL}${endpoint}`, // Try direct backend first
       `${this.baseURL}${endpoint}`, // Then try proxy
@@ -45,7 +48,11 @@ class SimpleAuthService {
           setTimeout(() => reject(new Error('Request timeout')), timeout);
         });
 
-        const fetchPromise = fetch(url, { ...options, credentials: 'include' });
+        const fetchPromise = fetch(url, {
+          ...fetchOptions,
+          credentials: 'include',
+          signal,
+        });
         const response = await Promise.race([fetchPromise, timeoutPromise]);
 
         logger.info(`Response received from ${url}`, {
@@ -59,6 +66,12 @@ class SimpleAuthService {
         // Return response regardless of status (let caller handle HTTP errors)
         return response;
       } catch (error) {
+        // Intentional abort (component unmount, auto-retry supersede, manual
+        // retry click) -- propagate immediately without logging, pinging, or
+        // trying the next URL. The caller is responsible for the cleanup.
+        if (error.name === 'AbortError' || signal?.aborted) {
+          throw error;
+        }
         // The backend FrontendLogRequest schema ignores unknown top-level fields,
         // so enrichment goes under `details` (captured as-is) and the stack goes
         // under the declared `stack_trace` field.
@@ -393,11 +406,12 @@ class SimpleAuthService {
   }
 
   // Check if user registration is enabled
-  async checkRegistrationEnabled() {
+  async checkRegistrationEnabled({ signal } = {}) {
     try {
       const response = await this.makeRequest('/auth/registration-status', {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
+        signal,
       });
 
       if (!response.ok) {
@@ -416,6 +430,11 @@ class SimpleAuthService {
       });
       return data;
     } catch (error) {
+      // Let AbortError propagate so the caller's retry/cleanup can distinguish
+      // "fetch aborted intentionally" from "fetch failed for real".
+      if (error.name === 'AbortError') {
+        throw error;
+      }
       logger.error('Error checking registration status', {
         error: error.message,
         category: 'auth_registration_check',
@@ -427,7 +446,7 @@ class SimpleAuthService {
   // SSO Methods
 
   // Check if SSO is available and get configuration
-  async getSSOConfig() {
+  async getSSOConfig({ signal } = {}) {
     try {
       logger.info('Checking SSO configuration', {
         category: 'sso_config_check',
@@ -436,6 +455,7 @@ class SimpleAuthService {
       const response = await this.makeRequest('/auth/sso/config', {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
+        signal,
       });
 
       if (!response.ok) {
@@ -456,6 +476,11 @@ class SimpleAuthService {
       });
       return data;
     } catch (error) {
+      // Let AbortError propagate so the caller's retry/cleanup can distinguish
+      // "fetch aborted intentionally" from "fetch failed for real".
+      if (error.name === 'AbortError') {
+        throw error;
+      }
       logger.error('Error checking SSO config', {
         error: error.message,
         category: 'sso_config_check',

--- a/frontend/src/services/auth/simpleAuthService.js
+++ b/frontend/src/services/auth/simpleAuthService.js
@@ -69,8 +69,18 @@ class SimpleAuthService {
         // Intentional abort (component unmount, auto-retry supersede, manual
         // retry click) -- propagate immediately without logging, pinging, or
         // trying the next URL. The caller is responsible for the cleanup.
-        if (error.name === 'AbortError' || signal?.aborted) {
+        if (error.name === 'AbortError') {
           throw error;
+        }
+        // If the external signal was aborted but the timeout race won first,
+        // the rejected error won't carry name === 'AbortError'. Normalize so
+        // downstream callers that key off error.name treat this as an abort.
+        if (signal?.aborted) {
+          throw typeof DOMException === 'function'
+            ? new DOMException('The operation was aborted.', 'AbortError')
+            : Object.assign(new Error('The operation was aborted.'), {
+                name: 'AbortError',
+              });
         }
         // The backend FrontendLogRequest schema ignores unknown top-level fields,
         // so enrichment goes under `details` (captured as-is) and the stack goes


### PR DESCRIPTION
## Summary

This pull request significantly improves the robustness and user experience of the login flow by implementing silent, exponential-backoff retries for configuration fetches (registration status and SSO config), handling network interruptions more gracefully, and refining error handling. It also enhances test coverage for these new behaviors. The most important changes are grouped below:

**Login flow robustness and retry logic:**

* Refactored the `Login` component to use a new `loadConfig` function that performs up to four attempts (one initial + three retries with increasing backoff) to fetch registration status and SSO config, only surfacing an error after all attempts fail. The retry logic is now resilient to transient network errors and supports cancellation of in-flight requests when superseded or on unmount. [[1]](diffhunk://#diff-99dd4f896ea3a584c44ebc6e0318b5444f81398d558006b60254e40ab3b37003L61-R144)], [[2]](diffhunk://#diff-99dd4f896ea3a584c44ebc6e0318b5444f81398d558006b60254e40ab3b37003L247-R312)])
* The login flow now listens for the browser's `online` event to immediately short-circuit any pending backoff and retry configuration fetches, improving recovery from lost connectivity. ([[frontend/src/pages/auth/Login.jsxL61-R144](diffhunk://#diff-99dd4f896ea3a584c44ebc6e0318b5444f81398d558006b60254e40ab3b37003L61-R144)])
* The "Retry" button on config error now re-runs the config load in place (without a full page reload), providing a smoother user experience. ([[frontend/src/pages/auth/Login.jsxL247-R312](diffhunk://#diff-99dd4f896ea3a584c44ebc6e0318b5444f81398d558006b60254e40ab3b37003L247-R312)])

**Service layer and error handling:**

* Updated `simpleAuthService.js` methods (`makeRequest`, `checkRegistrationEnabled`, `getSSOConfig`) to accept an optional `signal` parameter for request cancellation. Properly distinguishes between intentional aborts (which are not logged or retried) and real fetch failures, allowing the UI to handle retries and cleanup more accurately. [[1]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdR23-R25)], [[2]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdL48-R55)], [[3]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdR69-R74)], [[4]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdL396-R414)], [[5]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdR433-R437)], [[6]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdL430-R449)], [[7]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdR458)], [[8]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdR479-R483)])

**Testing improvements:**

* Added comprehensive tests to `Login.test.jsx` for the new retry logic, including silent recovery, maximum attempt limits, online event handling, and the retry button's behavior. Adjusted timeouts and assertions to account for the backoff and async nature of the new logic. [[1]](diffhunk://#diff-209ac0381f70bceb99cceca88faac08158e484a86fc85a2642600c22deb82950L2-R3)], [[2]](diffhunk://#diff-209ac0381f70bceb99cceca88faac08158e484a86fc85a2642600c22deb82950L104-R107)], [[3]](diffhunk://#diff-209ac0381f70bceb99cceca88faac08158e484a86fc85a2642600c22deb82950L116-R129)], [[4]](diffhunk://#diff-209ac0381f70bceb99cceca88faac08158e484a86fc85a2642600c22deb82950R165-R294)])

These changes make the login experience more resilient to network issues and improve both user feedback and code maintainability.

## Related issue

#723 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing



## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Login configuration fetch now includes automatic retry with exponential backoff on failure
  * Detects browser online status to trigger immediate retry attempts
  * Retry button reloads configuration without requiring full page reload

* **Tests**
  * Added comprehensive test coverage for login retry behavior, including auto-retry scenarios, successful recovery, retry exhaustion, and online event handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->