### PR TITLE
fix: corrected condition severity mismatch

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Erkrankung wird gespeichert...",
       "severity": {
-        "critical": "Kritisch",
+        "lifeThreatening": "Lebensbedrohlich",
         "mild": "Leicht",
         "moderate": "Mäßig",
         "severe": "Schwer"

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Saving condition...",
       "severity": {
-        "critical": "Critical",
+        "lifeThreatening": "Life-threatening",
         "mild": "Mild",
         "moderate": "Moderate",
         "severe": "Severe"

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Guardando condición...",
       "severity": {
-        "critical": "Crítica",
+        "lifeThreatening": "Amenaza para la vida",
         "mild": "Leve",
         "moderate": "Moderada",
         "severe": "Grave"

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Sauvegarde de la condition...",
       "severity": {
-        "critical": "Critique",
+        "lifeThreatening": "Critique",
         "mild": "Bénigne",
         "moderate": "Modérée",
         "severe": "Sévère"

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Salvataggio condizione...",
       "severity": {
-        "critical": "Critico",
+        "lifeThreatening": "Pericolosa per la vita",
         "mild": "Lieve",
         "moderate": "Moderato",
         "severe": "Grave"

--- a/frontend/public/locales/nl/common.json
+++ b/frontend/public/locales/nl/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Aandoening opslaan...",
       "severity": {
-        "critical": "Kritiek",
+        "lifeThreatening": "Levensbedreigend",
         "mild": "Licht",
         "moderate": "Matig",
         "severe": "Ernstig"

--- a/frontend/public/locales/pl/common.json
+++ b/frontend/public/locales/pl/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Zapisywanie schorzenia...",
       "severity": {
-        "critical": "Krytyczne",
+        "lifeThreatening": "Zagrażający życiu",
         "mild": "Łagodne",
         "moderate": "Umiarkowane",
         "severe": "Ciężkie"

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Salvando condição...",
       "severity": {
-        "critical": "Crítica",
+        "lifeThreatening": "Risco de vida",
         "mild": "Leve",
         "moderate": "Moderada",
         "severe": "Grave"

--- a/frontend/public/locales/ru/common.json
+++ b/frontend/public/locales/ru/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Сохранение заболевания...",
       "severity": {
-        "critical": "Критическая",
+        "lifeThreatening": "Угрожающая жизни",
         "mild": "Лёгкая",
         "moderate": "Средняя",
         "severe": "Тяжёлая"

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "Sparar tillstånd...",
       "severity": {
-        "critical": "Kritisk",
+        "lifeThreatening": "Livshotande",
         "mild": "Mild",
         "moderate": "Måttlig",
         "severe": "Svår"

--- a/frontend/public/locales/th/common.json
+++ b/frontend/public/locales/th/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "กำลังบันทึกโรค...",
       "severity": {
-        "critical": "วิกฤต",
+        "lifeThreatening": "คุกคามชีวิต",
         "mild": "เล็กน้อย",
         "moderate": "ปานกลาง",
         "severe": "รุนแรง"

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -66,7 +66,7 @@
       },
       "saving": "正在保存疾病...",
       "severity": {
-        "critical": "危重",
+        "lifeThreatening": "危及生命",
         "mild": "轻度",
         "moderate": "中度",
         "severe": "重度"

--- a/frontend/src/components/medical/conditions/ConditionCard.jsx
+++ b/frontend/src/components/medical/conditions/ConditionCard.jsx
@@ -69,7 +69,7 @@ const ConditionCard = ({
 
   const getSeverityColor = severity => {
     switch (severity) {
-      case 'critical':
+      case 'life-threatening':
         return 'red';
       case 'severe':
         return 'orange';

--- a/frontend/src/components/medical/conditions/ConditionFormWrapper.jsx
+++ b/frontend/src/components/medical/conditions/ConditionFormWrapper.jsx
@@ -249,10 +249,10 @@ const ConditionFormWrapper = ({
                           label: t('conditions.form.severity.severe', 'Severe'),
                         },
                         {
-                          value: 'critical',
+                          value: 'life-threatening',
                           label: t(
-                            'conditions.form.severity.critical',
-                            'Critical'
+                            'conditions.form.severity.lifeThreatening',
+                            'Life-threatening'
                           ),
                         },
                       ]}

--- a/frontend/src/components/medical/conditions/ConditionViewModal.jsx
+++ b/frontend/src/components/medical/conditions/ConditionViewModal.jsx
@@ -82,7 +82,7 @@ const ConditionViewModal = ({
 
   const getSeverityColor = severity => {
     switch (severity) {
-      case 'critical':
+      case 'life-threatening':
         return 'red';
       case 'severe':
         return 'orange';


### PR DESCRIPTION
## Summary

This pull request updates the terminology for a severity level in medical condition components and translations across the application. The term "critical" has been replaced with "life-threatening" (or equivalent) in both the codebase and all supported languages to improve clarity and consistency.

**Severity terminology update:**

* Replaced the severity value and label `'critical'`/`'Critical'` with `'life-threatening'`/`'Life-threatening'` in the condition form options and severity color logic in `ConditionFormWrapper.jsx`, `ConditionCard.jsx`, and `ConditionViewModal.jsx`. [[1]](diffhunk://#diff-40a25cb43ffea3f5191734b81b5d9938ee71f5b2be9c6eb8bf587de4c883816aL252-R255) [[2]](diffhunk://#diff-4a45cb17792b1b6204f6e73ea0b229c4f0aab0aa85813542416647b9a51666faL72-R72) [[3]](diffhunk://#diff-06852e15700c72c2ebfbcf7e344585b82f27bc80a062f4115fa2bc7a86423920L85-R85)

**Localization updates:**

* Updated the translation key from `"critical"` to `"lifeThreatening"` in the `severity` section for all supported locales, including English, German, Spanish, French, Italian, Dutch, Polish, Portuguese, Russian, Swedish, Thai, and Chinese, with appropriate translations. [[1]](diffhunk://#diff-33c499047fc22cc766f0d8b1be2a6103ce9c582c107b84d8219031120f04bd7aL69-R69) [[2]](diffhunk://#diff-2e67589bc551d2f12ba1499b32925674c0611ff673460af46437902cab5f058eL69-R69) [[3]](diffhunk://#diff-13c52b69dfe950d320432dae53ccb8a566a5d4d69ac5a7ba54f4a909a3bb4e6fL69-R69) [[4]](diffhunk://#diff-285d4745ded42255660eafafa54fc7490496e86f0ed40a9d9ea2f6687b8b32d6L69-R69) [[5]](diffhunk://#diff-7f4d6bada4d4e07a00f12836e045c0d3337f22b8b4cee8a62ec4d4d807f084a5L69-R69) [[6]](diffhunk://#diff-eb3abd7a6bed0d48909f22c3c1b0fa4e70460354dc8700a7dd8475aff026061dL69-R69) [[7]](diffhunk://#diff-e384602a1509f3538b8dc4379eec79f9eda68d2994c44ec58c29583da5c57e4bL69-R69) [[8]](diffhunk://#diff-176f05b6abedc9e7880d4ed22413ca5c6b41f830a638582cd3eaffecf4ebcf4cL69-R69) [[9]](diffhunk://#diff-b799d7eb879fabaf02950f3f21cf5b9cdd7b1cbf50039f1076570753d35946c5L69-R69) [[10]](diffhunk://#diff-5540ab968f171eb495e54200ccd528d6517ef32f2d4d447a031a7242d7074700L69-R69) [[11]](diffhunk://#diff-d351c7198f36a210b77113a1c9f074b7e9b44cc7ac9da77dd00f1a30d8204bacL69-R69) [[12]](diffhunk://#diff-288cc80fd82f3a272732993674872c4b24a919f69ea50259359e96eb8fc10263L69-R69)

## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated medical condition severity label terminology from "Critical" to "Life-threatening" across all user-facing interfaces and supported languages (German, English, Spanish, French, Italian, Dutch, Polish, Portuguese, Russian, Swedish, Thai, and Chinese). Severity level colors and form functionality remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/afairgiant/MediKeep/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->