### PR TITLE
fix: corrected admin page search and pagation

### DIFF
--- a/frontend/src/services/api/README.md
+++ b/frontend/src/services/api/README.md
@@ -183,7 +183,6 @@ Specialized service for administrative functions, extending the base API service
 
 - `bulkDeleteRecords(modelName, recordIds)` - Delete multiple records
 - `bulkUpdateRecords(modelName, recordIds, updateData)` - Update multiple records
-- `globalSearch(query, models)` - Search across multiple models
 - `exportModelData(modelName, format)` - Export data in various formats
 
 ### System Administration
@@ -240,7 +239,6 @@ const patients = await adminApiService.getModelRecords('Patient', {
 
 // Bulk operations
 await adminApiService.bulkDeleteRecords('Patient', [1, 2, 3]);
-const searchResults = await adminApiService.globalSearch('diabetes');
 ```
 
 ### Legacy API Service (Backward Compatibility)

--- a/frontend/src/services/api/__tests__/adminApi.test.js
+++ b/frontend/src/services/api/__tests__/adminApi.test.js
@@ -1,0 +1,50 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import adminApiService from '../adminApi';
+import BaseApiService from '../baseApi';
+
+describe('adminApiService.getModelRecords', () => {
+  let getSpy;
+
+  beforeEach(() => {
+    getSpy = vi
+      .spyOn(BaseApiService.prototype, 'get')
+      .mockResolvedValue({ items: [], total: 0, page: 1, per_page: 25, total_pages: 0 });
+  });
+
+  afterEach(() => {
+    getSpy.mockRestore();
+  });
+
+  it('forwards page, per_page, and search inside an options.params object', async () => {
+    await adminApiService.getModelRecords('user', {
+      page: 2,
+      per_page: 50,
+      search: 'foo',
+    });
+
+    expect(getSpy).toHaveBeenCalledWith('/models/user/', {
+      params: { page: 2, per_page: 50, search: 'foo' },
+    });
+  });
+
+  it('omits search from params when it is falsy', async () => {
+    await adminApiService.getModelRecords('medication', {
+      page: 1,
+      per_page: 25,
+      search: null,
+    });
+
+    expect(getSpy).toHaveBeenCalledWith('/models/medication/', {
+      params: { page: 1, per_page: 25 },
+    });
+  });
+
+  it('uses defaults (page=1, per_page=25, no search) when no params are provided', async () => {
+    await adminApiService.getModelRecords('user');
+
+    expect(getSpy).toHaveBeenCalledWith('/models/user/', {
+      params: { page: 1, per_page: 25 },
+    });
+  });
+});

--- a/frontend/src/services/api/adminApi.js
+++ b/frontend/src/services/api/adminApi.js
@@ -116,7 +116,7 @@ class AdminApiService extends BaseApiService {
     const queryParams = { page, per_page };
     if (search) queryParams.search = search;
 
-    return this.get(`/models/${modelName}/`, queryParams);
+    return this.get(`/models/${modelName}/`, { params: queryParams });
   }
 
   async getModelRecord(modelName, recordId) {
@@ -149,14 +149,6 @@ class AdminApiService extends BaseApiService {
       record_ids: recordIds,
       update_data: updateData,
     });
-  }
-
-  // Search across models
-  async globalSearch(query, models = null) {
-    const params = { query };
-    if (models) params.models = models.join(',');
-
-    return this.get('/search', params);
   }
 
   // Export model data as CSV


### PR DESCRIPTION
## Summary

This pull request focuses on improving the `adminApiService.getModelRecords` method by standardizing how query parameters are passed and tested. It also removes the deprecated `globalSearch` method from both the implementation and documentation, ensuring consistency and clarity in the API service.

**Improvements to API parameter handling:**

* Updated `getModelRecords` in `adminApiService` to always pass query parameters inside a `params` object, aligning with best practices for HTTP request libraries.
* Added comprehensive tests for `getModelRecords` to verify correct parameter forwarding, omission of falsy search terms, and use of default values when no parameters are provided.

**Cleanup and deprecation:**

* Removed the deprecated `globalSearch` method from `adminApiService` and its usage example, as well as its documentation in the README, to reduce confusion and maintain an up-to-date API surface. [[1]](diffhunk://#diff-4b32c32dd5c9431ad96c835cb2652d1aece2e244bd5f80f114eced2fd11ce9d8L154-L161) [[2]](diffhunk://#diff-e9a0de607f673df6cdd6126b35e5534e032b41a5a83269d3c615b24984eb04d0L186) [[3]](diffhunk://#diff-e9a0de607f673df6cdd6126b35e5534e032b41a5a83269d3c615b24984eb04d0L243)

## Related issue

Closes #851 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing



## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed parameter handling in model records retrieval.

* **Chores**
  * Removed global search functionality from the Admin API service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->