### PR TITLE
fix: increase default limit for API endpoints to 10000

### DIFF
--- a/app/api/v1/endpoints/allergy.py
+++ b/app/api/v1/endpoints/allergy.py
@@ -61,7 +61,7 @@ def read_allergies(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     severity: Optional[str] = Query(None),
     allergen: Optional[str] = Query(None),
     status: Optional[str] = Query(None),
@@ -350,7 +350,7 @@ def get_patient_allergies(
     db: Session = Depends(deps.get_db),
     patient_id: int = Depends(deps.verify_patient_access),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     current_user_id: int = Depends(deps.get_current_user_id),
 ) -> Any:
     """

--- a/app/api/v1/endpoints/condition.py
+++ b/app/api/v1/endpoints/condition.py
@@ -71,7 +71,7 @@ def read_conditions(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     status: Optional[str] = Query(None),
     tags: Optional[List[str]] = Query(None, description="Filter by tags"),
     tag_match_all: bool = Query(
@@ -770,7 +770,7 @@ def get_patient_conditions(
     patient_id: int = Depends(deps.verify_patient_access),
     current_user_id: int = Depends(deps.get_current_user_id),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
 ) -> Any:
     """Get all conditions for a specific patient."""
     with handle_database_errors(request=request):

--- a/app/api/v1/endpoints/emergency_contact.py
+++ b/app/api/v1/endpoints/emergency_contact.py
@@ -71,7 +71,7 @@ def read_emergency_contacts(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     is_active: Optional[bool] = Query(None),
     is_primary: Optional[bool] = Query(None),
     target_patient_id: int = Depends(deps.get_accessible_patient_id),

--- a/app/api/v1/endpoints/encounter.py
+++ b/app/api/v1/endpoints/encounter.py
@@ -69,7 +69,7 @@ def read_encounters(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     practitioner_id: Optional[int] = Query(None),
     tags: Optional[List[str]] = Query(None, description="Filter by tags"),
     tag_match_all: bool = Query(
@@ -246,7 +246,7 @@ def get_patient_encounters(
     db: Session = Depends(deps.get_db),
     patient_id: int = Depends(deps.verify_patient_access),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     current_user_id: int = Depends(deps.get_current_user_id),
 ) -> Any:
     """Get all encounters for a specific patient."""

--- a/app/api/v1/endpoints/family_member.py
+++ b/app/api/v1/endpoints/family_member.py
@@ -60,7 +60,7 @@ def read_family_members(
     *,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     relationship: Optional[str] = Query(None),
     target_patient_id: int = Depends(deps.get_accessible_patient_id),
 ) -> Any:

--- a/app/api/v1/endpoints/immunization.py
+++ b/app/api/v1/endpoints/immunization.py
@@ -59,7 +59,7 @@ def read_immunizations(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     vaccine_name: Optional[str] = Query(None),
     tags: Optional[List[str]] = Query(None, description="Filter by tags"),
     tag_match_all: bool = Query(
@@ -287,7 +287,7 @@ def get_patient_immunizations(
     db: Session = Depends(deps.get_db),
     patient_id: int = Depends(deps.verify_patient_access),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     current_user_id: int = Depends(deps.get_current_user_id),
 ) -> Any:
     """Get all immunizations for a specific patient."""

--- a/app/api/v1/endpoints/injury.py
+++ b/app/api/v1/endpoints/injury.py
@@ -98,7 +98,7 @@ def read_injuries(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     status: Optional[str] = Query(
         None, description="Filter by status (active/healing/resolved/chronic)"
     ),

--- a/app/api/v1/endpoints/medical_equipment.py
+++ b/app/api/v1/endpoints/medical_equipment.py
@@ -62,7 +62,7 @@ def read_medical_equipment(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     status: Optional[str] = Query(None),
     equipment_type: Optional[str] = Query(None),
     tags: Optional[List[str]] = Query(None, description="Filter by tags"),

--- a/app/api/v1/endpoints/medication.py
+++ b/app/api/v1/endpoints/medication.py
@@ -74,7 +74,7 @@ def read_medications(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     name: Optional[str] = Query(None),
     status: Optional[str] = Query(None),
     tags: Optional[List[str]] = Query(None, description="Filter by tags"),
@@ -266,7 +266,7 @@ def read_patient_medications(
     db: Session = Depends(deps.get_db),
     patient_id: int = Depends(deps.verify_patient_access),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     active_only: bool = Query(False),
     current_user_id: int = Depends(deps.get_current_user_id),
 ) -> Any:

--- a/app/api/v1/endpoints/practice.py
+++ b/app/api/v1/endpoints/practice.py
@@ -55,7 +55,7 @@ def read_practices(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     search: str = Query(None, min_length=1),
     current_user_id: int = Depends(deps.get_current_user_id),
 ) -> Any:

--- a/app/api/v1/endpoints/practitioner.py
+++ b/app/api/v1/endpoints/practitioner.py
@@ -48,7 +48,7 @@ def read_practitioners(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     specialty_id: Optional[int] = Query(None),
     practice_id: Optional[int] = Query(None),
     current_user_id: int = Depends(deps.get_current_user_id),

--- a/app/api/v1/endpoints/procedure.py
+++ b/app/api/v1/endpoints/procedure.py
@@ -61,7 +61,7 @@ def read_procedures(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     practitioner_id: Optional[int] = Query(None),
     status: Optional[str] = Query(None),
     tags: Optional[List[str]] = Query(None, description="Filter by tags"),
@@ -283,7 +283,7 @@ def get_patient_procedures(
     db: Session = Depends(deps.get_db),
     patient_id: int = Depends(deps.verify_patient_access),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     current_user_id: int = Depends(deps.get_current_user_id),
 ) -> Any:
     """

--- a/app/api/v1/endpoints/symptom.py
+++ b/app/api/v1/endpoints/symptom.py
@@ -70,7 +70,7 @@ def read_symptoms(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     status: Optional[str] = None,
     search: Optional[str] = None,
     target_patient_id: int = Depends(deps.get_accessible_patient_id),
@@ -288,7 +288,7 @@ def read_symptom_occurrences(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     current_user_patient_id: int = Depends(deps.get_current_user_patient_id),
     current_user: User = Depends(deps.get_current_user),
 ) -> Any:

--- a/app/api/v1/endpoints/treatment.py
+++ b/app/api/v1/endpoints/treatment.py
@@ -117,7 +117,7 @@ def read_treatments(
     request: Request,
     db: Session = Depends(deps.get_db),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     condition_id: Optional[int] = Query(None),
     status: Optional[str] = Query(None),
     tags: Optional[List[str]] = Query(None, description="Filter by tags"),
@@ -331,7 +331,7 @@ def get_patient_treatments(
     db: Session = Depends(deps.get_db),
     patient_id: int = Depends(deps.verify_patient_access),
     skip: int = 0,
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=10000, le=10000),
     current_user_id: int = Depends(deps.get_current_user_id),
 ) -> Any:
     """Get all treatments for a specific patient."""

--- a/tests/api/test_medications.py
+++ b/tests/api/test_medications.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.crud.patient import patient as patient_crud
+from app.models.clinical import Medication
 from app.schemas.patient import PatientCreate
 from tests.utils.user import create_random_user, create_user_token_headers
 
@@ -119,6 +120,40 @@ class TestMedicationAPI:
         data = response.json()
         assert len(data) >= 1
         assert data[0]["medication_name"] == "Aspirin"
+
+    def test_get_medications_returns_more_than_100(
+        self,
+        client: TestClient,
+        user_with_patient,
+        authenticated_headers,
+        db_session: Session,
+    ):
+        """Regression test for issue #843: list endpoint must not cap at 100 records."""
+        patient_id = user_with_patient["patient"].id
+        # Must exceed the previous 100-record cap that caused the bug.
+        bulk_count = 105
+        db_session.add_all(
+            [
+                Medication(
+                    medication_name=f"BulkMed{i:03d}",
+                    patient_id=patient_id,
+                    status="active",
+                )
+                for i in range(bulk_count)
+            ]
+        )
+        db_session.commit()
+
+        response = client.get(
+            "/api/v1/medications/", headers=authenticated_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == bulk_count, (
+            f"Expected {bulk_count} medications, got {len(data)} - "
+            "pagination cap may have regressed"
+        )
 
     def test_get_medication_by_id(
         self, client: TestClient, user_with_patient, authenticated_headers


### PR DESCRIPTION

## Summary

This pull request increases the maximum `limit` parameter for list endpoints across multiple API resources from 100 to 10,000, allowing clients to retrieve larger datasets in a single request. It also adds a regression test to ensure that the medications list endpoint correctly returns more than 100 records, addressing a previous bug where results were capped at 100.

**API Limit Increases:**

* Raised the default and maximum `limit` for list endpoints in the following resources from 100 to 10,000, allowing larger result sets to be returned in a single API call:
    - Allergies (`app/api/v1/endpoints/allergy.py`) [[1]](diffhunk://#diff-5ad8179468831dab6d686f00e38839a4a5b064d6f5782615695db2057f8e002eL64-R64) [[2]](diffhunk://#diff-5ad8179468831dab6d686f00e38839a4a5b064d6f5782615695db2057f8e002eL353-R353)
    - Conditions (`app/api/v1/endpoints/condition.py`) [[1]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L74-R74) [[2]](diffhunk://#diff-ff46ff71d81779bdbe52a298ff2ed722cb54eb815c1b37829024b92dc38a5250L773-R773)
    - Emergency Contacts (`app/api/v1/endpoints/emergency_contact.py`)
    - Encounters (`app/api/v1/endpoints/encounter.py`) [[1]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deL72-R72) [[2]](diffhunk://#diff-59058b92446bab168493a27b78cd6311a755c9f0a9e7d54304f562f24c5a06deL249-R249)
    - Family Members (`app/api/v1/endpoints/family_member.py`)
    - Immunizations (`app/api/v1/endpoints/immunization.py`) [[1]](diffhunk://#diff-75ccafd95efc4a44b84475d8533722ffb2d125a072ce276312ed81e68740db29L62-R62) [[2]](diffhunk://#diff-75ccafd95efc4a44b84475d8533722ffb2d125a072ce276312ed81e68740db29L290-R290)
    - Injuries (`app/api/v1/endpoints/injury.py`)
    - Medical Equipment (`app/api/v1/endpoints/medical_equipment.py`)
    - Medications (`app/api/v1/endpoints/medication.py`) [[1]](diffhunk://#diff-537b782e9fea8a2a9e1f3d04244eacde88eb29bdfbb3c678c3cfe87aaa9e416dL77-R77) [[2]](diffhunk://#diff-537b782e9fea8a2a9e1f3d04244eacde88eb29bdfbb3c678c3cfe87aaa9e416dL269-R269)
    - Practices (`app/api/v1/endpoints/practice.py`)
    - Practitioners (`app/api/v1/endpoints/practitioner.py`)
    - Procedures (`app/api/v1/endpoints/procedure.py`) [[1]](diffhunk://#diff-8fb797aa2881f013f2d987e2c3081c40a1022b983f6a3557ee9b0f8c79e0aa95L64-R64) [[2]](diffhunk://#diff-8fb797aa2881f013f2d987e2c3081c40a1022b983f6a3557ee9b0f8c79e0aa95L286-R286)
    - Symptoms (`app/api/v1/endpoints/symptom.py`) [[1]](diffhunk://#diff-c3706585bd430823cad4f128ae0a2c61b2085fb8637ace058d27846ce369f9d9L73-R73) [[2]](diffhunk://#diff-c3706585bd430823cad4f128ae0a2c61b2085fb8637ace058d27846ce369f9d9L291-R291)
    - Treatments (`app/api/v1/endpoints/treatment.py`) [[1]](diffhunk://#diff-6bae2d9df2cb3ed081a302b2b5116dca395e1fed42447df6906c42b19392087eL120-R120) [[2]](diffhunk://#diff-6bae2d9df2cb3ed081a302b2b5116dca395e1fed42447df6906c42b19392087eL334-R334)

**Testing and Bug Fixes:**

* Added a regression test to `tests/api/test_medications.py` to ensure the medications list endpoint returns more than 100 records, preventing regression of the previous cap bug. [[1]](diffhunk://#diff-70f59edaabe9345dd0a1548aadeb33d674c28a985eb1ceb8ec0e21f809c69d56R11) [[2]](diffhunk://#diff-70f59edaabe9345dd0a1548aadeb33d674c28a985eb1ceb8ec0e21f809c69d56R124-R157)

These changes ensure that clients can request larger data sets efficiently and that the API's pagination is functioning as intended.

## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing



## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Increased pagination limits across API list endpoints from 100 to 10,000 results per request for allergies, conditions, encounters, immunizations, medications, procedures, symptoms, treatments, and related data types.
  * Added advanced filtering options (tags, search, status filters) to select endpoints for improved data retrieval capabilities.

* **Tests**
  * Added regression test to verify medication listing returns complete data sets beyond 100 records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->