### PR TITLE
fix: allow linking of existing documents during record creation

### DIFF
--- a/frontend/public/locales/de/documents.json
+++ b/frontend/public/locales/de/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Dokument hinzufügen",
     "currentFiles": "Aktuelle Dateien:",
+    "documentsToLink": "Zu verknüpfende Dokumente:",
     "duplicateDocument": "Doppeltes Dokument",
     "duplicateExists": "Dieses Dokument existiert bereits in Paperless und kann nicht erneut hochgeladen werden.",
     "filesToUpload": "Dateien zum Hochladen:",
+    "linkDescriptionPlaceholder": "Beschreibung (optional)",
     "linkPaperless": "Bestehendes Paperless-Dokument verknüpfen",
     "linkPapra": "Bestehendes Papra-Dokument verknüpfen",
     "manageDocuments": "Dokumente verwalten",

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Add Document",
     "currentFiles": "Current Files:",
+    "documentsToLink": "Documents to Link:",
     "duplicateDocument": "Duplicate Document",
     "duplicateExists": "This document already exists in Paperless and cannot be uploaded again.",
     "filesToUpload": "Files to Upload:",
+    "linkDescriptionPlaceholder": "Description (optional)",
     "linkPaperless": "Link Existing Paperless Document",
     "linkPapra": "Link Existing Papra Document",
     "manageDocuments": "Manage Documents",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Agregar documento",
     "currentFiles": "Archivos actuales:",
+    "documentsToLink": "Documentos para vincular:",
     "duplicateDocument": "Documento duplicado",
     "duplicateExists": "Este documento ya existe en Paperless y no se puede cargar de nuevo.",
     "filesToUpload": "Archivos para cargar:",
+    "linkDescriptionPlaceholder": "Descripción (opcional)",
     "linkPaperless": "Vincular documento existente de Paperless",
     "linkPapra": "Vincular documento existente de Papra",
     "manageDocuments": "Gestionar documentos",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Ajouter un document",
     "currentFiles": "Fichiers actuels :",
+    "documentsToLink": "Documents à lier :",
     "duplicateDocument": "Document en double",
     "duplicateExists": "Ce document existe déjà dans Paperless et ne peut pas être téléversé à nouveau.",
     "filesToUpload": "Fichiers à téléverser :",
+    "linkDescriptionPlaceholder": "Description (facultative)",
     "linkPaperless": "Connecter un document existant dans Paperless",
     "linkPapra": "Connecter un document existant dans Papra",
     "manageDocuments": "Gérer les documents",

--- a/frontend/public/locales/it/documents.json
+++ b/frontend/public/locales/it/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Aggiungi documento",
     "currentFiles": "File attuali:",
+    "documentsToLink": "Documenti da collegare:",
     "duplicateDocument": "Documento duplicato",
     "duplicateExists": "Questo documento esiste già in Paperless e non può essere caricato di nuovo.",
     "filesToUpload": "File da caricare:",
+    "linkDescriptionPlaceholder": "Descrizione (opzionale)",
     "linkPaperless": "Collega documento Paperless esistente",
     "linkPapra": "Collega documento Papra esistente",
     "manageDocuments": "Gestisci documenti",

--- a/frontend/public/locales/nl/documents.json
+++ b/frontend/public/locales/nl/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Document toevoegen",
     "currentFiles": "Huidige bestanden:",
+    "documentsToLink": "Te koppelen documenten:",
     "duplicateDocument": "Duplicaat document",
     "duplicateExists": "Dit document bestaat al in Paperless en kan niet opnieuw worden geüpload.",
     "filesToUpload": "Te uploaden bestanden:",
+    "linkDescriptionPlaceholder": "Beschrijving (optioneel)",
     "linkPaperless": "Bestaand Paperless-document koppelen",
     "linkPapra": "Bestaand Papra-document koppelen",
     "manageDocuments": "Documenten beheren",

--- a/frontend/public/locales/pl/documents.json
+++ b/frontend/public/locales/pl/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Dodaj dokument",
     "currentFiles": "Bieżące pliki:",
+    "documentsToLink": "Dokumenty do powiązania:",
     "duplicateDocument": "Duplikat dokumentu",
     "duplicateExists": "Ten dokument już istnieje w Paperless i nie może zostać ponownie przesłany.",
     "filesToUpload": "Pliki do przesłania:",
+    "linkDescriptionPlaceholder": "Opis (opcjonalnie)",
     "linkPaperless": "Połącz istniejący dokument Paperless",
     "linkPapra": "Połącz istniejący dokument Papra",
     "manageDocuments": "Zarządzaj dokumentami",

--- a/frontend/public/locales/pt/documents.json
+++ b/frontend/public/locales/pt/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Adicionar documento",
     "currentFiles": "Ficheiros atuais:",
+    "documentsToLink": "Documentos para associar:",
     "duplicateDocument": "Documento duplicado",
     "duplicateExists": "Este documento já existe no Paperless e não pode ser carregado novamente.",
     "filesToUpload": "Ficheiros para carregar:",
+    "linkDescriptionPlaceholder": "Descrição (opcional)",
     "linkPaperless": "Associar documento Paperless existente",
     "linkPapra": "Associar documento Papra existente",
     "manageDocuments": "Gerir documentos",

--- a/frontend/public/locales/ru/documents.json
+++ b/frontend/public/locales/ru/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Добавить документ",
     "currentFiles": "Текущие файлы:",
+    "documentsToLink": "Документы для связывания:",
     "duplicateDocument": "Дублированный документ",
     "duplicateExists": "Этот документ уже существует в Paperless и не может быть загружен повторно.",
     "filesToUpload": "Файлы для загрузки:",
+    "linkDescriptionPlaceholder": "Описание (необязательно)",
     "linkPaperless": "Связать существующий документ Paperless",
     "linkPapra": "Связать существующий документ Papra",
     "manageDocuments": "Управление документами",

--- a/frontend/public/locales/sv/documents.json
+++ b/frontend/public/locales/sv/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "Lägg till dokument",
     "currentFiles": "Aktuella filer:",
+    "documentsToLink": "Dokument att länka:",
     "duplicateDocument": "Duplicerat dokument",
     "duplicateExists": "Detta dokument finns redan i Paperless och kan inte laddas upp igen.",
     "filesToUpload": "Filer att ladda upp:",
+    "linkDescriptionPlaceholder": "Beskrivning (valfritt)",
     "linkPaperless": "Länka befintligt Paperless-dokument",
     "linkPapra": "Länka befintligt Papra-dokument",
     "manageDocuments": "Hantera dokument",

--- a/frontend/public/locales/th/documents.json
+++ b/frontend/public/locales/th/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "เพิ่มเอกสาร",
     "currentFiles": "ไฟล์ปัจจุบัน:",
+    "documentsToLink": "เอกสารที่จะเชื่อมโยง:",
     "duplicateDocument": "เอกสารซ้ำซ้อน",
     "duplicateExists": "เอกสารนี้มีอยู่แล้วใน Paperless และไม่สามารถอัปโหลดอีกครั้งได้",
     "filesToUpload": "ไฟล์ที่จะอัปโหลด:",
+    "linkDescriptionPlaceholder": "คำอธิบาย (ไม่บังคับ)",
     "linkPaperless": "เชื่อมโยงเอกสาร Paperless ที่มีอยู่",
     "linkPapra": "เชื่อมโยงเอกสาร Papra ที่มีอยู่",
     "manageDocuments": "จัดการเอกสาร",

--- a/frontend/public/locales/zh/documents.json
+++ b/frontend/public/locales/zh/documents.json
@@ -73,9 +73,11 @@
   "manager": {
     "addDocument": "添加文档",
     "currentFiles": "当前文件：",
+    "documentsToLink": "待链接文档：",
     "duplicateDocument": "重复文档",
     "duplicateExists": "此文档在 Paperless 中已存在，无法重复上传。",
     "filesToUpload": "待上传文件：",
+    "linkDescriptionPlaceholder": "描述（可选）",
     "linkPaperless": "链接现有 Paperless 文档",
     "linkPapra": "链接现有 Papra 文档",
     "manageDocuments": "管理文档",

--- a/frontend/src/components/shared/DocumentManagerCore.jsx
+++ b/frontend/src/components/shared/DocumentManagerCore.jsx
@@ -8,7 +8,11 @@ import {
 import { notifications } from '@mantine/notifications';
 import { IconCheck, IconX } from '@tabler/icons-react';
 import { apiService } from '../../services/api';
-import { getPaperlessSettings } from '../../services/api/paperlessApi.jsx';
+import {
+  getPaperlessSettings,
+  linkPaperlessDocument,
+} from '../../services/api/paperlessApi.jsx';
+import { linkPapraDocument } from '../../services/api/papraApi.jsx';
 import logger from '../../services/logger';
 import {
   SUCCESS_MESSAGES,
@@ -16,6 +20,7 @@ import {
   enhancePaperlessError,
   formatErrorWithContext,
 } from '../../constants/errorMessages';
+import { generateId } from '../../utils/helpers';
 
 // Import configuration from upload progress hook
 const UPLOAD_CONFIG = {
@@ -136,6 +141,7 @@ const useDocumentManagerCore = ({
   // State management
   const [files, setFiles] = useState([]);
   const [pendingFiles, setPendingFiles] = useState([]);
+  const [pendingLinks, setPendingLinks] = useState([]);
   const [filesToDelete, setFilesToDelete] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -151,6 +157,11 @@ const useDocumentManagerCore = ({
   const monitoredSetPendingFiles = useCallback(newPendingFiles => {
     performanceMonitor.logStateUpdate('pendingFiles', newPendingFiles);
     setPendingFiles(newPendingFiles);
+  }, []);
+
+  const monitoredSetPendingLinks = useCallback(newPendingLinks => {
+    performanceMonitor.logStateUpdate('pendingLinks', newPendingLinks);
+    setPendingLinks(newPendingLinks);
   }, []);
 
   // Paperless settings state
@@ -218,6 +229,7 @@ const useDocumentManagerCore = ({
   // Refs for stable callbacks
   const filesRef = useRef(files);
   const pendingFilesRef = useRef(pendingFiles);
+  const pendingLinksRef = useRef(pendingLinks);
   const selectedStorageBackendRef = useRef(selectedStorageBackend);
   const paperlessSettingsRef = useRef(paperlessSettings);
   const paperlessAutoSyncRef = useRef(paperlessSettings?.paperless_auto_sync);
@@ -229,10 +241,17 @@ const useDocumentManagerCore = ({
   useEffect(() => {
     filesRef.current = files;
     pendingFilesRef.current = pendingFiles;
+    pendingLinksRef.current = pendingLinks;
     selectedStorageBackendRef.current = selectedStorageBackend;
     paperlessSettingsRef.current = paperlessSettings;
     paperlessAutoSyncRef.current = paperlessSettings?.paperless_auto_sync;
-  }, [files, pendingFiles, selectedStorageBackend, paperlessSettings]);
+  }, [
+    files,
+    pendingFiles,
+    pendingLinks,
+    selectedStorageBackend,
+    paperlessSettings,
+  ]);
 
   // Load paperless settings
   const loadPaperlessSettings = useCallback(async () => {
@@ -731,6 +750,52 @@ const useDocumentManagerCore = ({
     [monitoredSetPendingFiles]
   );
 
+  // In create mode the entity has no id yet, so /entity-files/{type}/{id}/link-{backend}
+  // can't be called. Queue here and flush after save via uploadPendingFiles(targetEntityId).
+  const handleAddPendingLink = useCallback(
+    linkData => {
+      const source = linkData?.paperless_document_id ? 'paperless' : 'papra';
+      const fallbackTitle =
+        source === 'paperless'
+          ? `Paperless document #${linkData?.paperless_document_id || ''}`
+          : `Papra document ${linkData?.papra_document_id || ''}`;
+      monitoredSetPendingLinks(prev => [
+        ...prev,
+        {
+          id: `link-${generateId()}`,
+          source,
+          linkData,
+          displayTitle: linkData?.description || fallbackTitle,
+        },
+      ]);
+    },
+    [monitoredSetPendingLinks]
+  );
+
+  const handleRemovePendingLink = useCallback(
+    linkId => {
+      monitoredSetPendingLinks(prev => prev.filter(l => l.id !== linkId));
+    },
+    [monitoredSetPendingLinks]
+  );
+
+  const handlePendingLinkDescriptionChange = useCallback(
+    (linkId, description) => {
+      monitoredSetPendingLinks(prev =>
+        prev.map(l =>
+          l.id === linkId
+            ? {
+                ...l,
+                linkData: { ...l.linkData, description },
+                displayTitle: description || l.displayTitle,
+              }
+            : l
+        )
+      );
+    },
+    [monitoredSetPendingLinks]
+  );
+
   // Mark file for deletion
   const handleMarkFileForDeletion = useCallback(fileId => {
     setFilesToDelete(prev => [...prev, fileId]);
@@ -1022,24 +1087,31 @@ const useDocumentManagerCore = ({
     ]
   );
 
-  // Batch upload pending files with progress tracking
+  // Batch upload pending files with progress tracking. Also flushes any
+  // pending "link existing remote document" operations queued in create mode.
   const uploadPendingFiles = useCallback(
     async targetEntityId => {
       const currentPendingFiles = pendingFilesRef.current;
+      const currentPendingLinks = pendingLinksRef.current;
 
       logger.info('document_manager_batch_upload_start', {
         message: 'Starting batch upload with progress tracking',
         entityType,
         targetEntityId,
         pendingFilesCount: currentPendingFiles.length,
+        pendingLinksCount: currentPendingLinks.length,
         component: 'DocumentManagerCore',
       });
 
-      if (currentPendingFiles.length === 0) {
+      if (
+        currentPendingFiles.length === 0 &&
+        currentPendingLinks.length === 0
+      ) {
         return true;
       }
 
-      // Start progress tracking
+      // Start progress tracking. Pending links share the same progress
+      // surface so the user sees one combined batch report.
       if (showProgressModal) {
         const progressFiles = currentPendingFiles.map((pf, index) => ({
           id: `batch-${index}`,
@@ -1047,7 +1119,13 @@ const useDocumentManagerCore = ({
           size: pf.file.size,
           description: pf.description,
         }));
-        startUpload(progressFiles);
+        const progressLinks = currentPendingLinks.map((pl, index) => ({
+          id: `link-${index}`,
+          name: pl.displayTitle,
+          size: 0,
+          description: pl.linkData?.description || '',
+        }));
+        startUpload([...progressFiles, ...progressLinks]);
       }
 
       const uploadPromises = currentPendingFiles.map(
@@ -1298,24 +1376,85 @@ const useDocumentManagerCore = ({
         }
       );
 
+      const linkPromises = currentPendingLinks.map(async (pendingLink, index) => {
+        const fileId = `link-${index}`;
+        try {
+          if (showProgressModal) {
+            debouncedUpdateProgress(fileId, 30, 'uploading');
+          }
+
+          if (pendingLink.source === 'paperless') {
+            await linkPaperlessDocument(
+              entityType,
+              targetEntityId,
+              pendingLink.linkData
+            );
+          } else if (pendingLink.source === 'papra') {
+            await linkPapraDocument(
+              entityType,
+              targetEntityId,
+              pendingLink.linkData
+            );
+          } else {
+            throw new Error(`Unknown link source: ${pendingLink.source}`);
+          }
+
+          if (showProgressModal) {
+            updateFileProgress(fileId, 100, 'completed');
+          }
+
+          logger.info('document_manager_pending_link_success', {
+            message: 'Pending document link processed',
+            entityType,
+            targetEntityId,
+            source: pendingLink.source,
+            component: 'DocumentManagerCore',
+          });
+        } catch (error) {
+          const errorMessage =
+            pendingLink.source === 'paperless'
+              ? enhancePaperlessError(error?.message || '')
+              : getUserFriendlyError(error, 'link');
+
+          if (showProgressModal) {
+            updateFileProgress(fileId, 0, 'failed', errorMessage);
+          }
+
+          logger.error('document_manager_pending_link_error', {
+            message: 'Failed to flush pending document link',
+            entityType,
+            targetEntityId,
+            source: pendingLink.source,
+            error: error?.message,
+            component: 'DocumentManagerCore',
+          });
+
+          throw new Error(errorMessage);
+        }
+      });
+
+      const totalCount =
+        currentPendingFiles.length + currentPendingLinks.length;
+
       try {
-        await Promise.all(uploadPromises);
+        await Promise.all([...uploadPromises, ...linkPromises]);
 
         // Complete successfully
         if (showProgressModal) {
           completeUpload(
             true,
-            `All ${currentPendingFiles.length} file(s) uploaded successfully!`
+            `All ${totalCount} document(s) processed successfully!`
           );
         }
 
         monitoredSetPendingFiles([]);
+        monitoredSetPendingLinks([]);
 
         // Refresh data
         await loadFiles();
 
         if (onUploadComplete) {
-          onUploadComplete(true, currentPendingFiles.length, 0);
+          onUploadComplete(true, totalCount, 0);
         }
 
         logger.info('document_manager_batch_upload_complete', {
@@ -1323,12 +1462,13 @@ const useDocumentManagerCore = ({
           entityType,
           targetEntityId,
           fileCount: currentPendingFiles.length,
+          linkCount: currentPendingLinks.length,
           component: 'DocumentManagerCore',
         });
 
         return true;
       } catch (error) {
-        // Some files failed
+        // Some files / links failed
         const completedCount = uploadState.files.filter(
           f => f.status === 'completed'
         ).length;
@@ -1339,7 +1479,7 @@ const useDocumentManagerCore = ({
         if (showProgressModal) {
           completeUpload(
             false,
-            `Upload completed with errors: ${completedCount} succeeded, ${failedCount} failed.`
+            `Operation completed with errors: ${completedCount} succeeded, ${failedCount} failed.`
           );
         }
 
@@ -1371,6 +1511,7 @@ const useDocumentManagerCore = ({
       onUploadComplete,
       debouncedUpdateProgress,
       monitoredSetPendingFiles,
+      monitoredSetPendingLinks,
     ]
   );
 
@@ -1566,6 +1707,7 @@ const useDocumentManagerCore = ({
       // State
       files,
       pendingFiles,
+      pendingLinks,
       filesToDelete,
       loading,
       error,
@@ -1585,6 +1727,9 @@ const useDocumentManagerCore = ({
       // Handlers
       handleAddPendingFile,
       handleRemovePendingFile,
+      handleAddPendingLink,
+      handleRemovePendingLink,
+      handlePendingLinkDescriptionChange,
       handleMarkFileForDeletion,
       handleUnmarkFileForDeletion,
       handleImmediateUpload,
@@ -1597,14 +1742,22 @@ const useDocumentManagerCore = ({
       loadFiles,
       checkSyncStatus,
 
-      // API
-      getPendingFilesCount: () => pendingFilesRef.current.length,
-      hasPendingFiles: () => pendingFilesRef.current.length > 0,
-      clearPendingFiles: () => monitoredSetPendingFiles([]),
+      // API: counts and presence checks include both files and queued links so
+      // existing callers (12 medical entity pages) Just Work without per-page changes.
+      getPendingFilesCount: () =>
+        pendingFilesRef.current.length + pendingLinksRef.current.length,
+      hasPendingFiles: () =>
+        pendingFilesRef.current.length > 0 ||
+        pendingLinksRef.current.length > 0,
+      clearPendingFiles: () => {
+        monitoredSetPendingFiles([]);
+        monitoredSetPendingLinks([]);
+      },
     }),
     [
       files,
       pendingFiles,
+      pendingLinks,
       filesToDelete,
       loading,
       error,
@@ -1618,6 +1771,9 @@ const useDocumentManagerCore = ({
       pendingStats,
       handleAddPendingFile,
       handleRemovePendingFile,
+      handleAddPendingLink,
+      handleRemovePendingLink,
+      handlePendingLinkDescriptionChange,
       handleMarkFileForDeletion,
       handleUnmarkFileForDeletion,
       handleImmediateUpload,
@@ -1630,6 +1786,7 @@ const useDocumentManagerCore = ({
       loadFiles,
       checkSyncStatus,
       monitoredSetPendingFiles,
+      monitoredSetPendingLinks,
     ]
   );
 

--- a/frontend/src/components/shared/DocumentManagerCore.test.jsx
+++ b/frontend/src/components/shared/DocumentManagerCore.test.jsx
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock dependencies BEFORE importing the hook so the module captures the mocks.
+vi.mock('../../services/api', () => ({
+  apiService: {
+    getEntityFiles: vi.fn(() => Promise.resolve([])),
+    uploadEntityFileWithTaskMonitoring: vi.fn(),
+    downloadEntityFile: vi.fn(),
+    deleteEntityFile: vi.fn(),
+    viewEntityFile: vi.fn(),
+    checkPaperlessSyncStatus: vi.fn(() => Promise.resolve({})),
+    checkPapraSyncStatus: vi.fn(() => Promise.resolve({})),
+    updateProcessingFiles: vi.fn(() => Promise.resolve({})),
+  },
+}));
+
+vi.mock('../../services/api/paperlessApi.jsx', () => ({
+  getPaperlessSettings: vi.fn(() =>
+    Promise.resolve({
+      paperless_enabled: false,
+      paperless_url: '',
+      paperless_has_credentials: false,
+      default_storage_backend: 'local',
+    })
+  ),
+  linkPaperlessDocument: vi.fn(() => Promise.resolve({ id: 1 })),
+}));
+
+vi.mock('../../services/api/papraApi.jsx', () => ({
+  linkPapraDocument: vi.fn(() => Promise.resolve({ id: 2 })),
+}));
+
+vi.mock('../../services/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import useDocumentManagerCore from './DocumentManagerCore';
+import { linkPaperlessDocument } from '../../services/api/paperlessApi.jsx';
+import { linkPapraDocument } from '../../services/api/papraApi.jsx';
+import { apiService } from '../../services/api';
+
+const baseProps = (overrides = {}) => ({
+  entityType: 'insurance',
+  entityId: null,
+  mode: 'create',
+  showProgressModal: false,
+  uploadState: { files: [], isUploading: false },
+  updateFileProgress: vi.fn(),
+  startUpload: vi.fn(),
+  completeUpload: vi.fn(),
+  resetUpload: vi.fn(),
+  ...overrides,
+});
+
+describe('useDocumentManagerCore — pending link queue (issue #852)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handleAddPendingLink queues a paperless link without calling the API', () => {
+    const { result } = renderHook(() => useDocumentManagerCore(baseProps()));
+
+    act(() => {
+      result.current.handleAddPendingLink({
+        paperless_document_id: '262',
+        description: 'Linked from Paperless: Insurance Card',
+      });
+    });
+
+    expect(linkPaperlessDocument).not.toHaveBeenCalled();
+    expect(result.current.pendingLinks).toHaveLength(1);
+    expect(result.current.pendingLinks[0]).toMatchObject({
+      source: 'paperless',
+      linkData: {
+        paperless_document_id: '262',
+        description: 'Linked from Paperless: Insurance Card',
+      },
+      displayTitle: 'Linked from Paperless: Insurance Card',
+    });
+    expect(result.current.hasPendingFiles()).toBe(true);
+    expect(result.current.getPendingFilesCount()).toBe(1);
+  });
+
+  it('uploadPendingFiles flushes queued paperless link with the saved entity id', async () => {
+    const { result } = renderHook(() => useDocumentManagerCore(baseProps()));
+
+    act(() => {
+      result.current.handleAddPendingLink({
+        paperless_document_id: '262',
+        description: 'Linked from Paperless: Insurance Card',
+      });
+    });
+
+    await act(async () => {
+      await result.current.uploadPendingFiles(42);
+    });
+
+    expect(linkPaperlessDocument).toHaveBeenCalledTimes(1);
+    expect(linkPaperlessDocument).toHaveBeenCalledWith(
+      'insurance',
+      42,
+      expect.objectContaining({
+        paperless_document_id: '262',
+        description: 'Linked from Paperless: Insurance Card',
+      })
+    );
+    // Internal-only displayTitle must NOT be shipped to the API.
+    const sentPayload = linkPaperlessDocument.mock.calls[0][2];
+    expect(sentPayload.displayTitle).toBeUndefined();
+    expect(result.current.pendingLinks).toHaveLength(0);
+  });
+
+  it('uploadPendingFiles routes papra links to the papra API', async () => {
+    const { result } = renderHook(() => useDocumentManagerCore(baseProps()));
+
+    act(() => {
+      result.current.handleAddPendingLink({
+        papra_document_id: 'doc_xyz',
+        description: 'Linked from Papra: Insurance Card',
+      });
+    });
+
+    await act(async () => {
+      await result.current.uploadPendingFiles(99);
+    });
+
+    expect(linkPapraDocument).toHaveBeenCalledTimes(1);
+    expect(linkPapraDocument).toHaveBeenCalledWith(
+      'insurance',
+      99,
+      expect.objectContaining({ papra_document_id: 'doc_xyz' })
+    );
+    expect(linkPaperlessDocument).not.toHaveBeenCalled();
+  });
+
+  it('handleRemovePendingLink drops a link from the queue', () => {
+    const { result } = renderHook(() => useDocumentManagerCore(baseProps()));
+
+    act(() => {
+      result.current.handleAddPendingLink({
+        paperless_document_id: '262',
+        description: 'A',
+      });
+      result.current.handleAddPendingLink({
+        paperless_document_id: '263',
+        description: 'B',
+      });
+    });
+
+    expect(result.current.pendingLinks).toHaveLength(2);
+    const idToRemove = result.current.pendingLinks[0].id;
+
+    act(() => {
+      result.current.handleRemovePendingLink(idToRemove);
+    });
+
+    expect(result.current.pendingLinks).toHaveLength(1);
+    expect(result.current.pendingLinks[0].linkData.paperless_document_id).toBe(
+      '263'
+    );
+  });
+
+  it('mixed pending file + pending link are flushed in one uploadPendingFiles call', async () => {
+    apiService.uploadEntityFileWithTaskMonitoring.mockResolvedValue({
+      taskMonitored: false,
+    });
+
+    const { result } = renderHook(() => useDocumentManagerCore(baseProps()));
+
+    act(() => {
+      result.current.handleAddPendingFile(
+        new File(['hello'], 'card.pdf', { type: 'application/pdf' }),
+        'My card'
+      );
+      result.current.handleAddPendingLink({
+        paperless_document_id: '262',
+        description: 'Linked from Paperless: Insurance Card',
+      });
+    });
+
+    expect(result.current.hasPendingFiles()).toBe(true);
+    expect(result.current.getPendingFilesCount()).toBe(2);
+
+    await act(async () => {
+      await result.current.uploadPendingFiles(7);
+    });
+
+    expect(apiService.uploadEntityFileWithTaskMonitoring).toHaveBeenCalledWith(
+      'insurance',
+      7,
+      expect.any(File),
+      'My card',
+      '',
+      'local',
+      null,
+      expect.any(Function)
+    );
+    expect(linkPaperlessDocument).toHaveBeenCalledWith(
+      'insurance',
+      7,
+      expect.objectContaining({ paperless_document_id: '262' })
+    );
+    expect(result.current.pendingFiles).toHaveLength(0);
+    expect(result.current.pendingLinks).toHaveLength(0);
+  });
+
+  it('clearPendingFiles clears both pending files and pending links', () => {
+    const { result } = renderHook(() => useDocumentManagerCore(baseProps()));
+
+    act(() => {
+      result.current.handleAddPendingFile(
+        new File(['x'], 'a.pdf', { type: 'application/pdf' }),
+        ''
+      );
+      result.current.handleAddPendingLink({
+        paperless_document_id: '1',
+      });
+    });
+
+    expect(result.current.getPendingFilesCount()).toBe(2);
+
+    act(() => {
+      result.current.clearPendingFiles();
+    });
+
+    expect(result.current.pendingFiles).toHaveLength(0);
+    expect(result.current.pendingLinks).toHaveLength(0);
+    expect(result.current.hasPendingFiles()).toBe(false);
+  });
+});

--- a/frontend/src/components/shared/DocumentManagerWithProgress.jsx
+++ b/frontend/src/components/shared/DocumentManagerWithProgress.jsx
@@ -109,6 +109,7 @@ const DocumentManagerContent = ({
           syncStatus={coreHandlers.syncStatus}
           syncLoading={coreHandlers.syncLoading}
           pendingFiles={coreHandlers.pendingFiles}
+          pendingLinks={coreHandlers.pendingLinks}
           filesToDelete={coreHandlers.filesToDelete}
           config={config}
           onUploadModalOpen={() => setShowUploadModal(true)}
@@ -124,6 +125,10 @@ const DocumentManagerContent = ({
           onRemovePendingFile={coreHandlers.handleRemovePendingFile}
           onPendingFileDescriptionChange={
             coreHandlers.handlePendingFileDescriptionChange
+          }
+          onRemovePendingLink={coreHandlers.handleRemovePendingLink}
+          onPendingLinkDescriptionChange={
+            coreHandlers.handlePendingLinkDescriptionChange
           }
           handleImmediateUpload={coreHandlers.handleImmediateUpload}
         />
@@ -237,11 +242,31 @@ const DocumentManagerWithProgress = React.memo(
       handleUploadModalClose();
     }, [mode, handleUploadModalClose]);
 
-    // Shared handler for linking documents from remote backends (Paperless, Papra)
+    // Shared handler for linking documents from remote backends (Paperless, Papra).
+    // When the entity has not been saved yet (create mode / no entityId), the
+    // operation is queued via the core hook's pending-link queue and flushed
+    // after save by uploadPendingFiles(savedEntityId). Otherwise it is POSTed
+    // immediately, mirroring the existing edit-mode behavior.
     const createLinkHandler = useCallback(
       (backendName, linkApiFn) => {
         return async linkData => {
-          const eventPrefix = `document_manager_link_${backendName.toLowerCase()}`;
+          const source = backendName.toLowerCase();
+          const eventPrefix = `document_manager_link_${source}`;
+
+          if (!entityId && handlersRef.current?.handleAddPendingLink) {
+            handlersRef.current.handleAddPendingLink(linkData);
+            logger.info(
+              `${eventPrefix}_queued`,
+              `${backendName} document queued for linking after entity save`,
+              {
+                component: 'DocumentManagerWithProgress',
+                entityType,
+                entityId,
+              }
+            );
+            return;
+          }
+
           try {
             logger.info(eventPrefix, `Linking ${backendName} document`, {
               component: 'DocumentManagerWithProgress',

--- a/frontend/src/components/shared/RenderModeContent.jsx
+++ b/frontend/src/components/shared/RenderModeContent.jsx
@@ -45,6 +45,7 @@ const RenderModeContent = memo(
     syncStatus,
     syncLoading,
     pendingFiles,
+    pendingLinks = [],
     filesToDelete,
     onUploadModalOpen,
     onLinkModalOpen,
@@ -57,6 +58,8 @@ const RenderModeContent = memo(
     onUnmarkFileForDeletion,
     onRemovePendingFile,
     onPendingFileDescriptionChange,
+    onRemovePendingLink,
+    onPendingLinkDescriptionChange,
   }) => {
     const { t } = useTranslation('documents');
     if (loading && files.length === 0) {
@@ -215,6 +218,58 @@ const RenderModeContent = memo(
       </Stack>
     );
 
+    const pendingLinksList = pendingLinks.length > 0 && (
+      <Stack gap="md">
+        <Title order={5}>{t('manager.documentsToLink')}</Title>
+        <Stack gap="sm">
+          {pendingLinks.map(pendingLink => (
+            <Paper key={pendingLink.id} withBorder p="sm" bg="grape.1">
+              <Group justify="space-between" align="flex-start">
+                <Group gap="xs" style={{ flex: 1 }}>
+                  <ThemeIcon variant="light" color="grape" size="sm">
+                    <IconLink size={14} />
+                  </ThemeIcon>
+                  <Stack gap="xs" style={{ flex: 1 }}>
+                    <Group gap="md">
+                      <Text fw={500} size="sm">
+                        {pendingLink.displayTitle}
+                      </Text>
+                      <Badge size="xs" color="grape" variant="light">
+                        {pendingLink.source === 'papra' ? 'Papra' : 'Paperless'}
+                      </Badge>
+                    </Group>
+                    {onPendingLinkDescriptionChange && (
+                      <TextInput
+                        placeholder={t('manager.linkDescriptionPlaceholder')}
+                        value={pendingLink.linkData?.description || ''}
+                        onChange={e =>
+                          onPendingLinkDescriptionChange(
+                            pendingLink.id,
+                            e.target.value
+                          )
+                        }
+                        size="xs"
+                      />
+                    )}
+                  </Stack>
+                </Group>
+                {onRemovePendingLink && (
+                  <ActionIcon
+                    variant="light"
+                    color="red"
+                    size="sm"
+                    onClick={() => onRemovePendingLink(pendingLink.id)}
+                  >
+                    <IconX size={14} />
+                  </ActionIcon>
+                )}
+              </Group>
+            </Paper>
+          ))}
+        </Stack>
+      </Stack>
+    );
+
     if (mode === 'view') {
       return (
         <Stack gap="md">
@@ -266,6 +321,7 @@ const RenderModeContent = memo(
 
           {addDocumentMenu('Manage Documents')}
           {pendingFilesList}
+          {pendingLinksList}
         </Stack>
       );
     }
@@ -276,6 +332,7 @@ const RenderModeContent = memo(
           {storageBackendSelector}
           {addDocumentMenu('Manage Documents')}
           {pendingFilesList}
+          {pendingLinksList}
         </Stack>
       );
     }


### PR DESCRIPTION
## Summary

This pull request adds support for linking existing remote documents (from Paperless or Papra) in the document manager, along with progress tracking and internationalization updates. The changes introduce new state management for pending document links, handlers for adding/removing links, and updates to the batch upload process to handle both file uploads and document linking in a unified way. Additionally, new translation keys are added across multiple languages to support the new UI elements.

**Document linking functionality:**

* Introduced `pendingLinks` state and related handlers (`handleAddPendingLink`, `handleRemovePendingLink`, `handlePendingLinkDescriptionChange`) in `DocumentManagerCore.jsx` to manage documents queued for linking instead of uploading. These links are processed after entity creation, similar to pending file uploads. [[1]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97R144) [[2]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97R162-R166) [[3]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97R232) [[4]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97R244-R254) [[5]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97R753-R798) [[6]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97R1710) [[7]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97R1730-R1732)

* Updated the `uploadPendingFiles` function to process both pending file uploads and pending document links in a single batch, with unified progress tracking and error handling. Linking uses the new `linkPaperlessDocument` and `linkPapraDocument` API calls. [[1]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97L1025-R1128) [[2]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97R1379-R1471) [[3]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97L1342-R1482) [[4]](diffhunk://#diff-8e54517407554950d2433d2b4c41d2e9a58bc447ab44b75dc3c9f8a4c9503f97R1514)

**API and utility imports:**

* Added imports for `linkPaperlessDocument`, `linkPapraDocument`, and `generateId` to support the new linking workflow in `DocumentManagerCore.jsx`.

**Internationalization:**

* Added new translation keys (`documentsToLink`, `linkDescriptionPlaceholder`) to the `manager` section of `documents.json` for all supported languages (English, German, Spanish, French, Italian, Dutch, Polish, Portuguese, Russian, Swedish, Thai, Chinese) to support the new linking UI. [[1]](diffhunk://#diff-71c1ebbe97d2136f2f3e7664bbf34e26985053f614414fffcb1273235bd98413R76-R80) [[2]](diffhunk://#diff-2806d12e928ae7b2865eecb810398fae17523e2a82a493accf9e5f2add5e4db1R76-R80) [[3]](diffhunk://#diff-9fa56b9814cf5a3ae20ffb5df9899552a32dfafe1a4cdaa67c0c4fde8a7e5d5dR76-R80) [[4]](diffhunk://#diff-a77588df27c4f046b1a820ab6897cee3993d18be4872198f3f1d4a31093a6a48R76-R80) [[5]](diffhunk://#diff-9704642862a4e1b133590f3703e7fbcbf735ec82f997ee947da3f11afabfe067R76-R80) [[6]](diffhunk://#diff-b37554eb74507d5742711593e34b9e51293a4cc01e8db40136f0cf04c446dd61R76-R80) [[7]](diffhunk://#diff-9f3a97e2c350673f8f8426721f1c0f623c3e102fd98552100013383d6e00565eR76-R80) [[8]](diffhunk://#diff-ac80ec8f3b9e610c10135d52f3688f201491408cb083f6421b0fdfcdd1f5e315R76-R80) [[9]](diffhunk://#diff-5b06482a1a16f3a601e00a5059c6f1f82dcf0ef63254caf1aee41a426c6c09cdR76-R80) [[10]](diffhunk://#diff-70d51639f09d10a9588ec7013f8ca959d4bb3076d16619fb4f16a2c984e50306R76-R80) [[11]](diffhunk://#diff-03aa3e254797a5d7b9344f5098726bf7f2c1c64f4145b4a28211f2b2482d0d13R76-R80) [[12]](diffhunk://#diff-728804e637f8758f86881146ec00074e69178354e0b3fb75e07761fc6411d947R76-R80)

## Related issue

#852 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

<!-- How did you verify this works? Manual steps, screenshots, or test names. -->

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to queue documents for linking before batch upload
  * Added optional description field for queued documents to link
  * Queued documents now display with source identification (Papra/Paperless)
  * Batch upload now processes both files and queued document links together

* **Documentation**
  * Added translations for document linking UI across 11 languages (German, English, Spanish, French, Italian, Dutch, Polish, Portuguese, Russian, Swedish, Thai, and Chinese)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->